### PR TITLE
Updating scalars for Forestry and Outdoor Recreation to extend to 2300

### DIFF
--- a/inst/extdata/fredi/scalars/Scalar_damageAdj_forestryLoss_growthFactor_SSP2.csv
+++ b/inst/extdata/fredi/scalars/Scalar_damageAdj_forestryLoss_growthFactor_SSP2.csv
@@ -1,4901 +1,5048 @@
-state,postal,year,value,scalarName
-Alabama,AL,2000,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2001,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2002,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2003,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2004,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2005,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2006,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2007,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2008,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2009,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2010,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2011,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2012,NA,forestryLoss_growthFactor_SSP2
-Alabama,AL,2013,0.992744169,forestryLoss_growthFactor_SSP2
-Alabama,AL,2014,0.99640047,forestryLoss_growthFactor_SSP2
-Alabama,AL,2015,1,forestryLoss_growthFactor_SSP2
-Alabama,AL,2016,0.998896411,forestryLoss_growthFactor_SSP2
-Alabama,AL,2017,0.99785403,forestryLoss_growthFactor_SSP2
-Alabama,AL,2018,0.99686936,forestryLoss_growthFactor_SSP2
-Alabama,AL,2019,0.995939139,forestryLoss_growthFactor_SSP2
-Alabama,AL,2020,0.99506032,forestryLoss_growthFactor_SSP2
-Alabama,AL,2021,0.982151787,forestryLoss_growthFactor_SSP2
-Alabama,AL,2022,0.969631917,forestryLoss_growthFactor_SSP2
-Alabama,AL,2023,0.957484001,forestryLoss_growthFactor_SSP2
-Alabama,AL,2024,0.945692257,forestryLoss_growthFactor_SSP2
-Alabama,AL,2025,0.934241768,forestryLoss_growthFactor_SSP2
-Alabama,AL,2026,0.929372269,forestryLoss_growthFactor_SSP2
-Alabama,AL,2027,0.924633819,forestryLoss_growthFactor_SSP2
-Alabama,AL,2028,0.920021484,forestryLoss_growthFactor_SSP2
-Alabama,AL,2029,0.915530567,forestryLoss_growthFactor_SSP2
-Alabama,AL,2030,0.911156598,forestryLoss_growthFactor_SSP2
-Alabama,AL,2031,0.90522586,forestryLoss_growthFactor_SSP2
-Alabama,AL,2032,0.899442261,forestryLoss_growthFactor_SSP2
-Alabama,AL,2033,0.893800663,forestryLoss_growthFactor_SSP2
-Alabama,AL,2034,0.888296159,forestryLoss_growthFactor_SSP2
-Alabama,AL,2035,0.882924062,forestryLoss_growthFactor_SSP2
-Alabama,AL,2036,0.870253664,forestryLoss_growthFactor_SSP2
-Alabama,AL,2037,0.857859393,forestryLoss_growthFactor_SSP2
-Alabama,AL,2038,0.845732478,forestryLoss_growthFactor_SSP2
-Alabama,AL,2039,0.833864513,forestryLoss_growthFactor_SSP2
-Alabama,AL,2040,0.822247437,forestryLoss_growthFactor_SSP2
-Alabama,AL,2041,0.824062267,forestryLoss_growthFactor_SSP2
-Alabama,AL,2042,0.825851893,forestryLoss_growthFactor_SSP2
-Alabama,AL,2043,0.827616897,forestryLoss_growthFactor_SSP2
-Alabama,AL,2044,0.82935784,forestryLoss_growthFactor_SSP2
-Alabama,AL,2045,0.831075266,forestryLoss_growthFactor_SSP2
-Alabama,AL,2046,0.812569893,forestryLoss_growthFactor_SSP2
-Alabama,AL,2047,0.794386048,forestryLoss_growthFactor_SSP2
-Alabama,AL,2048,0.776515458,forestryLoss_growthFactor_SSP2
-Alabama,AL,2049,0.758950127,forestryLoss_growthFactor_SSP2
-Alabama,AL,2050,0.741682331,forestryLoss_growthFactor_SSP2
-Alabama,AL,2051,0.739232282,forestryLoss_growthFactor_SSP2
-Alabama,AL,2052,0.736826635,forestryLoss_growthFactor_SSP2
-Alabama,AL,2053,0.73446426,forestryLoss_growthFactor_SSP2
-Alabama,AL,2054,0.732144061,forestryLoss_growthFactor_SSP2
-Alabama,AL,2055,0.72986498,forestryLoss_growthFactor_SSP2
-Alabama,AL,2056,0.733263051,forestryLoss_growthFactor_SSP2
-Alabama,AL,2057,0.73661232,forestryLoss_growthFactor_SSP2
-Alabama,AL,2058,0.739913871,forestryLoss_growthFactor_SSP2
-Alabama,AL,2059,0.743168753,forestryLoss_growthFactor_SSP2
-Alabama,AL,2060,0.746377985,forestryLoss_growthFactor_SSP2
-Alabama,AL,2061,0.737080848,forestryLoss_growthFactor_SSP2
-Alabama,AL,2062,0.727938965,forestryLoss_growthFactor_SSP2
-Alabama,AL,2063,0.718948515,forestryLoss_growthFactor_SSP2
-Alabama,AL,2064,0.710105799,forestryLoss_growthFactor_SSP2
-Alabama,AL,2065,0.70140724,forestryLoss_growthFactor_SSP2
-Alabama,AL,2066,0.702122509,forestryLoss_growthFactor_SSP2
-Alabama,AL,2067,0.702828717,forestryLoss_growthFactor_SSP2
-Alabama,AL,2068,0.703526054,forestryLoss_growthFactor_SSP2
-Alabama,AL,2069,0.704214703,forestryLoss_growthFactor_SSP2
-Alabama,AL,2070,0.704894842,forestryLoss_growthFactor_SSP2
-Alabama,AL,2071,0.711250617,forestryLoss_growthFactor_SSP2
-Alabama,AL,2072,0.717509175,forestryLoss_growthFactor_SSP2
-Alabama,AL,2073,0.723672724,forestryLoss_growthFactor_SSP2
-Alabama,AL,2074,0.729743404,forestryLoss_growthFactor_SSP2
-Alabama,AL,2075,0.735723294,forestryLoss_growthFactor_SSP2
-Alabama,AL,2076,0.734791219,forestryLoss_growthFactor_SSP2
-Alabama,AL,2077,0.733872259,forestryLoss_growthFactor_SSP2
-Alabama,AL,2078,0.732966113,forestryLoss_growthFactor_SSP2
-Alabama,AL,2079,0.732072492,forestryLoss_growthFactor_SSP2
-Alabama,AL,2080,0.731191115,forestryLoss_growthFactor_SSP2
-Alabama,AL,2081,0.732452104,forestryLoss_growthFactor_SSP2
-Alabama,AL,2082,0.733690305,forestryLoss_growthFactor_SSP2
-Alabama,AL,2083,0.734906263,forestryLoss_growthFactor_SSP2
-Alabama,AL,2084,0.736100506,forestryLoss_growthFactor_SSP2
-Alabama,AL,2085,0.737273544,forestryLoss_growthFactor_SSP2
-Alabama,AL,2086,0.732524283,forestryLoss_growthFactor_SSP2
-Alabama,AL,2087,0.727847727,forestryLoss_growthFactor_SSP2
-Alabama,AL,2088,0.723242231,forestryLoss_growthFactor_SSP2
-Alabama,AL,2089,0.718706197,forestryLoss_growthFactor_SSP2
-Alabama,AL,2090,0.714238076,forestryLoss_growthFactor_SSP2
-Alabama,AL,2091,0.728246151,forestryLoss_growthFactor_SSP2
-Alabama,AL,2092,0.742069711,forestryLoss_growthFactor_SSP2
-Alabama,AL,2093,0.755712821,forestryLoss_growthFactor_SSP2
-Alabama,AL,2094,0.769179425,forestryLoss_growthFactor_SSP2
-Alabama,AL,2095,0.78247335,forestryLoss_growthFactor_SSP2
-Alabama,AL,2096,0.79543244,forestryLoss_growthFactor_SSP2
-Alabama,AL,2097,0.808219554,forestryLoss_growthFactor_SSP2
-Alabama,AL,2098,0.82083851,forestryLoss_growthFactor_SSP2
-Alabama,AL,2099,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2000,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2001,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2002,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2003,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2004,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2005,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2006,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2007,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2008,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2009,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2010,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2011,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2012,NA,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2013,0.988499829,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2014,0.994307763,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2015,1,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2016,1.000923014,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2017,1.001834943,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2018,1.002735867,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2019,1.003625874,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2020,1.004505063,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2021,0.992526623,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2022,0.980900872,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2023,0.969612812,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2024,0.958648272,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2025,0.947993857,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2026,0.944414923,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2027,0.940929816,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2028,0.93753505,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2029,0.934227304,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2030,0.931003415,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2031,0.92628009,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2032,0.921669364,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2033,0.917167382,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2034,0.912770459,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2035,0.908475074,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2036,0.896433846,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2037,0.884649259,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2038,0.873113255,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2039,0.861818108,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2040,0.850756405,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2041,0.854426229,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2042,0.858026549,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2043,0.861559363,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2044,0.865026594,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2045,0.868430091,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2046,0.849890469,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2047,0.83167091,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2048,0.813763204,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2049,0.79615942,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2050,0.778851895,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2051,0.777660316,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2052,0.776488855,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2053,0.775337019,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2054,0.774204327,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2055,0.773090315,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2056,0.778129277,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2057,0.783089514,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2058,0.787972865,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2059,0.792781113,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2060,0.797515986,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2061,0.788670946,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2062,0.779971362,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2063,0.771413682,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2064,0.762994467,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2065,0.75471039,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2066,0.756612582,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2067,0.75848512,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2068,0.760328694,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2069,0.762143974,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2070,0.763931611,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2071,0.771961082,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2072,0.779868299,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2073,0.787656033,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2074,0.795326972,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2075,0.802883724,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2076,0.802976906,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2077,0.803068688,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2078,0.803159104,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2079,0.803248185,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2080,0.803335961,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2081,0.805628472,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2082,0.807885402,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2083,0.810107578,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2084,0.812295796,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2085,0.814450833,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2086,0.810073492,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2087,0.80576263,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2088,0.801516743,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2089,0.797334373,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2090,0.793214106,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2091,0.808698713,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2092,0.823950723,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2093,0.838975326,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2094,0.853777562,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2095,0.868362321,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2096,0.882548672,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2097,0.896520421,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2098,0.910282354,forestryLoss_growthFactor_SSP2
-Arkansas,AR,2099,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2000,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2001,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2002,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2003,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2004,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2005,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2006,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2007,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2008,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2009,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2010,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2011,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2012,NA,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2013,1.005049921,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2014,1.002520541,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2015,1,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2016,0.992869659,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2017,0.98591914,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2018,0.979141141,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2019,0.972528775,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2020,0.966075536,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2021,0.95868834,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2022,0.95146148,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2023,0.944389352,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2024,0.937466623,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2025,0.93068822,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2026,0.926473624,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2027,0.922334349,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2028,0.918268249,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2029,0.914273268,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2030,0.910347427,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2031,0.906093204,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2032,0.901909332,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2033,0.897793939,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2034,0.893745227,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2035,0.889761462,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2036,0.885585901,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2037,0.881481682,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2038,0.877446856,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2039,0.873479546,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2040,0.869577948,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2041,0.867037359,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2042,0.864530892,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2043,0.862057786,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2044,0.859617303,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2045,0.857208729,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2046,0.855451515,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2047,0.85372069,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2048,0.852015632,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2049,0.850335737,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2050,0.848680424,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2051,0.847006158,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2052,0.845352795,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2053,0.843719916,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2054,0.842107111,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2055,0.840513986,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2056,0.838003886,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2057,0.835527742,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2058,0.833084831,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2059,0.830674452,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2060,0.828295924,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2061,0.825743569,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2062,0.823229328,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2063,0.820752315,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2064,0.818311676,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2065,0.81590658,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2066,0.814041122,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2067,0.81220159,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2068,0.810387414,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2069,0.80859804,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2070,0.806832934,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2071,0.804341499,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2072,0.801888701,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2073,0.799473659,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2074,0.797095516,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2075,0.794753442,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2076,0.789642606,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2077,0.784615606,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2078,0.779670433,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2079,0.774805145,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2080,0.770017857,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2081,0.767643723,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2082,0.765309881,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2083,0.76301538,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2084,0.7607593,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2085,0.758540746,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2086,0.754032281,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2087,0.749591649,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2088,0.745217319,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2089,0.740907805,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2090,0.736661664,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2091,0.72100002,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2092,0.705542437,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2093,0.690284425,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2094,0.675221629,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2095,0.660349818,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2096,0.64550018,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2097,0.630843994,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2098,0.616376968,forestryLoss_growthFactor_SSP2
-Arizona,AZ,2099,NA,forestryLoss_growthFactor_SSP2
-California,CA,2000,NA,forestryLoss_growthFactor_SSP2
-California,CA,2001,NA,forestryLoss_growthFactor_SSP2
-California,CA,2002,NA,forestryLoss_growthFactor_SSP2
-California,CA,2003,NA,forestryLoss_growthFactor_SSP2
-California,CA,2004,NA,forestryLoss_growthFactor_SSP2
-California,CA,2005,NA,forestryLoss_growthFactor_SSP2
-California,CA,2006,NA,forestryLoss_growthFactor_SSP2
-California,CA,2007,NA,forestryLoss_growthFactor_SSP2
-California,CA,2008,NA,forestryLoss_growthFactor_SSP2
-California,CA,2009,NA,forestryLoss_growthFactor_SSP2
-California,CA,2010,NA,forestryLoss_growthFactor_SSP2
-California,CA,2011,NA,forestryLoss_growthFactor_SSP2
-California,CA,2012,NA,forestryLoss_growthFactor_SSP2
-California,CA,2013,1.009205451,forestryLoss_growthFactor_SSP2
-California,CA,2014,1.004555526,forestryLoss_growthFactor_SSP2
-California,CA,2015,1,forestryLoss_growthFactor_SSP2
-California,CA,2016,0.990925433,forestryLoss_growthFactor_SSP2
-California,CA,2017,0.982125562,forestryLoss_growthFactor_SSP2
-California,CA,2018,0.973587845,forestryLoss_growthFactor_SSP2
-California,CA,2019,0.965300497,forestryLoss_growthFactor_SSP2
-California,CA,2020,0.957252439,forestryLoss_growthFactor_SSP2
-California,CA,2021,0.946376589,forestryLoss_growthFactor_SSP2
-California,CA,2022,0.935796478,forestryLoss_growthFactor_SSP2
-California,CA,2023,0.92550005,forestryLoss_growthFactor_SSP2
-California,CA,2024,0.915475897,forestryLoss_growthFactor_SSP2
-California,CA,2025,0.905713221,forestryLoss_growthFactor_SSP2
-California,CA,2026,0.89837341,forestryLoss_growthFactor_SSP2
-California,CA,2027,0.891204169,forestryLoss_growthFactor_SSP2
-California,CA,2028,0.884199566,forestryLoss_growthFactor_SSP2
-California,CA,2029,0.877353943,forestryLoss_growthFactor_SSP2
-California,CA,2030,0.870661898,forestryLoss_growthFactor_SSP2
-California,CA,2031,0.864268565,forestryLoss_growthFactor_SSP2
-California,CA,2032,0.858014381,forestryLoss_growthFactor_SSP2
-California,CA,2033,0.851894813,forestryLoss_growthFactor_SSP2
-California,CA,2034,0.845905522,forestryLoss_growthFactor_SSP2
-California,CA,2035,0.840042356,forestryLoss_growthFactor_SSP2
-California,CA,2036,0.833750292,forestryLoss_growthFactor_SSP2
-California,CA,2037,0.827589597,forestryLoss_growthFactor_SSP2
-California,CA,2038,0.821556189,forestryLoss_growthFactor_SSP2
-California,CA,2039,0.815646155,forestryLoss_growthFactor_SSP2
-California,CA,2040,0.809855742,forestryLoss_growthFactor_SSP2
-California,CA,2041,0.803357234,forestryLoss_growthFactor_SSP2
-California,CA,2042,0.796988714,forestryLoss_growthFactor_SSP2
-California,CA,2043,0.790746337,forestryLoss_growthFactor_SSP2
-California,CA,2044,0.784626407,forestryLoss_growthFactor_SSP2
-California,CA,2045,0.778625368,forestryLoss_growthFactor_SSP2
-California,CA,2046,0.774596918,forestryLoss_growthFactor_SSP2
-California,CA,2047,0.770638609,forestryLoss_growthFactor_SSP2
-California,CA,2048,0.766748633,forestryLoss_growthFactor_SSP2
-California,CA,2049,0.762925246,forestryLoss_growthFactor_SSP2
-California,CA,2050,0.759166759,forestryLoss_growthFactor_SSP2
-California,CA,2051,0.755033644,forestryLoss_growthFactor_SSP2
-California,CA,2052,0.750969667,forestryLoss_growthFactor_SSP2
-California,CA,2053,0.746973136,forestryLoss_growthFactor_SSP2
-California,CA,2054,0.743042411,forestryLoss_growthFactor_SSP2
-California,CA,2055,0.739175905,forestryLoss_growthFactor_SSP2
-California,CA,2056,0.735257336,forestryLoss_growthFactor_SSP2
-California,CA,2057,0.731403713,forestryLoss_growthFactor_SSP2
-California,CA,2058,0.727613467,forestryLoss_growthFactor_SSP2
-California,CA,2059,0.723885082,forestryLoss_growthFactor_SSP2
-California,CA,2060,0.720217085,forestryLoss_growthFactor_SSP2
-California,CA,2061,0.715945182,forestryLoss_growthFactor_SSP2
-California,CA,2062,0.711745411,forestryLoss_growthFactor_SSP2
-California,CA,2063,0.707615986,forestryLoss_growthFactor_SSP2
-California,CA,2064,0.703555181,forestryLoss_growthFactor_SSP2
-California,CA,2065,0.699561324,forestryLoss_growthFactor_SSP2
-California,CA,2066,0.694635696,forestryLoss_growthFactor_SSP2
-California,CA,2067,0.689789593,forestryLoss_growthFactor_SSP2
-California,CA,2068,0.685021129,forestryLoss_growthFactor_SSP2
-California,CA,2069,0.680328481,forestryLoss_growthFactor_SSP2
-California,CA,2070,0.675709879,forestryLoss_growthFactor_SSP2
-California,CA,2071,0.671292683,forestryLoss_growthFactor_SSP2
-California,CA,2072,0.666942194,forestryLoss_growthFactor_SSP2
-California,CA,2073,0.662656905,forestryLoss_growthFactor_SSP2
-California,CA,2074,0.658435355,forestryLoss_growthFactor_SSP2
-California,CA,2075,0.654276124,forestryLoss_growthFactor_SSP2
-California,CA,2076,0.650727671,forestryLoss_growthFactor_SSP2
-California,CA,2077,0.647233474,forestryLoss_growthFactor_SSP2
-California,CA,2078,0.64379226,forestryLoss_growthFactor_SSP2
-California,CA,2079,0.640402797,forestryLoss_growthFactor_SSP2
-California,CA,2080,0.637063891,forestryLoss_growthFactor_SSP2
-California,CA,2081,0.630230288,forestryLoss_growthFactor_SSP2
-California,CA,2082,0.623498714,forestryLoss_growthFactor_SSP2
-California,CA,2083,0.616866825,forestryLoss_growthFactor_SSP2
-California,CA,2084,0.61033235,forestryLoss_growthFactor_SSP2
-California,CA,2085,0.603893087,forestryLoss_growthFactor_SSP2
-California,CA,2086,0.60050766,forestryLoss_growthFactor_SSP2
-California,CA,2087,0.597174422,forestryLoss_growthFactor_SSP2
-California,CA,2088,0.59389219,forestryLoss_growthFactor_SSP2
-California,CA,2089,0.590659816,forestryLoss_growthFactor_SSP2
-California,CA,2090,0.587476188,forestryLoss_growthFactor_SSP2
-California,CA,2091,0.575134836,forestryLoss_growthFactor_SSP2
-California,CA,2092,0.563014728,forestryLoss_growthFactor_SSP2
-California,CA,2093,0.551110849,forestryLoss_growthFactor_SSP2
-California,CA,2094,0.539418332,forestryLoss_growthFactor_SSP2
-California,CA,2095,0.527932453,forestryLoss_growthFactor_SSP2
-California,CA,2096,0.516482247,forestryLoss_growthFactor_SSP2
-California,CA,2097,0.505238247,forestryLoss_growthFactor_SSP2
-California,CA,2098,0.494195835,forestryLoss_growthFactor_SSP2
-California,CA,2099,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2000,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2001,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2002,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2003,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2004,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2005,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2006,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2007,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2008,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2009,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2010,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2011,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2012,NA,forestryLoss_growthFactor_SSP2
-Colorado,CO,2013,0.996600143,forestryLoss_growthFactor_SSP2
-Colorado,CO,2014,0.998362595,forestryLoss_growthFactor_SSP2
-Colorado,CO,2015,1,forestryLoss_growthFactor_SSP2
-Colorado,CO,2016,0.996880521,forestryLoss_growthFactor_SSP2
-Colorado,CO,2017,0.99378261,forestryLoss_growthFactor_SSP2
-Colorado,CO,2018,0.990707124,forestryLoss_growthFactor_SSP2
-Colorado,CO,2019,0.987654807,forestryLoss_growthFactor_SSP2
-Colorado,CO,2020,0.984626303,forestryLoss_growthFactor_SSP2
-Colorado,CO,2021,0.980373999,forestryLoss_growthFactor_SSP2
-Colorado,CO,2022,0.976158511,forestryLoss_growthFactor_SSP2
-Colorado,CO,2023,0.971980149,forestryLoss_growthFactor_SSP2
-Colorado,CO,2024,0.967839151,forestryLoss_growthFactor_SSP2
-Colorado,CO,2025,0.963735688,forestryLoss_growthFactor_SSP2
-Colorado,CO,2026,0.962507124,forestryLoss_growthFactor_SSP2
-Colorado,CO,2027,0.961260749,forestryLoss_growthFactor_SSP2
-Colorado,CO,2028,0.959998158,forestryLoss_growthFactor_SSP2
-Colorado,CO,2029,0.958720843,forestryLoss_growthFactor_SSP2
-Colorado,CO,2030,0.957430206,forestryLoss_growthFactor_SSP2
-Colorado,CO,2031,0.956179081,forestryLoss_growthFactor_SSP2
-Colorado,CO,2032,0.954908585,forestryLoss_growthFactor_SSP2
-Colorado,CO,2033,0.953620234,forestryLoss_growthFactor_SSP2
-Colorado,CO,2034,0.952315455,forestryLoss_growthFactor_SSP2
-Colorado,CO,2035,0.950995595,forestryLoss_growthFactor_SSP2
-Colorado,CO,2036,0.948860239,forestryLoss_growthFactor_SSP2
-Colorado,CO,2037,0.94673832,forestryLoss_growthFactor_SSP2
-Colorado,CO,2038,0.944629945,forestryLoss_growthFactor_SSP2
-Colorado,CO,2039,0.942535202,forestryLoss_growthFactor_SSP2
-Colorado,CO,2040,0.940454167,forestryLoss_growthFactor_SSP2
-Colorado,CO,2041,0.941463951,forestryLoss_growthFactor_SSP2
-Colorado,CO,2042,0.942421318,forestryLoss_growthFactor_SSP2
-Colorado,CO,2043,0.943328295,forestryLoss_growthFactor_SSP2
-Colorado,CO,2044,0.944186822,forestryLoss_growthFactor_SSP2
-Colorado,CO,2045,0.944998754,forestryLoss_growthFactor_SSP2
-Colorado,CO,2046,0.945545625,forestryLoss_growthFactor_SSP2
-Colorado,CO,2047,0.946074755,forestryLoss_growthFactor_SSP2
-Colorado,CO,2048,0.946586715,forestryLoss_growthFactor_SSP2
-Colorado,CO,2049,0.94708205,forestryLoss_growthFactor_SSP2
-Colorado,CO,2050,0.94756129,forestryLoss_growthFactor_SSP2
-Colorado,CO,2051,0.948696622,forestryLoss_growthFactor_SSP2
-Colorado,CO,2052,0.94979907,forestryLoss_growthFactor_SSP2
-Colorado,CO,2053,0.950869618,forestryLoss_growthFactor_SSP2
-Colorado,CO,2054,0.951909217,forestryLoss_growthFactor_SSP2
-Colorado,CO,2055,0.952918786,forestryLoss_growthFactor_SSP2
-Colorado,CO,2056,0.952299705,forestryLoss_growthFactor_SSP2
-Colorado,CO,2057,0.951676765,forestryLoss_growthFactor_SSP2
-Colorado,CO,2058,0.951050239,forestryLoss_growthFactor_SSP2
-Colorado,CO,2059,0.950420387,forestryLoss_growthFactor_SSP2
-Colorado,CO,2060,0.949787458,forestryLoss_growthFactor_SSP2
-Colorado,CO,2061,0.948617462,forestryLoss_growthFactor_SSP2
-Colorado,CO,2062,0.947458662,forestryLoss_growthFactor_SSP2
-Colorado,CO,2063,0.946310884,forestryLoss_growthFactor_SSP2
-Colorado,CO,2064,0.945173954,forestryLoss_growthFactor_SSP2
-Colorado,CO,2065,0.944047708,forestryLoss_growthFactor_SSP2
-Colorado,CO,2066,0.943393493,forestryLoss_growthFactor_SSP2
-Colorado,CO,2067,0.942743574,forestryLoss_growthFactor_SSP2
-Colorado,CO,2068,0.942097913,forestryLoss_growthFactor_SSP2
-Colorado,CO,2069,0.941456476,forestryLoss_growthFactor_SSP2
-Colorado,CO,2070,0.940819226,forestryLoss_growthFactor_SSP2
-Colorado,CO,2071,0.938304462,forestryLoss_growthFactor_SSP2
-Colorado,CO,2072,0.935829131,forestryLoss_growthFactor_SSP2
-Colorado,CO,2073,0.933392331,forestryLoss_growthFactor_SSP2
-Colorado,CO,2074,0.930993184,forestryLoss_growthFactor_SSP2
-Colorado,CO,2075,0.92863084,forestryLoss_growthFactor_SSP2
-Colorado,CO,2076,0.921738064,forestryLoss_growthFactor_SSP2
-Colorado,CO,2077,0.914959273,forestryLoss_growthFactor_SSP2
-Colorado,CO,2078,0.908291732,forestryLoss_growthFactor_SSP2
-Colorado,CO,2079,0.90173279,forestryLoss_growthFactor_SSP2
-Colorado,CO,2080,0.895279882,forestryLoss_growthFactor_SSP2
-Colorado,CO,2081,0.893326083,forestryLoss_growthFactor_SSP2
-Colorado,CO,2082,0.891409387,forestryLoss_growthFactor_SSP2
-Colorado,CO,2083,0.889528902,forestryLoss_growthFactor_SSP2
-Colorado,CO,2084,0.88768376,forestryLoss_growthFactor_SSP2
-Colorado,CO,2085,0.885873122,forestryLoss_growthFactor_SSP2
-Colorado,CO,2086,0.880905812,forestryLoss_growthFactor_SSP2
-Colorado,CO,2087,0.876012878,forestryLoss_growthFactor_SSP2
-Colorado,CO,2088,0.87119264,forestryLoss_growthFactor_SSP2
-Colorado,CO,2089,0.86644347,forestryLoss_growthFactor_SSP2
-Colorado,CO,2090,0.86176379,forestryLoss_growthFactor_SSP2
-Colorado,CO,2091,0.844772406,forestryLoss_growthFactor_SSP2
-Colorado,CO,2092,0.827987931,forestryLoss_growthFactor_SSP2
-Colorado,CO,2093,0.811405849,forestryLoss_growthFactor_SSP2
-Colorado,CO,2094,0.795021776,forestryLoss_growthFactor_SSP2
-Colorado,CO,2095,0.778831459,forestryLoss_growthFactor_SSP2
-Colorado,CO,2096,0.762581561,forestryLoss_growthFactor_SSP2
-Colorado,CO,2097,0.746532227,forestryLoss_growthFactor_SSP2
-Colorado,CO,2098,0.730679014,forestryLoss_growthFactor_SSP2
-Colorado,CO,2099,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2000,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2001,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2002,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2003,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2004,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2005,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2006,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2007,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2008,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2009,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2010,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2011,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2012,NA,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2013,1.031189033,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2014,1.015371979,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2015,1,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2016,0.980493843,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2017,0.96167614,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2018,0.943512976,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2019,0.925972575,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2020,0.909025133,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2021,0.891340641,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2022,0.874223344,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2023,0.857648137,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2024,0.841591328,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2025,0.826030545,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2026,0.813022032,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2027,0.800362941,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2028,0.788040129,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2029,0.776041087,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2030,0.764353901,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2031,0.752548462,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2032,0.741043725,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2033,0.729829062,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2034,0.718894324,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2035,0.708229817,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2036,0.698383746,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2037,0.688768238,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2038,0.679375714,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2039,0.670198911,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2040,0.661230874,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2041,0.652413787,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2042,0.643795581,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2043,0.635370037,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2044,0.627131185,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2045,0.619073295,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2046,0.612983766,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2047,0.60700498,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2048,0.60113402,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2049,0.595368068,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2050,0.589704403,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2051,0.584207902,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2052,0.578809728,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2053,0.57350739,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2054,0.568298478,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2055,0.563180661,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2056,0.558146911,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2057,0.553201042,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2058,0.548340876,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2059,0.543564304,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2060,0.538869286,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2061,0.533944126,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2062,0.529104396,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2063,0.524347955,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2064,0.519672732,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2065,0.515076723,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2066,0.510567017,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2067,0.506131875,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2068,0.501769513,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2069,0.497478202,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2070,0.493256266,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2071,0.489310232,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2072,0.485423595,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2073,0.481595015,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2074,0.477823191,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2075,0.474106864,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2076,0.470183523,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2077,0.466320237,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2078,0.462515596,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2079,0.458768236,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2080,0.455076834,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2081,0.451385293,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2082,0.447746067,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2083,0.444157969,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2084,0.440619848,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2085,0.437130589,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2086,0.432509756,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2087,0.42796004,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2088,0.42347983,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2089,0.419067563,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2090,0.414721723,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2091,0.404758005,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2092,0.394983888,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2093,0.385395054,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2094,0.375987315,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2095,0.366756603,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2096,0.35777901,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2097,0.348966535,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2098,0.34031548,forestryLoss_growthFactor_SSP2
-Connecticut,CT,2099,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2000,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2001,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2002,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2003,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2004,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2005,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2006,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2007,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2008,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2009,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2010,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2011,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2012,NA,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2013,0.989802519,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2014,0.995030895,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2015,1,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2016,1.000069119,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2017,1.000009567,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2018,0.999830422,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2019,0.999540102,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2020,0.999146425,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2021,0.999000149,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2022,0.998726246,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2023,0.998332942,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2024,0.997827926,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2025,0.997218392,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2026,1.000344538,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2027,1.003317936,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2028,1.006145583,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2029,1.008834107,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2030,1.011389787,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2031,1.01390204,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2032,1.016275052,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2033,1.018514966,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2034,1.020627616,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2035,1.022618552,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2036,1.025870067,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2037,1.028993005,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2038,1.03199238,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2039,1.034872975,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2040,1.037639359,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2041,1.040330237,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2042,1.042900614,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2043,1.045355041,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2044,1.047697875,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2045,1.049933285,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2046,1.055545081,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2047,1.061042078,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2048,1.066427467,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2049,1.071704325,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2050,1.076875625,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2051,1.081478313,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2052,1.08597305,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2053,1.090362881,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2054,1.094650749,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2055,1.098839494,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2056,1.102380038,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2057,1.105832343,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2058,1.109198917,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2059,1.112482177,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2060,1.115684462,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2061,1.117349805,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2062,1.118970915,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2063,1.12054908,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2064,1.122085539,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2065,1.123581491,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2066,1.123092026,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2067,1.122599847,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2068,1.122105129,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2069,1.12160804,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2070,1.121108742,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2071,1.121063821,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2072,1.121021669,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2073,1.120982204,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2074,1.120945348,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2075,1.120911024,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2076,1.122025094,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2077,1.123132958,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2078,1.124234684,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2079,1.125330339,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2080,1.126419987,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2081,1.127903018,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2082,1.129386016,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2083,1.130868867,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2084,1.132351458,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2085,1.133833681,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2086,1.131203032,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2087,1.128608679,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2088,1.126049817,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2089,1.12352566,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2090,1.121035448,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2091,1.097699772,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2092,1.074566598,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2093,1.051631722,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2094,1.028891061,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2095,1.006340652,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2096,0.982798826,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2097,0.959507367,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2098,0.936460763,forestryLoss_growthFactor_SSP2
-District of Columbia,DC,2099,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2000,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2001,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2002,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2003,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2004,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2005,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2006,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2007,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2008,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2009,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2010,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2011,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2012,NA,forestryLoss_growthFactor_SSP2
-Delaware,DE,2013,1.011261674,forestryLoss_growthFactor_SSP2
-Delaware,DE,2014,1.005573655,forestryLoss_growthFactor_SSP2
-Delaware,DE,2015,1,forestryLoss_growthFactor_SSP2
-Delaware,DE,2016,0.989931308,forestryLoss_growthFactor_SSP2
-Delaware,DE,2017,0.980164917,forestryLoss_growthFactor_SSP2
-Delaware,DE,2018,0.970687083,forestryLoss_growthFactor_SSP2
-Delaware,DE,2019,0.961484898,forestryLoss_growthFactor_SSP2
-Delaware,DE,2020,0.952546219,forestryLoss_growthFactor_SSP2
-Delaware,DE,2021,0.94178682,forestryLoss_growthFactor_SSP2
-Delaware,DE,2022,0.931318188,forestryLoss_growthFactor_SSP2
-Delaware,DE,2023,0.921128509,forestryLoss_growthFactor_SSP2
-Delaware,DE,2024,0.911206607,forestryLoss_growthFactor_SSP2
-Delaware,DE,2025,0.9015419,forestryLoss_growthFactor_SSP2
-Delaware,DE,2026,0.894251359,forestryLoss_growthFactor_SSP2
-Delaware,DE,2027,0.887130612,forestryLoss_growthFactor_SSP2
-Delaware,DE,2028,0.880173746,forestryLoss_growthFactor_SSP2
-Delaware,DE,2029,0.873375122,forestryLoss_growthFactor_SSP2
-Delaware,DE,2030,0.866729356,forestryLoss_growthFactor_SSP2
-Delaware,DE,2031,0.859470284,forestryLoss_growthFactor_SSP2
-Delaware,DE,2032,0.85237075,forestryLoss_growthFactor_SSP2
-Delaware,DE,2033,0.845425526,forestryLoss_growthFactor_SSP2
-Delaware,DE,2034,0.838629611,forestryLoss_growthFactor_SSP2
-Delaware,DE,2035,0.831978218,forestryLoss_growthFactor_SSP2
-Delaware,DE,2036,0.825533682,forestryLoss_growthFactor_SSP2
-Delaware,DE,2037,0.819224832,forestryLoss_growthFactor_SSP2
-Delaware,DE,2038,0.813047436,forestryLoss_growthFactor_SSP2
-Delaware,DE,2039,0.806997433,forestryLoss_growthFactor_SSP2
-Delaware,DE,2040,0.80107093,forestryLoss_growthFactor_SSP2
-Delaware,DE,2041,0.795248891,forestryLoss_growthFactor_SSP2
-Delaware,DE,2042,0.789544113,forestryLoss_growthFactor_SSP2
-Delaware,DE,2043,0.783953116,forestryLoss_growthFactor_SSP2
-Delaware,DE,2044,0.778472552,forestryLoss_growthFactor_SSP2
-Delaware,DE,2045,0.773099206,forestryLoss_growthFactor_SSP2
-Delaware,DE,2046,0.769740892,forestryLoss_growthFactor_SSP2
-Delaware,DE,2047,0.766441089,forestryLoss_growthFactor_SSP2
-Delaware,DE,2048,0.76319829,forestryLoss_growthFactor_SSP2
-Delaware,DE,2049,0.760011038,forestryLoss_growthFactor_SSP2
-Delaware,DE,2050,0.756877925,forestryLoss_growthFactor_SSP2
-Delaware,DE,2051,0.753522822,forestryLoss_growthFactor_SSP2
-Delaware,DE,2052,0.750223405,forestryLoss_growthFactor_SSP2
-Delaware,DE,2053,0.746978315,forestryLoss_growthFactor_SSP2
-Delaware,DE,2054,0.743786239,forestryLoss_growthFactor_SSP2
-Delaware,DE,2055,0.740645904,forestryLoss_growthFactor_SSP2
-Delaware,DE,2056,0.737065985,forestryLoss_growthFactor_SSP2
-Delaware,DE,2057,0.733543813,forestryLoss_growthFactor_SSP2
-Delaware,DE,2058,0.730078015,forestryLoss_growthFactor_SSP2
-Delaware,DE,2059,0.726667259,forestryLoss_growthFactor_SSP2
-Delaware,DE,2060,0.723310255,forestryLoss_growthFactor_SSP2
-Delaware,DE,2061,0.71922285,forestryLoss_growthFactor_SSP2
-Delaware,DE,2062,0.715203095,forestryLoss_growthFactor_SSP2
-Delaware,DE,2063,0.711249333,forestryLoss_growthFactor_SSP2
-Delaware,DE,2064,0.707359959,forestryLoss_growthFactor_SSP2
-Delaware,DE,2065,0.70353342,forestryLoss_growthFactor_SSP2
-Delaware,DE,2066,0.699869867,forestryLoss_growthFactor_SSP2
-Delaware,DE,2067,0.696264246,forestryLoss_growthFactor_SSP2
-Delaware,DE,2068,0.692715196,forestryLoss_growthFactor_SSP2
-Delaware,DE,2069,0.6892214,forestryLoss_growthFactor_SSP2
-Delaware,DE,2070,0.685781582,forestryLoss_growthFactor_SSP2
-Delaware,DE,2071,0.682154984,forestryLoss_growthFactor_SSP2
-Delaware,DE,2072,0.678583476,forestryLoss_growthFactor_SSP2
-Delaware,DE,2073,0.675065812,forestryLoss_growthFactor_SSP2
-Delaware,DE,2074,0.67160078,forestryLoss_growthFactor_SSP2
-Delaware,DE,2075,0.668187207,forestryLoss_growthFactor_SSP2
-Delaware,DE,2076,0.664477404,forestryLoss_growthFactor_SSP2
-Delaware,DE,2077,0.660826605,forestryLoss_growthFactor_SSP2
-Delaware,DE,2078,0.657233409,forestryLoss_growthFactor_SSP2
-Delaware,DE,2079,0.65369646,forestryLoss_growthFactor_SSP2
-Delaware,DE,2080,0.650214444,forestryLoss_growthFactor_SSP2
-Delaware,DE,2081,0.646679067,forestryLoss_growthFactor_SSP2
-Delaware,DE,2082,0.643198337,forestryLoss_growthFactor_SSP2
-Delaware,DE,2083,0.639770987,forestryLoss_growthFactor_SSP2
-Delaware,DE,2084,0.636395793,forestryLoss_growthFactor_SSP2
-Delaware,DE,2085,0.633071565,forestryLoss_growthFactor_SSP2
-Delaware,DE,2086,0.627880792,forestryLoss_growthFactor_SSP2
-Delaware,DE,2087,0.622768995,forestryLoss_growthFactor_SSP2
-Delaware,DE,2088,0.617734387,forestryLoss_growthFactor_SSP2
-Delaware,DE,2089,0.612775237,forestryLoss_growthFactor_SSP2
-Delaware,DE,2090,0.607889862,forestryLoss_growthFactor_SSP2
-Delaware,DE,2091,0.595529069,forestryLoss_growthFactor_SSP2
-Delaware,DE,2092,0.583360195,forestryLoss_growthFactor_SSP2
-Delaware,DE,2093,0.571378942,forestryLoss_growthFactor_SSP2
-Delaware,DE,2094,0.559581141,forestryLoss_growthFactor_SSP2
-Delaware,DE,2095,0.547962743,forestryLoss_growthFactor_SSP2
-Delaware,DE,2096,0.536334404,forestryLoss_growthFactor_SSP2
-Delaware,DE,2097,0.52488792,forestryLoss_growthFactor_SSP2
-Delaware,DE,2098,0.513619236,forestryLoss_growthFactor_SSP2
-Delaware,DE,2099,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2000,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2001,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2002,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2003,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2004,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2005,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2006,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2007,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2008,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2009,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2010,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2011,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2012,NA,forestryLoss_growthFactor_SSP2
-Florida,FL,2013,0.997944436,forestryLoss_growthFactor_SSP2
-Florida,FL,2014,0.999016502,forestryLoss_growthFactor_SSP2
-Florida,FL,2015,1,forestryLoss_growthFactor_SSP2
-Florida,FL,2016,0.996264198,forestryLoss_growthFactor_SSP2
-Florida,FL,2017,0.992588265,forestryLoss_growthFactor_SSP2
-Florida,FL,2018,0.988970813,forestryLoss_growthFactor_SSP2
-Florida,FL,2019,0.985410493,forestryLoss_growthFactor_SSP2
-Florida,FL,2020,0.981905996,forestryLoss_growthFactor_SSP2
-Florida,FL,2021,0.976116477,forestryLoss_growthFactor_SSP2
-Florida,FL,2022,0.970428939,forestryLoss_growthFactor_SSP2
-Florida,FL,2023,0.964840498,forestryLoss_growthFactor_SSP2
-Florida,FL,2024,0.959348386,forestryLoss_growthFactor_SSP2
-Florida,FL,2025,0.953949947,forestryLoss_growthFactor_SSP2
-Florida,FL,2026,0.951361736,forestryLoss_growthFactor_SSP2
-Florida,FL,2027,0.948801804,forestryLoss_growthFactor_SSP2
-Florida,FL,2028,0.946269839,forestryLoss_growthFactor_SSP2
-Florida,FL,2029,0.943765521,forestryLoss_growthFactor_SSP2
-Florida,FL,2030,0.941288531,forestryLoss_growthFactor_SSP2
-Florida,FL,2031,0.937151169,forestryLoss_growthFactor_SSP2
-Florida,FL,2032,0.933073116,forestryLoss_growthFactor_SSP2
-Florida,FL,2033,0.929053021,forestryLoss_growthFactor_SSP2
-Florida,FL,2034,0.92508958,forestryLoss_growthFactor_SSP2
-Florida,FL,2035,0.921181528,forestryLoss_growthFactor_SSP2
-Florida,FL,2036,0.918854331,forestryLoss_growthFactor_SSP2
-Florida,FL,2037,0.916554612,forestryLoss_growthFactor_SSP2
-Florida,FL,2038,0.914281872,forestryLoss_growthFactor_SSP2
-Florida,FL,2039,0.912035625,forestryLoss_growthFactor_SSP2
-Florida,FL,2040,0.909815395,forestryLoss_growthFactor_SSP2
-Florida,FL,2041,0.905718691,forestryLoss_growthFactor_SSP2
-Florida,FL,2042,0.901682309,forestryLoss_growthFactor_SSP2
-Florida,FL,2043,0.897704785,forestryLoss_growthFactor_SSP2
-Florida,FL,2044,0.893784705,forestryLoss_growthFactor_SSP2
-Florida,FL,2045,0.889920703,forestryLoss_growthFactor_SSP2
-Florida,FL,2046,0.890118574,forestryLoss_growthFactor_SSP2
-Florida,FL,2047,0.890308174,forestryLoss_growthFactor_SSP2
-Florida,FL,2048,0.890489781,forestryLoss_growthFactor_SSP2
-Florida,FL,2049,0.890663665,forestryLoss_growthFactor_SSP2
-Florida,FL,2050,0.890830083,forestryLoss_growthFactor_SSP2
-Florida,FL,2051,0.886445343,forestryLoss_growthFactor_SSP2
-Florida,FL,2052,0.882123286,forestryLoss_growthFactor_SSP2
-Florida,FL,2053,0.877862516,forestryLoss_growthFactor_SSP2
-Florida,FL,2054,0.873661677,forestryLoss_growthFactor_SSP2
-Florida,FL,2055,0.869519458,forestryLoss_growthFactor_SSP2
-Florida,FL,2056,0.866870419,forestryLoss_growthFactor_SSP2
-Florida,FL,2057,0.864255766,forestryLoss_growthFactor_SSP2
-Florida,FL,2058,0.861674792,forestryLoss_growthFactor_SSP2
-Florida,FL,2059,0.859126806,forestryLoss_growthFactor_SSP2
-Florida,FL,2060,0.856611139,forestryLoss_growthFactor_SSP2
-Florida,FL,2061,0.854957518,forestryLoss_growthFactor_SSP2
-Florida,FL,2062,0.853326563,forestryLoss_growthFactor_SSP2
-Florida,FL,2063,0.851717775,forestryLoss_growthFactor_SSP2
-Florida,FL,2064,0.850130672,forestryLoss_growthFactor_SSP2
-Florida,FL,2065,0.848564785,forestryLoss_growthFactor_SSP2
-Florida,FL,2066,0.845097578,forestryLoss_growthFactor_SSP2
-Florida,FL,2067,0.841681428,forestryLoss_growthFactor_SSP2
-Florida,FL,2068,0.838315176,forestryLoss_growthFactor_SSP2
-Florida,FL,2069,0.8349977,forestryLoss_growthFactor_SSP2
-Florida,FL,2070,0.831727911,forestryLoss_growthFactor_SSP2
-Florida,FL,2071,0.828680259,forestryLoss_growthFactor_SSP2
-Florida,FL,2072,0.825679617,forestryLoss_growthFactor_SSP2
-Florida,FL,2073,0.822724914,forestryLoss_growthFactor_SSP2
-Florida,FL,2074,0.819815111,forestryLoss_growthFactor_SSP2
-Florida,FL,2075,0.8169492,forestryLoss_growthFactor_SSP2
-Florida,FL,2076,0.814942327,forestryLoss_growthFactor_SSP2
-Florida,FL,2077,0.812969652,forestryLoss_growthFactor_SSP2
-Florida,FL,2078,0.811030348,forestryLoss_growthFactor_SSP2
-Florida,FL,2079,0.809123613,forestryLoss_growthFactor_SSP2
-Florida,FL,2080,0.807248672,forestryLoss_growthFactor_SSP2
-Florida,FL,2081,0.803901089,forestryLoss_growthFactor_SSP2
-Florida,FL,2082,0.800609085,forestryLoss_growthFactor_SSP2
-Florida,FL,2083,0.797371354,forestryLoss_growthFactor_SSP2
-Florida,FL,2084,0.794186631,forestryLoss_growthFactor_SSP2
-Florida,FL,2085,0.791053688,forestryLoss_growthFactor_SSP2
-Florida,FL,2086,0.787889466,forestryLoss_growthFactor_SSP2
-Florida,FL,2087,0.784772599,forestryLoss_growthFactor_SSP2
-Florida,FL,2088,0.781702016,forestryLoss_growthFactor_SSP2
-Florida,FL,2089,0.778676683,forestryLoss_growthFactor_SSP2
-Florida,FL,2090,0.775695593,forestryLoss_growthFactor_SSP2
-Florida,FL,2091,0.762841828,forestryLoss_growthFactor_SSP2
-Florida,FL,2092,0.750152798,forestryLoss_growthFactor_SSP2
-Florida,FL,2093,0.737624885,forestryLoss_growthFactor_SSP2
-Florida,FL,2094,0.725254581,forestryLoss_growthFactor_SSP2
-Florida,FL,2095,0.713038476,forestryLoss_growthFactor_SSP2
-Florida,FL,2096,0.700479978,forestryLoss_growthFactor_SSP2
-Florida,FL,2097,0.688095194,forestryLoss_growthFactor_SSP2
-Florida,FL,2098,0.675880263,forestryLoss_growthFactor_SSP2
-Florida,FL,2099,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2000,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2001,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2002,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2003,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2004,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2005,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2006,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2007,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2008,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2009,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2010,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2011,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2012,NA,forestryLoss_growthFactor_SSP2
-Georgia,GA,2013,0.988798579,forestryLoss_growthFactor_SSP2
-Georgia,GA,2014,0.994475455,forestryLoss_growthFactor_SSP2
-Georgia,GA,2015,1,forestryLoss_growthFactor_SSP2
-Georgia,GA,2016,1.00072187,forestryLoss_growthFactor_SSP2
-Georgia,GA,2017,1.001402482,forestryLoss_growthFactor_SSP2
-Georgia,GA,2018,1.002044213,forestryLoss_growthFactor_SSP2
-Georgia,GA,2019,1.002649276,forestryLoss_growthFactor_SSP2
-Georgia,GA,2020,1.003219738,forestryLoss_growthFactor_SSP2
-Georgia,GA,2021,0.995344236,forestryLoss_growthFactor_SSP2
-Georgia,GA,2022,0.987669318,forestryLoss_growthFactor_SSP2
-Georgia,GA,2023,0.980187117,forestryLoss_growthFactor_SSP2
-Georgia,GA,2024,0.972890182,forestryLoss_growthFactor_SSP2
-Georgia,GA,2025,0.96577145,forestryLoss_growthFactor_SSP2
-Georgia,GA,2026,0.961494204,forestryLoss_growthFactor_SSP2
-Georgia,GA,2027,0.957306995,forestryLoss_growthFactor_SSP2
-Georgia,GA,2028,0.953206889,forestryLoss_growthFactor_SSP2
-Georgia,GA,2029,0.94919108,forestryLoss_growthFactor_SSP2
-Georgia,GA,2030,0.945256888,forestryLoss_growthFactor_SSP2
-Georgia,GA,2031,0.937189215,forestryLoss_growthFactor_SSP2
-Georgia,GA,2032,0.929289107,forestryLoss_growthFactor_SSP2
-Georgia,GA,2033,0.921551256,forestryLoss_growthFactor_SSP2
-Georgia,GA,2034,0.91397058,forestryLoss_growthFactor_SSP2
-Georgia,GA,2035,0.90654221,forestryLoss_growthFactor_SSP2
-Georgia,GA,2036,0.904109896,forestryLoss_growthFactor_SSP2
-Georgia,GA,2037,0.901720705,forestryLoss_growthFactor_SSP2
-Georgia,GA,2038,0.899373426,forestryLoss_growthFactor_SSP2
-Georgia,GA,2039,0.897066896,forestryLoss_growthFactor_SSP2
-Georgia,GA,2040,0.894799994,forestryLoss_growthFactor_SSP2
-Georgia,GA,2041,0.888057928,forestryLoss_growthFactor_SSP2
-Georgia,GA,2042,0.881441768,forestryLoss_growthFactor_SSP2
-Georgia,GA,2043,0.874947921,forestryLoss_growthFactor_SSP2
-Georgia,GA,2044,0.868572932,forestryLoss_growthFactor_SSP2
-Georgia,GA,2045,0.862313475,forestryLoss_growthFactor_SSP2
-Georgia,GA,2046,0.865340001,forestryLoss_growthFactor_SSP2
-Georgia,GA,2047,0.868312632,forestryLoss_growthFactor_SSP2
-Georgia,GA,2048,0.871232774,forestryLoss_growthFactor_SSP2
-Georgia,GA,2049,0.874101783,forestryLoss_growthFactor_SSP2
-Georgia,GA,2050,0.87692097,forestryLoss_growthFactor_SSP2
-Georgia,GA,2051,0.865012965,forestryLoss_growthFactor_SSP2
-Georgia,GA,2052,0.853294521,forestryLoss_growthFactor_SSP2
-Georgia,GA,2053,0.84176112,forestryLoss_growthFactor_SSP2
-Georgia,GA,2054,0.830408387,forestryLoss_growthFactor_SSP2
-Georgia,GA,2055,0.819232086,forestryLoss_growthFactor_SSP2
-Georgia,GA,2056,0.814676012,forestryLoss_growthFactor_SSP2
-Georgia,GA,2057,0.810189585,forestryLoss_growthFactor_SSP2
-Georgia,GA,2058,0.805771198,forestryLoss_growthFactor_SSP2
-Georgia,GA,2059,0.801419294,forestryLoss_growthFactor_SSP2
-Georgia,GA,2060,0.797132362,forestryLoss_growthFactor_SSP2
-Georgia,GA,2061,0.797008305,forestryLoss_growthFactor_SSP2
-Georgia,GA,2062,0.796884516,forestryLoss_growthFactor_SSP2
-Georgia,GA,2063,0.796761009,forestryLoss_growthFactor_SSP2
-Georgia,GA,2064,0.796637799,forestryLoss_growthFactor_SSP2
-Georgia,GA,2065,0.7965149,forestryLoss_growthFactor_SSP2
-Georgia,GA,2066,0.790197039,forestryLoss_growthFactor_SSP2
-Georgia,GA,2067,0.783976824,forestryLoss_growthFactor_SSP2
-Georgia,GA,2068,0.777851986,forestryLoss_growthFactor_SSP2
-Georgia,GA,2069,0.771820328,forestryLoss_growthFactor_SSP2
-Georgia,GA,2070,0.765879719,forestryLoss_growthFactor_SSP2
-Georgia,GA,2071,0.760345459,forestryLoss_growthFactor_SSP2
-Georgia,GA,2072,0.754895807,forestryLoss_growthFactor_SSP2
-Georgia,GA,2073,0.749528841,forestryLoss_growthFactor_SSP2
-Georgia,GA,2074,0.744242699,forestryLoss_growthFactor_SSP2
-Georgia,GA,2075,0.739035574,forestryLoss_growthFactor_SSP2
-Georgia,GA,2076,0.738854608,forestryLoss_growthFactor_SSP2
-Georgia,GA,2077,0.738677723,forestryLoss_growthFactor_SSP2
-Georgia,GA,2078,0.738504815,forestryLoss_growthFactor_SSP2
-Georgia,GA,2079,0.738335782,forestryLoss_growthFactor_SSP2
-Georgia,GA,2080,0.738170524,forestryLoss_growthFactor_SSP2
-Georgia,GA,2081,0.73245215,forestryLoss_growthFactor_SSP2
-Georgia,GA,2082,0.726824542,forestryLoss_growthFactor_SSP2
-Georgia,GA,2083,0.721285586,forestryLoss_growthFactor_SSP2
-Georgia,GA,2084,0.715833236,forestryLoss_growthFactor_SSP2
-Georgia,GA,2085,0.710465506,forestryLoss_growthFactor_SSP2
-Georgia,GA,2086,0.710695315,forestryLoss_growthFactor_SSP2
-Georgia,GA,2087,0.710921341,forestryLoss_growthFactor_SSP2
-Georgia,GA,2088,0.711143671,forestryLoss_growthFactor_SSP2
-Georgia,GA,2089,0.711362389,forestryLoss_growthFactor_SSP2
-Georgia,GA,2090,0.711577577,forestryLoss_growthFactor_SSP2
-Georgia,GA,2091,0.714529779,forestryLoss_growthFactor_SSP2
-Georgia,GA,2092,0.717423781,forestryLoss_growthFactor_SSP2
-Georgia,GA,2093,0.720260912,forestryLoss_growthFactor_SSP2
-Georgia,GA,2094,0.723042461,forestryLoss_growthFactor_SSP2
-Georgia,GA,2095,0.725769679,forestryLoss_growthFactor_SSP2
-Georgia,GA,2096,0.728264245,forestryLoss_growthFactor_SSP2
-Georgia,GA,2097,0.730708,forestryLoss_growthFactor_SSP2
-Georgia,GA,2098,0.733102084,forestryLoss_growthFactor_SSP2
-Georgia,GA,2099,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2000,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2001,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2002,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2003,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2004,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2005,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2006,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2007,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2008,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2009,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2010,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2011,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2012,NA,forestryLoss_growthFactor_SSP2
-Iowa,IA,2013,1.021495416,forestryLoss_growthFactor_SSP2
-Iowa,IA,2014,1.010607413,forestryLoss_growthFactor_SSP2
-Iowa,IA,2015,1,forestryLoss_growthFactor_SSP2
-Iowa,IA,2016,0.985079496,forestryLoss_growthFactor_SSP2
-Iowa,IA,2017,0.970656481,forestryLoss_growthFactor_SSP2
-Iowa,IA,2018,0.956707078,forestryLoss_growthFactor_SSP2
-Iowa,IA,2019,0.943208897,forestryLoss_growthFactor_SSP2
-Iowa,IA,2020,0.930140921,forestryLoss_growthFactor_SSP2
-Iowa,IA,2021,0.916733176,forestryLoss_growthFactor_SSP2
-Iowa,IA,2022,0.903720091,forestryLoss_growthFactor_SSP2
-Iowa,IA,2023,0.891084885,forestryLoss_growthFactor_SSP2
-Iowa,IA,2024,0.878811704,forestryLoss_growthFactor_SSP2
-Iowa,IA,2025,0.866885559,forestryLoss_growthFactor_SSP2
-Iowa,IA,2026,0.857768074,forestryLoss_growthFactor_SSP2
-Iowa,IA,2027,0.848876352,forestryLoss_growthFactor_SSP2
-Iowa,IA,2028,0.840202248,forestryLoss_growthFactor_SSP2
-Iowa,IA,2029,0.831738004,forestryLoss_growthFactor_SSP2
-Iowa,IA,2030,0.82347622,forestryLoss_growthFactor_SSP2
-Iowa,IA,2031,0.815737144,forestryLoss_growthFactor_SSP2
-Iowa,IA,2032,0.808177292,forestryLoss_growthFactor_SSP2
-Iowa,IA,2033,0.800790619,forestryLoss_growthFactor_SSP2
-Iowa,IA,2034,0.793571348,forestryLoss_growthFactor_SSP2
-Iowa,IA,2035,0.786513951,forestryLoss_growthFactor_SSP2
-Iowa,IA,2036,0.779757032,forestryLoss_growthFactor_SSP2
-Iowa,IA,2037,0.773144304,forestryLoss_growthFactor_SSP2
-Iowa,IA,2038,0.766671238,forestryLoss_growthFactor_SSP2
-Iowa,IA,2039,0.760333488,forestryLoss_growthFactor_SSP2
-Iowa,IA,2040,0.75412689,forestryLoss_growthFactor_SSP2
-Iowa,IA,2041,0.750119966,forestryLoss_growthFactor_SSP2
-Iowa,IA,2042,0.746192745,forestryLoss_growthFactor_SSP2
-Iowa,IA,2043,0.742342875,forestryLoss_growthFactor_SSP2
-Iowa,IA,2044,0.738568096,forestryLoss_growthFactor_SSP2
-Iowa,IA,2045,0.734866234,forestryLoss_growthFactor_SSP2
-Iowa,IA,2046,0.730643721,forestryLoss_growthFactor_SSP2
-Iowa,IA,2047,0.726493231,forestryLoss_growthFactor_SSP2
-Iowa,IA,2048,0.722412929,forestryLoss_growthFactor_SSP2
-Iowa,IA,2049,0.718401041,forestryLoss_growthFactor_SSP2
-Iowa,IA,2050,0.714455854,forestryLoss_growthFactor_SSP2
-Iowa,IA,2051,0.712164084,forestryLoss_growthFactor_SSP2
-Iowa,IA,2052,0.709906617,forestryLoss_growthFactor_SSP2
-Iowa,IA,2053,0.707682664,forestryLoss_growthFactor_SSP2
-Iowa,IA,2054,0.705491463,forestryLoss_growthFactor_SSP2
-Iowa,IA,2055,0.703332274,forestryLoss_growthFactor_SSP2
-Iowa,IA,2056,0.700738332,forestryLoss_growthFactor_SSP2
-Iowa,IA,2057,0.698181828,forestryLoss_growthFactor_SSP2
-Iowa,IA,2058,0.695661928,forestryLoss_growthFactor_SSP2
-Iowa,IA,2059,0.693177824,forestryLoss_growthFactor_SSP2
-Iowa,IA,2060,0.690728732,forestryLoss_growthFactor_SSP2
-Iowa,IA,2061,0.688003663,forestryLoss_growthFactor_SSP2
-Iowa,IA,2062,0.685321043,forestryLoss_growthFactor_SSP2
-Iowa,IA,2063,0.682679865,forestryLoss_growthFactor_SSP2
-Iowa,IA,2064,0.680079153,forestryLoss_growthFactor_SSP2
-Iowa,IA,2065,0.677517961,forestryLoss_growthFactor_SSP2
-Iowa,IA,2066,0.67518902,forestryLoss_growthFactor_SSP2
-Iowa,IA,2067,0.672894739,forestryLoss_growthFactor_SSP2
-Iowa,IA,2068,0.670634328,forestryLoss_growthFactor_SSP2
-Iowa,IA,2069,0.66840702,forestryLoss_growthFactor_SSP2
-Iowa,IA,2070,0.666212074,forestryLoss_growthFactor_SSP2
-Iowa,IA,2071,0.66386343,forestryLoss_growthFactor_SSP2
-Iowa,IA,2072,0.661551154,forestryLoss_growthFactor_SSP2
-Iowa,IA,2073,0.659274415,forestryLoss_growthFactor_SSP2
-Iowa,IA,2074,0.65703241,forestryLoss_growthFactor_SSP2
-Iowa,IA,2075,0.654824358,forestryLoss_growthFactor_SSP2
-Iowa,IA,2076,0.654110962,forestryLoss_growthFactor_SSP2
-Iowa,IA,2077,0.653411856,forestryLoss_growthFactor_SSP2
-Iowa,IA,2078,0.652726681,forestryLoss_growthFactor_SSP2
-Iowa,IA,2079,0.652055089,forestryLoss_growthFactor_SSP2
-Iowa,IA,2080,0.651396743,forestryLoss_growthFactor_SSP2
-Iowa,IA,2081,0.650132187,forestryLoss_growthFactor_SSP2
-Iowa,IA,2082,0.648893499,forestryLoss_growthFactor_SSP2
-Iowa,IA,2083,0.647680047,forestryLoss_growthFactor_SSP2
-Iowa,IA,2084,0.64649122,forestryLoss_growthFactor_SSP2
-Iowa,IA,2085,0.645326425,forestryLoss_growthFactor_SSP2
-Iowa,IA,2086,0.642765374,forestryLoss_growthFactor_SSP2
-Iowa,IA,2087,0.64024213,forestryLoss_growthFactor_SSP2
-Iowa,IA,2088,0.63775584,forestryLoss_growthFactor_SSP2
-Iowa,IA,2089,0.635305679,forestryLoss_growthFactor_SSP2
-Iowa,IA,2090,0.632890847,forestryLoss_growthFactor_SSP2
-Iowa,IA,2091,0.621733663,forestryLoss_growthFactor_SSP2
-Iowa,IA,2092,0.610690717,forestryLoss_growthFactor_SSP2
-Iowa,IA,2093,0.599759573,forestryLoss_growthFactor_SSP2
-Iowa,IA,2094,0.588937866,forestryLoss_growthFactor_SSP2
-Iowa,IA,2095,0.578223299,forestryLoss_growthFactor_SSP2
-Iowa,IA,2096,0.567644712,forestryLoss_growthFactor_SSP2
-Iowa,IA,2097,0.557168234,forestryLoss_growthFactor_SSP2
-Iowa,IA,2098,0.546791627,forestryLoss_growthFactor_SSP2
-Iowa,IA,2099,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2000,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2001,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2002,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2003,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2004,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2005,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2006,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2007,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2008,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2009,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2010,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2011,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2012,NA,forestryLoss_growthFactor_SSP2
-Idaho,ID,2013,0.975509724,forestryLoss_growthFactor_SSP2
-Idaho,ID,2014,0.987911342,forestryLoss_growthFactor_SSP2
-Idaho,ID,2015,1,forestryLoss_growthFactor_SSP2
-Idaho,ID,2016,1.00710132,forestryLoss_growthFactor_SSP2
-Idaho,ID,2017,1.013955672,forestryLoss_growthFactor_SSP2
-Idaho,ID,2018,1.020575141,forestryLoss_growthFactor_SSP2
-Idaho,ID,2019,1.026971055,forestryLoss_growthFactor_SSP2
-Idaho,ID,2020,1.033154041,forestryLoss_growthFactor_SSP2
-Idaho,ID,2021,1.025117711,forestryLoss_growthFactor_SSP2
-Idaho,ID,2022,1.017280729,forestryLoss_growthFactor_SSP2
-Idaho,ID,2023,1.009635406,forestryLoss_growthFactor_SSP2
-Idaho,ID,2024,1.002174457,forestryLoss_growthFactor_SSP2
-Idaho,ID,2025,0.994890974,forestryLoss_growthFactor_SSP2
-Idaho,ID,2026,0.988527777,forestryLoss_growthFactor_SSP2
-Idaho,ID,2027,0.982301652,forestryLoss_growthFactor_SSP2
-Idaho,ID,2028,0.976208059,forestryLoss_growthFactor_SSP2
-Idaho,ID,2029,0.97024266,forestryLoss_growthFactor_SSP2
-Idaho,ID,2030,0.96440131,forestryLoss_growthFactor_SSP2
-Idaho,ID,2031,0.964415403,forestryLoss_growthFactor_SSP2
-Idaho,ID,2032,0.964415039,forestryLoss_growthFactor_SSP2
-Idaho,ID,2033,0.964400959,forestryLoss_growthFactor_SSP2
-Idaho,ID,2034,0.964373862,forestryLoss_growthFactor_SSP2
-Idaho,ID,2035,0.964334413,forestryLoss_growthFactor_SSP2
-Idaho,ID,2036,0.952839539,forestryLoss_growthFactor_SSP2
-Idaho,ID,2037,0.941576678,forestryLoss_growthFactor_SSP2
-Idaho,ID,2038,0.930538756,forestryLoss_growthFactor_SSP2
-Idaho,ID,2039,0.919718988,forestryLoss_growthFactor_SSP2
-Idaho,ID,2040,0.909110864,forestryLoss_growthFactor_SSP2
-Idaho,ID,2041,0.934913416,forestryLoss_growthFactor_SSP2
-Idaho,ID,2042,0.960193493,forestryLoss_growthFactor_SSP2
-Idaho,ID,2043,0.98496665,forestryLoss_growthFactor_SSP2
-Idaho,ID,2044,1.009247831,forestryLoss_growthFactor_SSP2
-Idaho,ID,2045,1.033051405,forestryLoss_growthFactor_SSP2
-Idaho,ID,2046,1.031934696,forestryLoss_growthFactor_SSP2
-Idaho,ID,2047,1.030834358,forestryLoss_growthFactor_SSP2
-Idaho,ID,2048,1.029750012,forestryLoss_growthFactor_SSP2
-Idaho,ID,2049,1.028681289,forestryLoss_growthFactor_SSP2
-Idaho,ID,2050,1.027627833,forestryLoss_growthFactor_SSP2
-Idaho,ID,2051,1.039928937,forestryLoss_growthFactor_SSP2
-Idaho,ID,2052,1.052026425,forestryLoss_growthFactor_SSP2
-Idaho,ID,2053,1.063925256,forestryLoss_growthFactor_SSP2
-Idaho,ID,2054,1.07563023,forestryLoss_growthFactor_SSP2
-Idaho,ID,2055,1.087145995,forestryLoss_growthFactor_SSP2
-Idaho,ID,2056,1.087030301,forestryLoss_growthFactor_SSP2
-Idaho,ID,2057,1.086911785,forestryLoss_growthFactor_SSP2
-Idaho,ID,2058,1.086790576,forestryLoss_growthFactor_SSP2
-Idaho,ID,2059,1.086666797,forestryLoss_growthFactor_SSP2
-Idaho,ID,2060,1.086540566,forestryLoss_growthFactor_SSP2
-Idaho,ID,2061,1.084762027,forestryLoss_growthFactor_SSP2
-Idaho,ID,2062,1.083009815,forestryLoss_growthFactor_SSP2
-Idaho,ID,2063,1.081283324,forestryLoss_growthFactor_SSP2
-Idaho,ID,2064,1.079581964,forestryLoss_growthFactor_SSP2
-Idaho,ID,2065,1.077905167,forestryLoss_growthFactor_SSP2
-Idaho,ID,2066,1.085172092,forestryLoss_growthFactor_SSP2
-Idaho,ID,2067,1.092321998,forestryLoss_growthFactor_SSP2
-Idaho,ID,2068,1.099357651,forestryLoss_growthFactor_SSP2
-Idaho,ID,2069,1.106281736,forestryLoss_growthFactor_SSP2
-Idaho,ID,2070,1.113096851,forestryLoss_growthFactor_SSP2
-Idaho,ID,2071,1.099508922,forestryLoss_growthFactor_SSP2
-Idaho,ID,2072,1.086128492,forestryLoss_growthFactor_SSP2
-Idaho,ID,2073,1.072950854,forestryLoss_growthFactor_SSP2
-Idaho,ID,2074,1.059971441,forestryLoss_growthFactor_SSP2
-Idaho,ID,2075,1.047185822,forestryLoss_growthFactor_SSP2
-Idaho,ID,2076,0.999000947,forestryLoss_growthFactor_SSP2
-Idaho,ID,2077,0.951588041,forestryLoss_growthFactor_SSP2
-Idaho,ID,2078,0.904928743,forestryLoss_growthFactor_SSP2
-Idaho,ID,2079,0.85900527,forestryLoss_growthFactor_SSP2
-Idaho,ID,2080,0.813800394,forestryLoss_growthFactor_SSP2
-Idaho,ID,2081,0.812364561,forestryLoss_growthFactor_SSP2
-Idaho,ID,2082,0.810955812,forestryLoss_growthFactor_SSP2
-Idaho,ID,2083,0.809573496,forestryLoss_growthFactor_SSP2
-Idaho,ID,2084,0.808216981,forestryLoss_growthFactor_SSP2
-Idaho,ID,2085,0.806885654,forestryLoss_growthFactor_SSP2
-Idaho,ID,2086,0.798660547,forestryLoss_growthFactor_SSP2
-Idaho,ID,2087,0.790559456,forestryLoss_growthFactor_SSP2
-Idaho,ID,2088,0.782579581,forestryLoss_growthFactor_SSP2
-Idaho,ID,2089,0.774718204,forestryLoss_growthFactor_SSP2
-Idaho,ID,2090,0.76697269,forestryLoss_growthFactor_SSP2
-Idaho,ID,2091,0.77622213,forestryLoss_growthFactor_SSP2
-Idaho,ID,2092,0.785288159,forestryLoss_growthFactor_SSP2
-Idaho,ID,2093,0.794174966,forestryLoss_growthFactor_SSP2
-Idaho,ID,2094,0.802886616,forestryLoss_growthFactor_SSP2
-Idaho,ID,2095,0.811427053,forestryLoss_growthFactor_SSP2
-Idaho,ID,2096,0.81977027,forestryLoss_growthFactor_SSP2
-Idaho,ID,2097,0.827939849,forestryLoss_growthFactor_SSP2
-Idaho,ID,2098,0.835939693,forestryLoss_growthFactor_SSP2
-Idaho,ID,2099,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2000,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2001,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2002,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2003,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2004,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2005,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2006,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2007,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2008,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2009,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2010,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2011,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2012,NA,forestryLoss_growthFactor_SSP2
-Illinois,IL,2013,1.032220937,forestryLoss_growthFactor_SSP2
-Illinois,IL,2014,1.015881013,forestryLoss_growthFactor_SSP2
-Illinois,IL,2015,1,forestryLoss_growthFactor_SSP2
-Illinois,IL,2016,0.980000421,forestryLoss_growthFactor_SSP2
-Illinois,IL,2017,0.960706449,forestryLoss_growthFactor_SSP2
-Illinois,IL,2018,0.942083329,forestryLoss_growthFactor_SSP2
-Illinois,IL,2019,0.924098498,forestryLoss_growthFactor_SSP2
-Illinois,IL,2020,0.906721415,forestryLoss_growthFactor_SSP2
-Illinois,IL,2021,0.888465603,forestryLoss_growthFactor_SSP2
-Illinois,IL,2022,0.870798759,forestryLoss_growthFactor_SSP2
-Illinois,IL,2023,0.853694743,forestryLoss_growthFactor_SSP2
-Illinois,IL,2024,0.837128896,forestryLoss_growthFactor_SSP2
-Illinois,IL,2025,0.82107793,forestryLoss_growthFactor_SSP2
-Illinois,IL,2026,0.807327651,forestryLoss_growthFactor_SSP2
-Illinois,IL,2027,0.793949105,forestryLoss_growthFactor_SSP2
-Illinois,IL,2028,0.780928267,forestryLoss_growthFactor_SSP2
-Illinois,IL,2029,0.768251788,forestryLoss_growthFactor_SSP2
-Illinois,IL,2030,0.755906958,forestryLoss_growthFactor_SSP2
-Illinois,IL,2031,0.7433801,forestryLoss_growthFactor_SSP2
-Illinois,IL,2032,0.731176923,forestryLoss_growthFactor_SSP2
-Illinois,IL,2033,0.719285912,forestryLoss_growthFactor_SSP2
-Illinois,IL,2034,0.707696072,forestryLoss_growthFactor_SSP2
-Illinois,IL,2035,0.696396904,forestryLoss_growthFactor_SSP2
-Illinois,IL,2036,0.685293115,forestryLoss_growthFactor_SSP2
-Illinois,IL,2037,0.674452922,forestryLoss_growthFactor_SSP2
-Illinois,IL,2038,0.663867603,forestryLoss_growthFactor_SSP2
-Illinois,IL,2039,0.653528808,forestryLoss_growthFactor_SSP2
-Illinois,IL,2040,0.643428537,forestryLoss_growthFactor_SSP2
-Illinois,IL,2041,0.633825032,forestryLoss_growthFactor_SSP2
-Illinois,IL,2042,0.624444072,forestryLoss_growthFactor_SSP2
-Illinois,IL,2043,0.615278619,forestryLoss_growthFactor_SSP2
-Illinois,IL,2044,0.606321922,forestryLoss_growthFactor_SSP2
-Illinois,IL,2045,0.597567497,forestryLoss_growthFactor_SSP2
-Illinois,IL,2046,0.589335727,forestryLoss_growthFactor_SSP2
-Illinois,IL,2047,0.581254024,forestryLoss_growthFactor_SSP2
-Illinois,IL,2048,0.573318428,forestryLoss_growthFactor_SSP2
-Illinois,IL,2049,0.565525119,forestryLoss_growthFactor_SSP2
-Illinois,IL,2050,0.557870402,forestryLoss_growthFactor_SSP2
-Illinois,IL,2051,0.55057249,forestryLoss_growthFactor_SSP2
-Illinois,IL,2052,0.543407556,forestryLoss_growthFactor_SSP2
-Illinois,IL,2053,0.536372204,forestryLoss_growthFactor_SSP2
-Illinois,IL,2054,0.529463146,forestryLoss_growthFactor_SSP2
-Illinois,IL,2055,0.522677203,forestryLoss_growthFactor_SSP2
-Illinois,IL,2056,0.515547183,forestryLoss_growthFactor_SSP2
-Illinois,IL,2057,0.508545223,forestryLoss_growthFactor_SSP2
-Illinois,IL,2058,0.501668108,forestryLoss_growthFactor_SSP2
-Illinois,IL,2059,0.494912724,forestryLoss_growthFactor_SSP2
-Illinois,IL,2060,0.488276056,forestryLoss_growthFactor_SSP2
-Illinois,IL,2061,0.481549036,forestryLoss_growthFactor_SSP2
-Illinois,IL,2062,0.474941545,forestryLoss_growthFactor_SSP2
-Illinois,IL,2063,0.468450553,forestryLoss_growthFactor_SSP2
-Illinois,IL,2064,0.462073133,forestryLoss_growthFactor_SSP2
-Illinois,IL,2065,0.455806451,forestryLoss_growthFactor_SSP2
-Illinois,IL,2066,0.44969306,forestryLoss_growthFactor_SSP2
-Illinois,IL,2067,0.443683105,forestryLoss_growthFactor_SSP2
-Illinois,IL,2068,0.437774085,forestryLoss_growthFactor_SSP2
-Illinois,IL,2069,0.43196358,forestryLoss_growthFactor_SSP2
-Illinois,IL,2070,0.426249243,forestryLoss_growthFactor_SSP2
-Illinois,IL,2071,0.420686496,forestryLoss_growthFactor_SSP2
-Illinois,IL,2072,0.415207036,forestryLoss_growthFactor_SSP2
-Illinois,IL,2073,0.409808987,forestryLoss_growthFactor_SSP2
-Illinois,IL,2074,0.404490531,forestryLoss_growthFactor_SSP2
-Illinois,IL,2075,0.399249903,forestryLoss_growthFactor_SSP2
-Illinois,IL,2076,0.394579651,forestryLoss_growthFactor_SSP2
-Illinois,IL,2077,0.389978537,forestryLoss_growthFactor_SSP2
-Illinois,IL,2078,0.385444954,forestryLoss_growthFactor_SSP2
-Illinois,IL,2079,0.380977348,forestryLoss_growthFactor_SSP2
-Illinois,IL,2080,0.376574211,forestryLoss_growthFactor_SSP2
-Illinois,IL,2081,0.372034635,forestryLoss_growthFactor_SSP2
-Illinois,IL,2082,0.367555419,forestryLoss_growthFactor_SSP2
-Illinois,IL,2083,0.363135215,forestryLoss_growthFactor_SSP2
-Illinois,IL,2084,0.358772718,forestryLoss_growthFactor_SSP2
-Illinois,IL,2085,0.354466661,forestryLoss_growthFactor_SSP2
-Illinois,IL,2086,0.349468302,forestryLoss_growthFactor_SSP2
-Illinois,IL,2087,0.344547795,forestryLoss_growthFactor_SSP2
-Illinois,IL,2088,0.339703371,forestryLoss_growthFactor_SSP2
-Illinois,IL,2089,0.334933316,forestryLoss_growthFactor_SSP2
-Illinois,IL,2090,0.330235968,forestryLoss_growthFactor_SSP2
-Illinois,IL,2091,0.320861382,forestryLoss_growthFactor_SSP2
-Illinois,IL,2092,0.311714552,forestryLoss_growthFactor_SSP2
-Illinois,IL,2093,0.302790208,forestryLoss_growthFactor_SSP2
-Illinois,IL,2094,0.294083239,forestryLoss_growthFactor_SSP2
-Illinois,IL,2095,0.285588681,forestryLoss_growthFactor_SSP2
-Illinois,IL,2096,0.277422777,forestryLoss_growthFactor_SSP2
-Illinois,IL,2097,0.269452784,forestryLoss_growthFactor_SSP2
-Illinois,IL,2098,0.261674288,forestryLoss_growthFactor_SSP2
-Illinois,IL,2099,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2000,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2001,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2002,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2003,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2004,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2005,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2006,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2007,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2008,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2009,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2010,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2011,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2012,NA,forestryLoss_growthFactor_SSP2
-Indiana,IN,2013,1.023297749,forestryLoss_growthFactor_SSP2
-Indiana,IN,2014,1.011492392,forestryLoss_growthFactor_SSP2
-Indiana,IN,2015,1,forestryLoss_growthFactor_SSP2
-Indiana,IN,2016,0.984229455,forestryLoss_growthFactor_SSP2
-Indiana,IN,2017,0.968993454,forestryLoss_growthFactor_SSP2
-Indiana,IN,2018,0.954266141,forestryLoss_growthFactor_SSP2
-Indiana,IN,2019,0.940023278,forestryLoss_growthFactor_SSP2
-Indiana,IN,2020,0.926242117,forestryLoss_growthFactor_SSP2
-Indiana,IN,2021,0.911252338,forestryLoss_growthFactor_SSP2
-Indiana,IN,2022,0.89671784,forestryLoss_growthFactor_SSP2
-Indiana,IN,2023,0.882618965,forestryLoss_growthFactor_SSP2
-Indiana,IN,2024,0.868937153,forestryLoss_growthFactor_SSP2
-Indiana,IN,2025,0.855654861,forestryLoss_growthFactor_SSP2
-Indiana,IN,2026,0.844851407,forestryLoss_growthFactor_SSP2
-Indiana,IN,2027,0.834324614,forestryLoss_growthFactor_SSP2
-Indiana,IN,2028,0.824064322,forestryLoss_growthFactor_SSP2
-Indiana,IN,2029,0.814060855,forestryLoss_growthFactor_SSP2
-Indiana,IN,2030,0.804304992,forestryLoss_growthFactor_SSP2
-Indiana,IN,2031,0.795180958,forestryLoss_growthFactor_SSP2
-Indiana,IN,2032,0.786279559,forestryLoss_growthFactor_SSP2
-Indiana,IN,2033,0.777593082,forestryLoss_growthFactor_SSP2
-Indiana,IN,2034,0.769114163,forestryLoss_growthFactor_SSP2
-Indiana,IN,2035,0.760835759,forestryLoss_growthFactor_SSP2
-Indiana,IN,2036,0.752208889,forestryLoss_growthFactor_SSP2
-Indiana,IN,2037,0.743776083,forestryLoss_growthFactor_SSP2
-Indiana,IN,2038,0.73553108,forestryLoss_growthFactor_SSP2
-Indiana,IN,2039,0.72746788,forestryLoss_growthFactor_SSP2
-Indiana,IN,2040,0.719580732,forestryLoss_growthFactor_SSP2
-Indiana,IN,2041,0.714525565,forestryLoss_growthFactor_SSP2
-Indiana,IN,2042,0.709584247,forestryLoss_growthFactor_SSP2
-Indiana,IN,2043,0.704753221,forestryLoss_growthFactor_SSP2
-Indiana,IN,2044,0.700029072,forestryLoss_growthFactor_SSP2
-Indiana,IN,2045,0.69540852,forestryLoss_growthFactor_SSP2
-Indiana,IN,2046,0.688531648,forestryLoss_growthFactor_SSP2
-Indiana,IN,2047,0.681776588,forestryLoss_growthFactor_SSP2
-Indiana,IN,2048,0.675140174,forestryLoss_growthFactor_SSP2
-Indiana,IN,2049,0.668619345,forestryLoss_growthFactor_SSP2
-Indiana,IN,2050,0.662211147,forestryLoss_growthFactor_SSP2
-Indiana,IN,2051,0.65792802,forestryLoss_growthFactor_SSP2
-Indiana,IN,2052,0.653719644,forestryLoss_growthFactor_SSP2
-Indiana,IN,2053,0.64958415,forestryLoss_growthFactor_SSP2
-Indiana,IN,2054,0.645519726,forestryLoss_growthFactor_SSP2
-Indiana,IN,2055,0.64152462,forestryLoss_growthFactor_SSP2
-Indiana,IN,2056,0.636658511,forestryLoss_growthFactor_SSP2
-Indiana,IN,2057,0.631874859,forestryLoss_growthFactor_SSP2
-Indiana,IN,2058,0.627171649,forestryLoss_growthFactor_SSP2
-Indiana,IN,2059,0.622546934,forestryLoss_growthFactor_SSP2
-Indiana,IN,2060,0.617998824,forestryLoss_growthFactor_SSP2
-Indiana,IN,2061,0.61321328,forestryLoss_growthFactor_SSP2
-Indiana,IN,2062,0.608509377,forestryLoss_growthFactor_SSP2
-Indiana,IN,2063,0.603885084,forestryLoss_growthFactor_SSP2
-Indiana,IN,2064,0.599338438,forestryLoss_growthFactor_SSP2
-Indiana,IN,2065,0.594867538,forestryLoss_growthFactor_SSP2
-Indiana,IN,2066,0.590766325,forestryLoss_growthFactor_SSP2
-Indiana,IN,2067,0.58673205,forestryLoss_growthFactor_SSP2
-Indiana,IN,2068,0.58276312,forestryLoss_growthFactor_SSP2
-Indiana,IN,2069,0.578857992,forestryLoss_growthFactor_SSP2
-Indiana,IN,2070,0.575015169,forestryLoss_growthFactor_SSP2
-Indiana,IN,2071,0.57015176,forestryLoss_growthFactor_SSP2
-Indiana,IN,2072,0.56536192,forestryLoss_growthFactor_SSP2
-Indiana,IN,2073,0.560643985,forestryLoss_growthFactor_SSP2
-Indiana,IN,2074,0.555996342,forestryLoss_growthFactor_SSP2
-Indiana,IN,2075,0.551417426,forestryLoss_growthFactor_SSP2
-Indiana,IN,2076,0.548832071,forestryLoss_growthFactor_SSP2
-Indiana,IN,2077,0.54628609,forestryLoss_growthFactor_SSP2
-Indiana,IN,2078,0.543778561,forestryLoss_growthFactor_SSP2
-Indiana,IN,2079,0.541308591,forestryLoss_growthFactor_SSP2
-Indiana,IN,2080,0.538875313,forestryLoss_growthFactor_SSP2
-Indiana,IN,2081,0.535276581,forestryLoss_growthFactor_SSP2
-Indiana,IN,2082,0.531730056,forestryLoss_growthFactor_SSP2
-Indiana,IN,2083,0.528234547,forestryLoss_growthFactor_SSP2
-Indiana,IN,2084,0.524788901,forestryLoss_growthFactor_SSP2
-Indiana,IN,2085,0.521391998,forestryLoss_growthFactor_SSP2
-Indiana,IN,2086,0.517214701,forestryLoss_growthFactor_SSP2
-Indiana,IN,2087,0.513101614,forestryLoss_growthFactor_SSP2
-Indiana,IN,2088,0.509051282,forestryLoss_growthFactor_SSP2
-Indiana,IN,2089,0.505062295,forestryLoss_growthFactor_SSP2
-Indiana,IN,2090,0.501133283,forestryLoss_growthFactor_SSP2
-Indiana,IN,2091,0.491925746,forestryLoss_growthFactor_SSP2
-Indiana,IN,2092,0.482891504,forestryLoss_growthFactor_SSP2
-Indiana,IN,2093,0.474026614,forestryLoss_growthFactor_SSP2
-Indiana,IN,2094,0.465327251,forestryLoss_growthFactor_SSP2
-Indiana,IN,2095,0.456789701,forestryLoss_growthFactor_SSP2
-Indiana,IN,2096,0.448374318,forestryLoss_growthFactor_SSP2
-Indiana,IN,2097,0.440114532,forestryLoss_growthFactor_SSP2
-Indiana,IN,2098,0.432006855,forestryLoss_growthFactor_SSP2
-Indiana,IN,2099,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2000,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2001,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2002,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2003,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2004,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2005,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2006,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2007,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2008,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2009,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2010,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2011,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2012,NA,forestryLoss_growthFactor_SSP2
-Kansas,KS,2013,1.02360607,forestryLoss_growthFactor_SSP2
-Kansas,KS,2014,1.011643751,forestryLoss_growthFactor_SSP2
-Kansas,KS,2015,1,forestryLoss_growthFactor_SSP2
-Kansas,KS,2016,0.984084134,forestryLoss_growthFactor_SSP2
-Kansas,KS,2017,0.968709206,forestryLoss_growthFactor_SSP2
-Kansas,KS,2018,0.95384902,forestryLoss_growthFactor_SSP2
-Kansas,KS,2019,0.939479015,forestryLoss_growthFactor_SSP2
-Kansas,KS,2020,0.925576146,forestryLoss_growthFactor_SSP2
-Kansas,KS,2021,0.910367111,forestryLoss_growthFactor_SSP2
-Kansas,KS,2022,0.895620146,forestryLoss_growthFactor_SSP2
-Kansas,KS,2023,0.881315298,forestryLoss_growthFactor_SSP2
-Kansas,KS,2024,0.867433727,forestryLoss_growthFactor_SSP2
-Kansas,KS,2025,0.853957626,forestryLoss_growthFactor_SSP2
-Kansas,KS,2026,0.843977802,forestryLoss_growthFactor_SSP2
-Kansas,KS,2027,0.834254184,forestryLoss_growthFactor_SSP2
-Kansas,KS,2028,0.824777353,forestryLoss_growthFactor_SSP2
-Kansas,KS,2029,0.815538336,forestryLoss_growthFactor_SSP2
-Kansas,KS,2030,0.806528581,forestryLoss_growthFactor_SSP2
-Kansas,KS,2031,0.797396535,forestryLoss_growthFactor_SSP2
-Kansas,KS,2032,0.788486281,forestryLoss_growthFactor_SSP2
-Kansas,KS,2033,0.779790157,forestryLoss_growthFactor_SSP2
-Kansas,KS,2034,0.771300839,forestryLoss_growthFactor_SSP2
-Kansas,KS,2035,0.76301133,forestryLoss_growthFactor_SSP2
-Kansas,KS,2036,0.754412341,forestryLoss_growthFactor_SSP2
-Kansas,KS,2037,0.746005545,forestryLoss_growthFactor_SSP2
-Kansas,KS,2038,0.73778476,forestryLoss_growthFactor_SSP2
-Kansas,KS,2039,0.729744063,forestryLoss_growthFactor_SSP2
-Kansas,KS,2040,0.721877775,forestryLoss_growthFactor_SSP2
-Kansas,KS,2041,0.714152104,forestryLoss_growthFactor_SSP2
-Kansas,KS,2042,0.706591114,forestryLoss_growthFactor_SSP2
-Kansas,KS,2043,0.69918978,forestryLoss_growthFactor_SSP2
-Kansas,KS,2044,0.691943278,forestryLoss_growthFactor_SSP2
-Kansas,KS,2045,0.684846974,forestryLoss_growthFactor_SSP2
-Kansas,KS,2046,0.680097731,forestryLoss_growthFactor_SSP2
-Kansas,KS,2047,0.675432873,forestryLoss_growthFactor_SSP2
-Kansas,KS,2048,0.670850202,forestryLoss_growthFactor_SSP2
-Kansas,KS,2049,0.666347597,forestryLoss_growthFactor_SSP2
-Kansas,KS,2050,0.661923006,forestryLoss_growthFactor_SSP2
-Kansas,KS,2051,0.657850176,forestryLoss_growthFactor_SSP2
-Kansas,KS,2052,0.653846809,forestryLoss_growthFactor_SSP2
-Kansas,KS,2053,0.649911187,forestryLoss_growthFactor_SSP2
-Kansas,KS,2054,0.646041645,forestryLoss_growthFactor_SSP2
-Kansas,KS,2055,0.642236575,forestryLoss_growthFactor_SSP2
-Kansas,KS,2056,0.637873063,forestryLoss_growthFactor_SSP2
-Kansas,KS,2057,0.633581891,forestryLoss_growthFactor_SSP2
-Kansas,KS,2058,0.629361312,forestryLoss_growthFactor_SSP2
-Kansas,KS,2059,0.625209635,forestryLoss_growthFactor_SSP2
-Kansas,KS,2060,0.621125222,forestryLoss_growthFactor_SSP2
-Kansas,KS,2061,0.616537221,forestryLoss_growthFactor_SSP2
-Kansas,KS,2062,0.612026508,forestryLoss_growthFactor_SSP2
-Kansas,KS,2063,0.607591172,forestryLoss_growthFactor_SSP2
-Kansas,KS,2064,0.603229367,forestryLoss_growthFactor_SSP2
-Kansas,KS,2065,0.598939302,forestryLoss_growthFactor_SSP2
-Kansas,KS,2066,0.59512954,forestryLoss_growthFactor_SSP2
-Kansas,KS,2067,0.591381399,forestryLoss_growthFactor_SSP2
-Kansas,KS,2068,0.587693417,forestryLoss_growthFactor_SSP2
-Kansas,KS,2069,0.58406418,forestryLoss_growthFactor_SSP2
-Kansas,KS,2070,0.580492315,forestryLoss_growthFactor_SSP2
-Kansas,KS,2071,0.577322258,forestryLoss_growthFactor_SSP2
-Kansas,KS,2072,0.57420029,forestryLoss_growthFactor_SSP2
-Kansas,KS,2073,0.571125323,forestryLoss_growthFactor_SSP2
-Kansas,KS,2074,0.568096302,forestryLoss_growthFactor_SSP2
-Kansas,KS,2075,0.565112201,forestryLoss_growthFactor_SSP2
-Kansas,KS,2076,0.56184758,forestryLoss_growthFactor_SSP2
-Kansas,KS,2077,0.558634372,forestryLoss_growthFactor_SSP2
-Kansas,KS,2078,0.555471359,forestryLoss_growthFactor_SSP2
-Kansas,KS,2079,0.552357363,forestryLoss_growthFactor_SSP2
-Kansas,KS,2080,0.549291242,forestryLoss_growthFactor_SSP2
-Kansas,KS,2081,0.546437012,forestryLoss_growthFactor_SSP2
-Kansas,KS,2082,0.543625714,forestryLoss_growthFactor_SSP2
-Kansas,KS,2083,0.540856359,forestryLoss_growthFactor_SSP2
-Kansas,KS,2084,0.538127991,forestryLoss_growthFactor_SSP2
-Kansas,KS,2085,0.535439681,forestryLoss_growthFactor_SSP2
-Kansas,KS,2086,0.531407868,forestryLoss_growthFactor_SSP2
-Kansas,KS,2087,0.527437627,forestryLoss_growthFactor_SSP2
-Kansas,KS,2088,0.523527563,forestryLoss_growthFactor_SSP2
-Kansas,KS,2089,0.519676325,forestryLoss_growthFactor_SSP2
-Kansas,KS,2090,0.515882601,forestryLoss_growthFactor_SSP2
-Kansas,KS,2091,0.503398599,forestryLoss_growthFactor_SSP2
-Kansas,KS,2092,0.491115263,forestryLoss_growthFactor_SSP2
-Kansas,KS,2093,0.479028086,forestryLoss_growthFactor_SSP2
-Kansas,KS,2094,0.467132693,forestryLoss_growthFactor_SSP2
-Kansas,KS,2095,0.455424839,forestryLoss_growthFactor_SSP2
-Kansas,KS,2096,0.443960774,forestryLoss_growthFactor_SSP2
-Kansas,KS,2097,0.432674079,forestryLoss_growthFactor_SSP2
-Kansas,KS,2098,0.421560798,forestryLoss_growthFactor_SSP2
-Kansas,KS,2099,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2000,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2001,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2002,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2003,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2004,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2005,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2006,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2007,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2008,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2009,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2010,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2011,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2012,NA,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2013,1.012758239,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2014,1.006286206,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2015,1,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2016,0.989289425,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2017,0.978950465,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2018,0.968964951,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2019,0.959315857,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2020,0.949987211,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2021,0.935958521,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2022,0.922356693,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2023,0.909163282,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2024,0.89636087,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2025,0.883932996,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2026,0.875656712,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2027,0.867596028,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2028,0.859742958,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2029,0.852089895,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2030,0.844629595,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2031,0.836294341,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2032,0.828163053,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2033,0.820228655,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2034,0.81248439,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2035,0.804923799,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2036,0.794982606,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2037,0.785262211,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2038,0.775755534,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2039,0.766455789,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2040,0.757356472,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2041,0.753063701,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2042,0.74886848,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2043,0.74476775,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2044,0.740758574,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2045,0.736838132,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2046,0.72659024,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2047,0.716521978,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2048,0.706628701,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2049,0.696905924,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2050,0.68734931,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2051,0.683270949,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2052,0.679263569,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2053,0.675325396,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2054,0.671454713,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2055,0.667649858,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2056,0.666007381,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2057,0.664395711,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2058,0.662814058,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2059,0.661261659,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2060,0.659737775,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2061,0.653556475,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2062,0.647479118,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2063,0.641503137,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2064,0.635626049,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2065,0.62984545,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2066,0.62771679,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2067,0.625623333,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2068,0.623564234,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2069,0.621538678,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2070,0.619545873,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2071,0.620031559,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2072,0.620509544,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2073,0.620980005,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2074,0.621443114,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2075,0.621899038,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2076,0.619538578,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2077,0.61721454,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2078,0.614926069,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2079,0.612672336,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2080,0.610452535,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2081,0.609153245,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2082,0.607871843,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2083,0.606607928,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2084,0.605361109,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2085,0.604131006,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2086,0.599751553,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2087,0.595439089,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2088,0.591192098,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2089,0.587009109,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2090,0.582888694,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2091,0.58016244,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2092,0.577497192,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2093,0.574891545,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2094,0.572344137,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2095,0.569853644,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2096,0.567348285,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2097,0.564896109,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2098,0.562495919,forestryLoss_growthFactor_SSP2
-Kentucky,KY,2099,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2000,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2001,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2002,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2003,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2004,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2005,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2006,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2007,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2008,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2009,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2010,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2011,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2012,NA,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2013,0.995299523,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2014,0.997671969,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2015,1,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2016,0.997643106,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2017,0.995370955,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2018,0.99317934,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2019,0.991064317,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2020,0.98902219,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2021,0.977473025,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2022,0.966256648,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2023,0.955359062,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2024,0.944767039,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2025,0.934468064,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2026,0.930089157,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2027,0.925819061,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2028,0.921653843,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2029,0.917589757,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2030,0.91362323,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2031,0.908276898,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2032,0.903054214,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2033,0.897951011,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2034,0.892963305,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2035,0.888087286,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2036,0.877477444,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2037,0.867093451,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2038,0.856928221,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2039,0.846974958,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2040,0.837227144,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2041,0.838140045,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2042,0.839037882,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2043,0.839921055,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2044,0.840789946,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2045,0.841644926,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2046,0.826967772,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2047,0.812544013,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2048,0.798367148,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2049,0.7844309,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2050,0.770729199,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2051,0.768847771,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2052,0.766997267,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2053,0.765176939,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2054,0.76338606,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2055,0.761623926,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2056,0.764416491,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2057,0.76716531,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2058,0.769871408,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2059,0.772535776,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2060,0.775159375,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2061,0.767570676,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2062,0.760106902,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2063,0.752765,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2064,0.745542014,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2065,0.738435086,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2066,0.738619293,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2067,0.73880129,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2068,0.738981123,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2069,0.739158835,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2070,0.739334468,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2071,0.744218926,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2072,0.749028909,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2073,0.753766108,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2074,0.758432158,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2075,0.763028651,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2076,0.762110225,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2077,0.761206248,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2078,0.760316378,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2079,0.759440284,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2080,0.758577646,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2081,0.759513734,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2082,0.760435216,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2083,0.761342431,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2084,0.762235707,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2085,0.763115361,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2086,0.75881446,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2087,0.754578851,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2088,0.750407057,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2089,0.746297647,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2090,0.742249231,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2091,0.749818223,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2092,0.757272837,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2093,0.764615625,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2094,0.771849068,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2095,0.778975573,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2096,0.785806363,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2097,0.792533418,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2098,0.799159051,forestryLoss_growthFactor_SSP2
-Louisiana,LA,2099,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2000,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2001,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2002,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2003,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2004,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2005,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2006,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2007,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2008,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2009,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2010,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2011,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2012,NA,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2013,1.018317725,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2014,1.009045134,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2015,1,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2016,0.98658386,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2017,0.973603287,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2018,0.961037646,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2019,0.94886758,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2020,0.937074908,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2021,0.924408891,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2022,0.912110781,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2023,0.900165041,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2024,0.888556987,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2025,0.877272732,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2026,0.868645832,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2027,0.860231582,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2028,0.85202233,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2029,0.844010784,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2030,0.836189992,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2031,0.827869972,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2032,0.819742816,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2033,0.811802018,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2034,0.804041354,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2035,0.796454877,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2036,0.78934531,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2037,0.782390348,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2038,0.775585086,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2039,0.768924822,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2040,0.762405045,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2041,0.755726833,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2042,0.749186984,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2043,0.742781333,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2044,0.736505878,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2045,0.730356775,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2046,0.726265914,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2047,0.722247042,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2048,0.718298295,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2049,0.714417869,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2050,0.710604026,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2051,0.70663931,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2052,0.702741004,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2053,0.698907478,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2054,0.695137159,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2055,0.69142852,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2056,0.687649923,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2057,0.683932625,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2058,0.680275161,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2059,0.676676115,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2060,0.673134114,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2061,0.66915899,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2062,0.66525,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2063,0.661405522,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2064,0.657623982,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2065,0.653903859,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2066,0.649905715,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2067,0.645971697,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2068,0.642100291,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2069,0.638290027,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2070,0.634539486,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2071,0.630845835,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2072,0.627208108,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2073,0.62362504,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2074,0.620095403,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2075,0.616618008,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2076,0.613159052,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2077,0.609754765,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2078,0.606403853,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2079,0.603105061,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2080,0.599857174,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2081,0.596553517,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2082,0.593299762,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2083,0.590094761,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2084,0.586937398,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2085,0.583826596,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2086,0.578883436,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2087,0.574015815,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2088,0.569222022,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2089,0.5645004,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2090,0.559849339,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2091,0.54682816,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2092,0.53402239,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2093,0.521427177,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2094,0.509037814,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2095,0.496849733,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2096,0.484733169,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2097,0.472816636,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2098,0.461095663,forestryLoss_growthFactor_SSP2
-Massachusetts,MA,2099,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2000,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2001,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2002,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2003,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2004,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2005,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2006,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2007,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2008,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2009,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2010,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2011,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2012,NA,forestryLoss_growthFactor_SSP2
-Maryland,MD,2013,1.015477264,forestryLoss_growthFactor_SSP2
-Maryland,MD,2014,1.007645579,forestryLoss_growthFactor_SSP2
-Maryland,MD,2015,1,forestryLoss_growthFactor_SSP2
-Maryland,MD,2016,0.987937386,forestryLoss_growthFactor_SSP2
-Maryland,MD,2017,0.976260301,forestryLoss_growthFactor_SSP2
-Maryland,MD,2018,0.964950624,forestryLoss_growthFactor_SSP2
-Maryland,MD,2019,0.953991352,forestryLoss_growthFactor_SSP2
-Maryland,MD,2020,0.94336651,forestryLoss_growthFactor_SSP2
-Maryland,MD,2021,0.931177769,forestryLoss_growthFactor_SSP2
-Maryland,MD,2022,0.919336652,forestryLoss_growthFactor_SSP2
-Maryland,MD,2023,0.907828616,forestryLoss_growthFactor_SSP2
-Maryland,MD,2024,0.896639913,forestryLoss_growthFactor_SSP2
-Maryland,MD,2025,0.885757538,forestryLoss_growthFactor_SSP2
-Maryland,MD,2026,0.877513025,forestryLoss_growthFactor_SSP2
-Maryland,MD,2027,0.869468297,forestryLoss_growthFactor_SSP2
-Maryland,MD,2028,0.861616235,forestryLoss_growthFactor_SSP2
-Maryland,MD,2029,0.853950052,forestryLoss_growthFactor_SSP2
-Maryland,MD,2030,0.846463273,forestryLoss_growthFactor_SSP2
-Maryland,MD,2031,0.838589601,forestryLoss_growthFactor_SSP2
-Maryland,MD,2032,0.830894973,forestryLoss_growthFactor_SSP2
-Maryland,MD,2033,0.823373411,forestryLoss_growthFactor_SSP2
-Maryland,MD,2034,0.816019196,forestryLoss_growthFactor_SSP2
-Maryland,MD,2035,0.808826859,forestryLoss_growthFactor_SSP2
-Maryland,MD,2036,0.802143492,forestryLoss_growthFactor_SSP2
-Maryland,MD,2037,0.795603097,forestryLoss_growthFactor_SSP2
-Maryland,MD,2038,0.789201177,forestryLoss_growthFactor_SSP2
-Maryland,MD,2039,0.782933418,forestryLoss_growthFactor_SSP2
-Maryland,MD,2040,0.776795684,forestryLoss_growthFactor_SSP2
-Maryland,MD,2041,0.7710137,forestryLoss_growthFactor_SSP2
-Maryland,MD,2042,0.765349398,forestryLoss_growthFactor_SSP2
-Maryland,MD,2043,0.759799267,forestryLoss_growthFactor_SSP2
-Maryland,MD,2044,0.754359932,forestryLoss_growthFactor_SSP2
-Maryland,MD,2045,0.749028148,forestryLoss_growthFactor_SSP2
-Maryland,MD,2046,0.74571199,forestryLoss_growthFactor_SSP2
-Maryland,MD,2047,0.742453811,forestryLoss_growthFactor_SSP2
-Maryland,MD,2048,0.739252114,forestryLoss_growthFactor_SSP2
-Maryland,MD,2049,0.736105453,forestryLoss_growthFactor_SSP2
-Maryland,MD,2050,0.73301243,forestryLoss_growthFactor_SSP2
-Maryland,MD,2051,0.729897012,forestryLoss_growthFactor_SSP2
-Maryland,MD,2052,0.72683321,forestryLoss_growthFactor_SSP2
-Maryland,MD,2053,0.723819767,forestryLoss_growthFactor_SSP2
-Maryland,MD,2054,0.720855465,forestryLoss_growthFactor_SSP2
-Maryland,MD,2055,0.717939125,forestryLoss_growthFactor_SSP2
-Maryland,MD,2056,0.714677847,forestryLoss_growthFactor_SSP2
-Maryland,MD,2057,0.711468692,forestryLoss_growthFactor_SSP2
-Maryland,MD,2058,0.708310426,forestryLoss_growthFactor_SSP2
-Maryland,MD,2059,0.705201854,forestryLoss_growthFactor_SSP2
-Maryland,MD,2060,0.702141817,forestryLoss_growthFactor_SSP2
-Maryland,MD,2061,0.6983264,forestryLoss_growthFactor_SSP2
-Maryland,MD,2062,0.694573816,forestryLoss_growthFactor_SSP2
-Maryland,MD,2063,0.690882529,forestryLoss_growthFactor_SSP2
-Maryland,MD,2064,0.687251053,forestryLoss_growthFactor_SSP2
-Maryland,MD,2065,0.683677949,forestryLoss_growthFactor_SSP2
-Maryland,MD,2066,0.680141759,forestryLoss_growthFactor_SSP2
-Maryland,MD,2067,0.676661474,forestryLoss_growthFactor_SSP2
-Maryland,MD,2068,0.67323578,forestryLoss_growthFactor_SSP2
-Maryland,MD,2069,0.669863406,forestryLoss_growthFactor_SSP2
-Maryland,MD,2070,0.666543121,forestryLoss_growthFactor_SSP2
-Maryland,MD,2071,0.663243653,forestryLoss_growthFactor_SSP2
-Maryland,MD,2072,0.659994402,forestryLoss_growthFactor_SSP2
-Maryland,MD,2073,0.656794231,forestryLoss_growthFactor_SSP2
-Maryland,MD,2074,0.653642036,forestryLoss_growthFactor_SSP2
-Maryland,MD,2075,0.650536745,forestryLoss_growthFactor_SSP2
-Maryland,MD,2076,0.647219921,forestryLoss_growthFactor_SSP2
-Maryland,MD,2077,0.643956402,forestryLoss_growthFactor_SSP2
-Maryland,MD,2078,0.640744919,forestryLoss_growthFactor_SSP2
-Maryland,MD,2079,0.637584241,forestryLoss_growthFactor_SSP2
-Maryland,MD,2080,0.63447318,forestryLoss_growthFactor_SSP2
-Maryland,MD,2081,0.631309308,forestryLoss_growthFactor_SSP2
-Maryland,MD,2082,0.628195504,forestryLoss_growthFactor_SSP2
-Maryland,MD,2083,0.625130605,forestryLoss_growthFactor_SSP2
-Maryland,MD,2084,0.62211348,forestryLoss_growthFactor_SSP2
-Maryland,MD,2085,0.619143036,forestryLoss_growthFactor_SSP2
-Maryland,MD,2086,0.614541549,forestryLoss_growthFactor_SSP2
-Maryland,MD,2087,0.610009712,forestryLoss_growthFactor_SSP2
-Maryland,MD,2088,0.605545949,forestryLoss_growthFactor_SSP2
-Maryland,MD,2089,0.601148733,forestryLoss_growthFactor_SSP2
-Maryland,MD,2090,0.596816584,forestryLoss_growthFactor_SSP2
-Maryland,MD,2091,0.585395981,forestryLoss_growthFactor_SSP2
-Maryland,MD,2092,0.574133985,forestryLoss_growthFactor_SSP2
-Maryland,MD,2093,0.563027083,forestryLoss_growthFactor_SSP2
-Maryland,MD,2094,0.552071867,forestryLoss_growthFactor_SSP2
-Maryland,MD,2095,0.541265027,forestryLoss_growthFactor_SSP2
-Maryland,MD,2096,0.530422945,forestryLoss_growthFactor_SSP2
-Maryland,MD,2097,0.519732949,forestryLoss_growthFactor_SSP2
-Maryland,MD,2098,0.509191657,forestryLoss_growthFactor_SSP2
-Maryland,MD,2099,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2000,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2001,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2002,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2003,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2004,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2005,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2006,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2007,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2008,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2009,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2010,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2011,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2012,NA,forestryLoss_growthFactor_SSP2
-Maine,ME,2013,0.980951824,forestryLoss_growthFactor_SSP2
-Maine,ME,2014,0.990570345,forestryLoss_growthFactor_SSP2
-Maine,ME,2015,1,forestryLoss_growthFactor_SSP2
-Maine,ME,2016,1.004572428,forestryLoss_growthFactor_SSP2
-Maine,ME,2017,1.00903255,forestryLoss_growthFactor_SSP2
-Maine,ME,2018,1.013384834,forestryLoss_growthFactor_SSP2
-Maine,ME,2019,1.017633499,forestryLoss_growthFactor_SSP2
-Maine,ME,2020,1.021782532,forestryLoss_growthFactor_SSP2
-Maine,ME,2021,1.003603387,forestryLoss_growthFactor_SSP2
-Maine,ME,2022,0.985968325,forestryLoss_growthFactor_SSP2
-Maine,ME,2023,0.968854021,forestryLoss_growthFactor_SSP2
-Maine,ME,2024,0.952238444,forestryLoss_growthFactor_SSP2
-Maine,ME,2025,0.936100772,forestryLoss_growthFactor_SSP2
-Maine,ME,2026,0.921617945,forestryLoss_growthFactor_SSP2
-Maine,ME,2027,0.907500757,forestryLoss_growthFactor_SSP2
-Maine,ME,2028,0.893735881,forestryLoss_growthFactor_SSP2
-Maine,ME,2029,0.880310621,forestryLoss_growthFactor_SSP2
-Maine,ME,2030,0.867212875,forestryLoss_growthFactor_SSP2
-Maine,ME,2031,0.856924998,forestryLoss_growthFactor_SSP2
-Maine,ME,2032,0.84688819,forestryLoss_growthFactor_SSP2
-Maine,ME,2033,0.837093756,forestryLoss_growthFactor_SSP2
-Maine,ME,2034,0.827533386,forestryLoss_growthFactor_SSP2
-Maine,ME,2035,0.818199142,forestryLoss_growthFactor_SSP2
-Maine,ME,2036,0.809861794,forestryLoss_growthFactor_SSP2
-Maine,ME,2037,0.801715101,forestryLoss_growthFactor_SSP2
-Maine,ME,2038,0.793752863,forestryLoss_growthFactor_SSP2
-Maine,ME,2039,0.785969139,forestryLoss_growthFactor_SSP2
-Maine,ME,2040,0.778358238,forestryLoss_growthFactor_SSP2
-Maine,ME,2041,0.787198317,forestryLoss_growthFactor_SSP2
-Maine,ME,2042,0.795879346,forestryLoss_growthFactor_SSP2
-Maine,ME,2043,0.804405767,forestryLoss_growthFactor_SSP2
-Maine,ME,2044,0.812781855,forestryLoss_growthFactor_SSP2
-Maine,ME,2045,0.821011725,forestryLoss_growthFactor_SSP2
-Maine,ME,2046,0.830311516,forestryLoss_growthFactor_SSP2
-Maine,ME,2047,0.839455144,forestryLoss_growthFactor_SSP2
-Maine,ME,2048,0.848446554,forestryLoss_growthFactor_SSP2
-Maine,ME,2049,0.857289558,forestryLoss_growthFactor_SSP2
-Maine,ME,2050,0.865987842,forestryLoss_growthFactor_SSP2
-Maine,ME,2051,0.880547778,forestryLoss_growthFactor_SSP2
-Maine,ME,2052,0.894879454,forestryLoss_growthFactor_SSP2
-Maine,ME,2053,0.908988264,forestryLoss_growthFactor_SSP2
-Maine,ME,2054,0.922879428,forestryLoss_growthFactor_SSP2
-Maine,ME,2055,0.936558005,forestryLoss_growthFactor_SSP2
-Maine,ME,2056,0.942160376,forestryLoss_growthFactor_SSP2
-Maine,ME,2057,0.947680305,forestryLoss_growthFactor_SSP2
-Maine,ME,2058,0.953119649,forestryLoss_growthFactor_SSP2
-Maine,ME,2059,0.95848021,forestryLoss_growthFactor_SSP2
-Maine,ME,2060,0.963763737,forestryLoss_growthFactor_SSP2
-Maine,ME,2061,0.957420368,forestryLoss_growthFactor_SSP2
-Maine,ME,2062,0.951184382,forestryLoss_growthFactor_SSP2
-Maine,ME,2063,0.945053116,forestryLoss_growthFactor_SSP2
-Maine,ME,2064,0.939023998,forestryLoss_growthFactor_SSP2
-Maine,ME,2065,0.933094537,forestryLoss_growthFactor_SSP2
-Maine,ME,2066,0.930762113,forestryLoss_growthFactor_SSP2
-Maine,ME,2067,0.928469077,forestryLoss_growthFactor_SSP2
-Maine,ME,2068,0.926214479,forestryLoss_growthFactor_SSP2
-Maine,ME,2069,0.923997396,forestryLoss_growthFactor_SSP2
-Maine,ME,2070,0.921816936,forestryLoss_growthFactor_SSP2
-Maine,ME,2071,0.910860627,forestryLoss_growthFactor_SSP2
-Maine,ME,2072,0.90007054,forestryLoss_growthFactor_SSP2
-Maine,ME,2073,0.889442914,forestryLoss_growthFactor_SSP2
-Maine,ME,2074,0.878974098,forestryLoss_growthFactor_SSP2
-Maine,ME,2075,0.868660553,forestryLoss_growthFactor_SSP2
-Maine,ME,2076,0.856519024,forestryLoss_growthFactor_SSP2
-Maine,ME,2077,0.844569303,forestryLoss_growthFactor_SSP2
-Maine,ME,2078,0.832806846,forestryLoss_growthFactor_SSP2
-Maine,ME,2079,0.821227253,forestryLoss_growthFactor_SSP2
-Maine,ME,2080,0.80982626,forestryLoss_growthFactor_SSP2
-Maine,ME,2081,0.79344593,forestryLoss_growthFactor_SSP2
-Maine,ME,2082,0.777316981,forestryLoss_growthFactor_SSP2
-Maine,ME,2083,0.761433605,forestryLoss_growthFactor_SSP2
-Maine,ME,2084,0.745790171,forestryLoss_growthFactor_SSP2
-Maine,ME,2085,0.730381222,forestryLoss_growthFactor_SSP2
-Maine,ME,2086,0.711231143,forestryLoss_growthFactor_SSP2
-Maine,ME,2087,0.692372626,forestryLoss_growthFactor_SSP2
-Maine,ME,2088,0.673799078,forestryLoss_growthFactor_SSP2
-Maine,ME,2089,0.655504099,forestryLoss_growthFactor_SSP2
-Maine,ME,2090,0.637481482,forestryLoss_growthFactor_SSP2
-Maine,ME,2091,0.673927344,forestryLoss_growthFactor_SSP2
-Maine,ME,2092,0.709855899,forestryLoss_growthFactor_SSP2
-Maine,ME,2093,0.745278628,forestryLoss_growthFactor_SSP2
-Maine,ME,2094,0.780206677,forestryLoss_growthFactor_SSP2
-Maine,ME,2095,0.814650863,forestryLoss_growthFactor_SSP2
-Maine,ME,2096,0.848486611,forestryLoss_growthFactor_SSP2
-Maine,ME,2097,0.881839524,forestryLoss_growthFactor_SSP2
-Maine,ME,2098,0.914720344,forestryLoss_growthFactor_SSP2
-Maine,ME,2099,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2000,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2001,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2002,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2003,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2004,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2005,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2006,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2007,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2008,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2009,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2010,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2011,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2012,NA,forestryLoss_growthFactor_SSP2
-Michigan,MI,2013,1.026002623,forestryLoss_growthFactor_SSP2
-Michigan,MI,2014,1.012815597,forestryLoss_growthFactor_SSP2
-Michigan,MI,2015,1,forestryLoss_growthFactor_SSP2
-Michigan,MI,2016,0.982967916,forestryLoss_growthFactor_SSP2
-Michigan,MI,2017,0.966534526,forestryLoss_growthFactor_SSP2
-Michigan,MI,2018,0.950670392,forestryLoss_growthFactor_SSP2
-Michigan,MI,2019,0.935347927,forestryLoss_growthFactor_SSP2
-Michigan,MI,2020,0.920541256,forestryLoss_growthFactor_SSP2
-Michigan,MI,2021,0.904421166,forestryLoss_growthFactor_SSP2
-Michigan,MI,2022,0.888810968,forestryLoss_growthFactor_SSP2
-Michigan,MI,2023,0.87368823,forestryLoss_growthFactor_SSP2
-Michigan,MI,2024,0.859031781,forestryLoss_growthFactor_SSP2
-Michigan,MI,2025,0.844821626,forestryLoss_growthFactor_SSP2
-Michigan,MI,2026,0.831798264,forestryLoss_growthFactor_SSP2
-Michigan,MI,2027,0.819118393,forestryLoss_growthFactor_SSP2
-Michigan,MI,2028,0.806769208,forestryLoss_growthFactor_SSP2
-Michigan,MI,2029,0.794738519,forestryLoss_growthFactor_SSP2
-Michigan,MI,2030,0.783014714,forestryLoss_growthFactor_SSP2
-Michigan,MI,2031,0.771034106,forestryLoss_growthFactor_SSP2
-Michigan,MI,2032,0.759354592,forestryLoss_growthFactor_SSP2
-Michigan,MI,2033,0.747965597,forestryLoss_growthFactor_SSP2
-Michigan,MI,2034,0.736857019,forestryLoss_growthFactor_SSP2
-Michigan,MI,2035,0.726019208,forestryLoss_growthFactor_SSP2
-Michigan,MI,2036,0.716813854,forestryLoss_growthFactor_SSP2
-Michigan,MI,2037,0.707825254,forestryLoss_growthFactor_SSP2
-Michigan,MI,2038,0.699046262,forestryLoss_growthFactor_SSP2
-Michigan,MI,2039,0.690470036,forestryLoss_growthFactor_SSP2
-Michigan,MI,2040,0.68209002,forestryLoss_growthFactor_SSP2
-Michigan,MI,2041,0.673823337,forestryLoss_growthFactor_SSP2
-Michigan,MI,2042,0.665745199,forestryLoss_growthFactor_SSP2
-Michigan,MI,2043,0.657849683,forestryLoss_growthFactor_SSP2
-Michigan,MI,2044,0.650131105,forestryLoss_growthFactor_SSP2
-Michigan,MI,2045,0.642584006,forestryLoss_growthFactor_SSP2
-Michigan,MI,2046,0.637407055,forestryLoss_growthFactor_SSP2
-Michigan,MI,2047,0.632325322,forestryLoss_growthFactor_SSP2
-Michigan,MI,2048,0.627336283,forestryLoss_growthFactor_SSP2
-Michigan,MI,2049,0.622437504,forestryLoss_growthFactor_SSP2
-Michigan,MI,2050,0.617626632,forestryLoss_growthFactor_SSP2
-Michigan,MI,2051,0.614137866,forestryLoss_growthFactor_SSP2
-Michigan,MI,2052,0.610715749,forestryLoss_growthFactor_SSP2
-Michigan,MI,2053,0.607358539,forestryLoss_growthFactor_SSP2
-Michigan,MI,2054,0.604064556,forestryLoss_growthFactor_SSP2
-Michigan,MI,2055,0.600832171,forestryLoss_growthFactor_SSP2
-Michigan,MI,2056,0.594235711,forestryLoss_growthFactor_SSP2
-Michigan,MI,2057,0.587753023,forestryLoss_growthFactor_SSP2
-Michigan,MI,2058,0.581381305,forestryLoss_growthFactor_SSP2
-Michigan,MI,2059,0.575117845,forestryLoss_growthFactor_SSP2
-Michigan,MI,2060,0.568960013,forestryLoss_growthFactor_SSP2
-Michigan,MI,2061,0.563675029,forestryLoss_growthFactor_SSP2
-Michigan,MI,2062,0.558482173,forestryLoss_growthFactor_SSP2
-Michigan,MI,2063,0.553379129,forestryLoss_growthFactor_SSP2
-Michigan,MI,2064,0.54836366,forestryLoss_growthFactor_SSP2
-Michigan,MI,2065,0.543433601,forestryLoss_growthFactor_SSP2
-Michigan,MI,2066,0.536178753,forestryLoss_growthFactor_SSP2
-Michigan,MI,2067,0.52904242,forestryLoss_growthFactor_SSP2
-Michigan,MI,2068,0.522021778,forestryLoss_growthFactor_SSP2
-Michigan,MI,2069,0.515114094,forestryLoss_growthFactor_SSP2
-Michigan,MI,2070,0.50831672,forestryLoss_growthFactor_SSP2
-Michigan,MI,2071,0.504225238,forestryLoss_growthFactor_SSP2
-Michigan,MI,2072,0.500195119,forestryLoss_growthFactor_SSP2
-Michigan,MI,2073,0.496224982,forestryLoss_growthFactor_SSP2
-Michigan,MI,2074,0.492313484,forestryLoss_growthFactor_SSP2
-Michigan,MI,2075,0.488459326,forestryLoss_growthFactor_SSP2
-Michigan,MI,2076,0.482609758,forestryLoss_growthFactor_SSP2
-Michigan,MI,2077,0.476849718,forestryLoss_growthFactor_SSP2
-Michigan,MI,2078,0.471177105,forestryLoss_growthFactor_SSP2
-Michigan,MI,2079,0.465589885,forestryLoss_growthFactor_SSP2
-Michigan,MI,2080,0.460086086,forestryLoss_growthFactor_SSP2
-Michigan,MI,2081,0.45629639,forestryLoss_growthFactor_SSP2
-Michigan,MI,2082,0.452558613,forestryLoss_growthFactor_SSP2
-Michigan,MI,2083,0.448871587,forestryLoss_growthFactor_SSP2
-Michigan,MI,2084,0.445234181,forestryLoss_growthFactor_SSP2
-Michigan,MI,2085,0.441645296,forestryLoss_growthFactor_SSP2
-Michigan,MI,2086,0.439485566,forestryLoss_growthFactor_SSP2
-Michigan,MI,2087,0.437359923,forestryLoss_growthFactor_SSP2
-Michigan,MI,2088,0.435267591,forestryLoss_growthFactor_SSP2
-Michigan,MI,2089,0.433207817,forestryLoss_growthFactor_SSP2
-Michigan,MI,2090,0.431179873,forestryLoss_growthFactor_SSP2
-Michigan,MI,2091,0.424021081,forestryLoss_growthFactor_SSP2
-Michigan,MI,2092,0.417024966,forestryLoss_growthFactor_SSP2
-Michigan,MI,2093,0.41018778,forestryLoss_growthFactor_SSP2
-Michigan,MI,2094,0.403505885,forestryLoss_growthFactor_SSP2
-Michigan,MI,2095,0.396975751,forestryLoss_growthFactor_SSP2
-Michigan,MI,2096,0.390589799,forestryLoss_growthFactor_SSP2
-Michigan,MI,2097,0.384347123,forestryLoss_growthFactor_SSP2
-Michigan,MI,2098,0.378244496,forestryLoss_growthFactor_SSP2
-Michigan,MI,2099,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2000,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2001,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2002,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2003,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2004,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2005,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2006,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2007,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2008,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2009,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2010,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2011,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2012,NA,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2013,1.013439878,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2014,1.006636367,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2015,1,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2016,0.98892358,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2017,0.978206047,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2018,0.967830418,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2019,0.957780757,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2020,0.948042098,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2021,0.936365726,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2022,0.925024223,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2023,0.914003537,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2024,0.903290387,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2025,0.892872212,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2026,0.88342337,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2027,0.874203676,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2028,0.865204959,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2029,0.856419432,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2030,0.847839667,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2031,0.839116066,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2032,0.8305915,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2033,0.822259308,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2034,0.814113124,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2035,0.806146857,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2036,0.80024942,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2037,0.79447964,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2038,0.788833475,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2039,0.783307051,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2040,0.777896655,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2041,0.772685201,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2042,0.767581508,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2043,0.762582336,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2044,0.757684572,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2045,0.752885223,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2046,0.750779998,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2047,0.748712027,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2048,0.746680344,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2049,0.744684012,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2050,0.742722128,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2051,0.742590389,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2052,0.742461798,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2053,0.742336266,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2054,0.742213706,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2055,0.742094036,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2056,0.737143826,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2057,0.732272068,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2058,0.727476913,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2059,0.722756569,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2060,0.718109303,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2061,0.714426569,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2062,0.710804483,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2063,0.707241564,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2064,0.703736375,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2065,0.70028753,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2066,0.693475162,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2067,0.686770287,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2068,0.680170387,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2069,0.673673018,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2070,0.667275813,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2071,0.664974401,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2072,0.662708088,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2073,0.660476079,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2074,0.6582776,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2075,0.656111903,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2076,0.651382644,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2077,0.646729382,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2078,0.642150308,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2079,0.637643668,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2080,0.633207767,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2081,0.631033564,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2082,0.628894463,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2083,0.626789644,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2084,0.624718311,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2085,0.622679695,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2086,0.622441074,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2087,0.622205871,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2088,0.621974011,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2089,0.621745418,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2090,0.621520022,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2091,0.613585159,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2092,0.605757189,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2093,0.598033752,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2094,0.590412557,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2095,0.582891381,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2096,0.575373595,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2097,0.567954908,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2098,0.56063312,forestryLoss_growthFactor_SSP2
-Minnesota,MN,2099,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2000,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2001,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2002,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2003,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2004,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2005,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2006,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2007,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2008,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2009,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2010,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2011,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2012,NA,forestryLoss_growthFactor_SSP2
-Missouri,MO,2013,1.022590592,forestryLoss_growthFactor_SSP2
-Missouri,MO,2014,1.011139344,forestryLoss_growthFactor_SSP2
-Missouri,MO,2015,1,forestryLoss_growthFactor_SSP2
-Missouri,MO,2016,0.984579673,forestryLoss_growthFactor_SSP2
-Missouri,MO,2017,0.969689417,forestryLoss_growthFactor_SSP2
-Missouri,MO,2018,0.955303426,forestryLoss_growthFactor_SSP2
-Missouri,MO,2019,0.941397512,forestryLoss_growthFactor_SSP2
-Missouri,MO,2020,0.927948981,forestryLoss_growthFactor_SSP2
-Missouri,MO,2021,0.911458529,forestryLoss_growthFactor_SSP2
-Missouri,MO,2022,0.895472888,forestryLoss_growthFactor_SSP2
-Missouri,MO,2023,0.879970181,forestryLoss_growthFactor_SSP2
-Missouri,MO,2024,0.864929754,forestryLoss_growthFactor_SSP2
-Missouri,MO,2025,0.850332087,forestryLoss_growthFactor_SSP2
-Missouri,MO,2026,0.8378385,forestryLoss_growthFactor_SSP2
-Missouri,MO,2027,0.825666482,forestryLoss_growthFactor_SSP2
-Missouri,MO,2028,0.813804192,forestryLoss_growthFactor_SSP2
-Missouri,MO,2029,0.802240356,forestryLoss_growthFactor_SSP2
-Missouri,MO,2030,0.790964228,forestryLoss_growthFactor_SSP2
-Missouri,MO,2031,0.782114636,forestryLoss_growthFactor_SSP2
-Missouri,MO,2032,0.773486925,forestryLoss_growthFactor_SSP2
-Missouri,MO,2033,0.765073311,forestryLoss_growthFactor_SSP2
-Missouri,MO,2034,0.756866359,forestryLoss_growthFactor_SSP2
-Missouri,MO,2035,0.748858964,forestryLoss_growthFactor_SSP2
-Missouri,MO,2036,0.738973873,forestryLoss_growthFactor_SSP2
-Missouri,MO,2037,0.729313299,forestryLoss_growthFactor_SSP2
-Missouri,MO,2038,0.719869964,forestryLoss_growthFactor_SSP2
-Missouri,MO,2039,0.710636895,forestryLoss_growthFactor_SSP2
-Missouri,MO,2040,0.70160741,forestryLoss_growthFactor_SSP2
-Missouri,MO,2041,0.700841715,forestryLoss_growthFactor_SSP2
-Missouri,MO,2042,0.700109244,forestryLoss_growthFactor_SSP2
-Missouri,MO,2043,0.69940875,forestryLoss_growthFactor_SSP2
-Missouri,MO,2044,0.698739038,forestryLoss_growthFactor_SSP2
-Missouri,MO,2045,0.698098966,forestryLoss_growthFactor_SSP2
-Missouri,MO,2046,0.688054448,forestryLoss_growthFactor_SSP2
-Missouri,MO,2047,0.678187458,forestryLoss_growthFactor_SSP2
-Missouri,MO,2048,0.668493383,forestryLoss_growthFactor_SSP2
-Missouri,MO,2049,0.658967773,forestryLoss_growthFactor_SSP2
-Missouri,MO,2050,0.649606323,forestryLoss_growthFactor_SSP2
-Missouri,MO,2051,0.646306427,forestryLoss_growthFactor_SSP2
-Missouri,MO,2052,0.643067289,forestryLoss_growthFactor_SSP2
-Missouri,MO,2053,0.639887348,forestryLoss_growthFactor_SSP2
-Missouri,MO,2054,0.636765095,forestryLoss_growthFactor_SSP2
-Missouri,MO,2055,0.633699071,forestryLoss_growthFactor_SSP2
-Missouri,MO,2056,0.628491944,forestryLoss_growthFactor_SSP2
-Missouri,MO,2057,0.623374468,forestryLoss_growthFactor_SSP2
-Missouri,MO,2058,0.618344437,forestryLoss_growthFactor_SSP2
-Missouri,MO,2059,0.613399714,forestryLoss_growthFactor_SSP2
-Missouri,MO,2060,0.60853823,forestryLoss_growthFactor_SSP2
-Missouri,MO,2061,0.603024593,forestryLoss_growthFactor_SSP2
-Missouri,MO,2062,0.597605887,forestryLoss_growthFactor_SSP2
-Missouri,MO,2063,0.592279742,forestryLoss_growthFactor_SSP2
-Missouri,MO,2064,0.587043863,forestryLoss_growthFactor_SSP2
-Missouri,MO,2065,0.581896032,forestryLoss_growthFactor_SSP2
-Missouri,MO,2066,0.577663538,forestryLoss_growthFactor_SSP2
-Missouri,MO,2067,0.573501382,forestryLoss_growthFactor_SSP2
-Missouri,MO,2068,0.569407878,forestryLoss_growthFactor_SSP2
-Missouri,MO,2069,0.565381391,forestryLoss_growthFactor_SSP2
-Missouri,MO,2070,0.561420338,forestryLoss_growthFactor_SSP2
-Missouri,MO,2071,0.554055452,forestryLoss_growthFactor_SSP2
-Missouri,MO,2072,0.546801955,forestryLoss_growthFactor_SSP2
-Missouri,MO,2073,0.539657329,forestryLoss_growthFactor_SSP2
-Missouri,MO,2074,0.532619131,forestryLoss_growthFactor_SSP2
-Missouri,MO,2075,0.525684992,forestryLoss_growthFactor_SSP2
-Missouri,MO,2076,0.52458283,forestryLoss_growthFactor_SSP2
-Missouri,MO,2077,0.523495387,forestryLoss_growthFactor_SSP2
-Missouri,MO,2078,0.522422335,forestryLoss_growthFactor_SSP2
-Missouri,MO,2079,0.521363354,forestryLoss_growthFactor_SSP2
-Missouri,MO,2080,0.520318133,forestryLoss_growthFactor_SSP2
-Missouri,MO,2081,0.516055668,forestryLoss_growthFactor_SSP2
-Missouri,MO,2082,0.511854289,forestryLoss_growthFactor_SSP2
-Missouri,MO,2083,0.507712606,forestryLoss_growthFactor_SSP2
-Missouri,MO,2084,0.503629274,forestryLoss_growthFactor_SSP2
-Missouri,MO,2085,0.499602985,forestryLoss_growthFactor_SSP2
-Missouri,MO,2086,0.495934747,forestryLoss_growthFactor_SSP2
-Missouri,MO,2087,0.492323264,forestryLoss_growthFactor_SSP2
-Missouri,MO,2088,0.488767248,forestryLoss_growthFactor_SSP2
-Missouri,MO,2089,0.485265451,forestryLoss_growthFactor_SSP2
-Missouri,MO,2090,0.481816661,forestryLoss_growthFactor_SSP2
-Missouri,MO,2091,0.479388995,forestryLoss_growthFactor_SSP2
-Missouri,MO,2092,0.477045789,forestryLoss_growthFactor_SSP2
-Missouri,MO,2093,0.474785056,forestryLoss_growthFactor_SSP2
-Missouri,MO,2094,0.472604867,forestryLoss_growthFactor_SSP2
-Missouri,MO,2095,0.470503351,forestryLoss_growthFactor_SSP2
-Missouri,MO,2096,0.46844256,forestryLoss_growthFactor_SSP2
-Missouri,MO,2097,0.466453959,forestryLoss_growthFactor_SSP2
-Missouri,MO,2098,0.464535913,forestryLoss_growthFactor_SSP2
-Missouri,MO,2099,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2000,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2001,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2002,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2003,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2004,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2005,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2006,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2007,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2008,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2009,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2010,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2011,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2012,NA,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2013,0.986470893,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2014,0.993299518,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2015,1,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2016,1.001914351,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2017,1.003796653,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2018,1.005647713,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2019,1.007468314,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2020,1.00925921,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2021,0.996463317,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2022,0.984053961,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2023,0.972014496,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2024,0.960329202,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2025,0.948983222,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2026,0.945164045,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2027,0.941451105,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2028,0.93784034,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2029,0.934327885,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2030,0.930910061,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2031,0.925726833,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2032,0.920674098,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2033,0.915747268,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2034,0.910941962,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2035,0.906253995,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2036,0.892547602,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2037,0.879138834,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2038,0.866018254,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2039,0.853176817,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2040,0.84060585,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2041,0.844684704,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2042,0.848692806,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2043,0.852632091,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2044,0.856504418,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2045,0.86031158,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2046,0.838905747,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2047,0.817871166,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2048,0.797198293,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2049,0.776877904,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2050,0.75690109,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2051,0.755180246,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2052,0.753491547,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2053,0.751834164,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2054,0.750207292,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2055,0.748610156,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2056,0.754003076,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2057,0.759315172,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2058,0.764548285,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2059,0.769704202,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2060,0.774784654,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2061,0.764513884,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2062,0.754414099,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2063,0.744481096,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2064,0.734710811,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2065,0.725099308,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2066,0.727061379,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2067,0.728994557,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2068,0.730899498,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2069,0.732776837,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2070,0.734627191,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2071,0.743438417,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2072,0.752115126,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2073,0.76066037,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2074,0.76907711,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2075,0.777368217,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2076,0.777225958,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2077,0.777084507,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2078,0.776943853,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2079,0.776803989,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2080,0.776664905,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2081,0.779057573,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2082,0.781410304,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2083,0.783724038,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2084,0.785999686,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2085,0.78823813,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2086,0.783469451,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2087,0.778773714,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2088,0.774149267,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2089,0.769594507,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2090,0.765107882,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2091,0.785207358,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2092,0.805029097,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2093,0.824579246,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2094,0.843863772,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2095,0.862888468,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2096,0.881537907,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2097,0.899925846,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2098,0.918058102,forestryLoss_growthFactor_SSP2
-Mississippi,MS,2099,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2000,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2001,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2002,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2003,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2004,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2005,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2006,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2007,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2008,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2009,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2010,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2011,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2012,NA,forestryLoss_growthFactor_SSP2
-Montana,MT,2013,0.978205571,forestryLoss_growthFactor_SSP2
-Montana,MT,2014,0.989233868,forestryLoss_growthFactor_SSP2
-Montana,MT,2015,1,forestryLoss_growthFactor_SSP2
-Montana,MT,2016,1.005833269,forestryLoss_growthFactor_SSP2
-Montana,MT,2017,1.011477044,forestryLoss_growthFactor_SSP2
-Montana,MT,2018,1.016940304,forestryLoss_growthFactor_SSP2
-Montana,MT,2019,1.022231474,forestryLoss_growthFactor_SSP2
-Montana,MT,2020,1.027358465,forestryLoss_growthFactor_SSP2
-Montana,MT,2021,1.017752662,forestryLoss_growthFactor_SSP2
-Montana,MT,2022,1.008408818,forestryLoss_growthFactor_SSP2
-Montana,MT,2023,0.999316236,forestryLoss_growthFactor_SSP2
-Montana,MT,2024,0.990464796,forestryLoss_growthFactor_SSP2
-Montana,MT,2025,0.98184492,forestryLoss_growthFactor_SSP2
-Montana,MT,2026,0.974111978,forestryLoss_growthFactor_SSP2
-Montana,MT,2027,0.966558696,forestryLoss_growthFactor_SSP2
-Montana,MT,2028,0.959178827,forestryLoss_growthFactor_SSP2
-Montana,MT,2029,0.951966411,forestryLoss_growthFactor_SSP2
-Montana,MT,2030,0.944915762,forestryLoss_growthFactor_SSP2
-Montana,MT,2031,0.943913463,forestryLoss_growthFactor_SSP2
-Montana,MT,2032,0.942929401,forestryLoss_growthFactor_SSP2
-Montana,MT,2033,0.941963051,forestryLoss_growthFactor_SSP2
-Montana,MT,2034,0.941013906,forestryLoss_growthFactor_SSP2
-Montana,MT,2035,0.940081482,forestryLoss_growthFactor_SSP2
-Montana,MT,2036,0.927496775,forestryLoss_growthFactor_SSP2
-Montana,MT,2037,0.915172995,forestryLoss_growthFactor_SSP2
-Montana,MT,2038,0.90310207,forestryLoss_growthFactor_SSP2
-Montana,MT,2039,0.891276256,forestryLoss_growthFactor_SSP2
-Montana,MT,2040,0.879688124,forestryLoss_growthFactor_SSP2
-Montana,MT,2041,0.905664129,forestryLoss_growthFactor_SSP2
-Montana,MT,2042,0.93111996,forestryLoss_growthFactor_SSP2
-Montana,MT,2043,0.956071016,forestryLoss_growthFactor_SSP2
-Montana,MT,2044,0.980532099,forestryLoss_growthFactor_SSP2
-Montana,MT,2045,1.004517436,forestryLoss_growthFactor_SSP2
-Montana,MT,2046,1.003111674,forestryLoss_growthFactor_SSP2
-Montana,MT,2047,1.001728092,forestryLoss_growthFactor_SSP2
-Montana,MT,2048,1.000366148,forestryLoss_growthFactor_SSP2
-Montana,MT,2049,0.999025322,forestryLoss_growthFactor_SSP2
-Montana,MT,2050,0.997705107,forestryLoss_growthFactor_SSP2
-Montana,MT,2051,1.010630808,forestryLoss_growthFactor_SSP2
-Montana,MT,2052,1.023342765,forestryLoss_growthFactor_SSP2
-Montana,MT,2053,1.035846183,forestryLoss_growthFactor_SSP2
-Montana,MT,2054,1.048146095,forestryLoss_growthFactor_SSP2
-Montana,MT,2055,1.060247379,forestryLoss_growthFactor_SSP2
-Montana,MT,2056,1.060690105,forestryLoss_growthFactor_SSP2
-Montana,MT,2057,1.061120144,forestryLoss_growthFactor_SSP2
-Montana,MT,2058,1.06153787,forestryLoss_growthFactor_SSP2
-Montana,MT,2059,1.061943644,forestryLoss_growthFactor_SSP2
-Montana,MT,2060,1.062337815,forestryLoss_growthFactor_SSP2
-Montana,MT,2061,1.061002238,forestryLoss_growthFactor_SSP2
-Montana,MT,2062,1.059685189,forestryLoss_growthFactor_SSP2
-Montana,MT,2063,1.058386258,forestryLoss_growthFactor_SSP2
-Montana,MT,2064,1.057105045,forestryLoss_growthFactor_SSP2
-Montana,MT,2065,1.055841166,forestryLoss_growthFactor_SSP2
-Montana,MT,2066,1.063611477,forestryLoss_growthFactor_SSP2
-Montana,MT,2067,1.071256729,forestryLoss_growthFactor_SSP2
-Montana,MT,2068,1.078779879,forestryLoss_growthFactor_SSP2
-Montana,MT,2069,1.086183794,forestryLoss_growthFactor_SSP2
-Montana,MT,2070,1.093471252,forestryLoss_growthFactor_SSP2
-Montana,MT,2071,1.079831914,forestryLoss_growthFactor_SSP2
-Montana,MT,2072,1.06640092,forestryLoss_growthFactor_SSP2
-Montana,MT,2073,1.053173543,forestryLoss_growthFactor_SSP2
-Montana,MT,2074,1.040145196,forestryLoss_growthFactor_SSP2
-Montana,MT,2075,1.027311429,forestryLoss_growthFactor_SSP2
-Montana,MT,2076,0.978067844,forestryLoss_growthFactor_SSP2
-Montana,MT,2077,0.929613304,forestryLoss_growthFactor_SSP2
-Montana,MT,2078,0.881929042,forestryLoss_growthFactor_SSP2
-Montana,MT,2079,0.83499688,forestryLoss_growthFactor_SSP2
-Montana,MT,2080,0.788799208,forestryLoss_growthFactor_SSP2
-Montana,MT,2081,0.787923314,forestryLoss_growthFactor_SSP2
-Montana,MT,2082,0.787067343,forestryLoss_growthFactor_SSP2
-Montana,MT,2083,0.7862308,forestryLoss_growthFactor_SSP2
-Montana,MT,2084,0.785413208,forestryLoss_growthFactor_SSP2
-Montana,MT,2085,0.784614102,forestryLoss_growthFactor_SSP2
-Montana,MT,2086,0.776800175,forestryLoss_growthFactor_SSP2
-Montana,MT,2087,0.769103754,forestryLoss_growthFactor_SSP2
-Montana,MT,2088,0.761522187,forestryLoss_growthFactor_SSP2
-Montana,MT,2089,0.7540529,forestryLoss_growthFactor_SSP2
-Montana,MT,2090,0.746693396,forestryLoss_growthFactor_SSP2
-Montana,MT,2091,0.757480844,forestryLoss_growthFactor_SSP2
-Montana,MT,2092,0.768051443,forestryLoss_growthFactor_SSP2
-Montana,MT,2093,0.778410149,forestryLoss_growthFactor_SSP2
-Montana,MT,2094,0.788561773,forestryLoss_growthFactor_SSP2
-Montana,MT,2095,0.798510984,forestryLoss_growthFactor_SSP2
-Montana,MT,2096,0.808119734,forestryLoss_growthFactor_SSP2
-Montana,MT,2097,0.817530669,forestryLoss_growthFactor_SSP2
-Montana,MT,2098,0.826748233,forestryLoss_growthFactor_SSP2
-Montana,MT,2099,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2000,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2001,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2002,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2003,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2004,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2005,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2006,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2007,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2008,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2009,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2010,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2011,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2012,NA,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2013,0.996501171,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2014,0.998280607,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2015,1,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2016,0.99702299,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2017,0.994123254,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2018,0.991297588,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2019,0.98854297,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2020,0.985856552,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2021,0.977201293,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2022,0.968770926,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2023,0.960556522,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2024,0.952549627,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2025,0.944742232,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2026,0.939703533,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2027,0.934774827,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2028,0.929952435,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2029,0.925232849,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2030,0.920612712,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2031,0.912918361,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2032,0.905385387,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2033,0.898008648,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2034,0.89078322,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2035,0.883704388,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2036,0.880214126,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2037,0.876790772,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2038,0.873432349,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2039,0.870136958,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2040,0.866902774,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2041,0.860461039,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2042,0.85414034,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2043,0.84793721,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2044,0.841848317,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2045,0.835870455,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2046,0.837041744,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2047,0.83819126,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2048,0.839319582,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2049,0.84042727,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2050,0.841514865,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2051,0.832166788,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2052,0.82296728,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2053,0.813912804,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2054,0.804999934,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2055,0.796225352,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2056,0.791979577,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2057,0.787798895,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2058,0.7836818,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2059,0.779626835,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2060,0.775632587,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2061,0.774571362,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2062,0.773525874,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2063,0.772495757,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2064,0.771480661,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2065,0.770480244,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2066,0.765256641,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2067,0.760113404,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2068,0.75504867,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2069,0.750060633,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2070,0.745147546,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2071,0.740722123,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2072,0.736364475,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2073,0.732073061,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2074,0.727846389,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2075,0.723683009,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2076,0.723031426,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2077,0.722391945,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2078,0.721764265,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2079,0.721148098,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2080,0.720543162,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2081,0.716143726,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2082,0.71181571,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2083,0.707557444,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2084,0.703367309,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2085,0.699243735,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2086,0.698380122,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2087,0.69752915,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2088,0.696690537,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2089,0.695864005,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2090,0.695049288,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2091,0.692567888,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2092,0.690100547,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2093,0.687647,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2094,0.685206991,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2095,0.682780271,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2096,0.680257849,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2097,0.677748939,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2098,0.675253257,forestryLoss_growthFactor_SSP2
-North Carolina,NC,2099,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2000,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2001,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2002,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2003,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2004,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2005,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2006,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2007,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2008,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2009,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2010,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2011,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2012,NA,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2013,0.984561087,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2014,0.992451747,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2015,1,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2016,1.002556948,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2017,1.004886987,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2018,1.007004256,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2019,1.008921916,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2020,1.010652223,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2021,1.013629449,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2022,1.016350303,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2023,1.018829265,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2024,1.021079912,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2025,1.023114983,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2026,1.030669727,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2027,1.037935207,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2028,1.044923872,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2029,1.051647532,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2030,1.058117398,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2031,1.065548632,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2032,1.072694262,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2033,1.079565943,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2034,1.086174771,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2035,1.092531308,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2036,1.100409237,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2037,1.10803116,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2038,1.115406568,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2039,1.122544526,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2040,1.129453697,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2041,1.137244959,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2042,1.144778827,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2043,1.15206442,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2044,1.159110472,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2045,1.165925353,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2046,1.177678601,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2047,1.189200074,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2048,1.200496115,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2049,1.211572843,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2050,1.222436166,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2051,1.234529052,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2052,1.246367343,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2053,1.257957953,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2054,1.269307563,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2055,1.280422629,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2056,1.29191291,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2057,1.303158275,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2058,1.314165328,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2059,1.324940451,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2060,1.335489816,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2061,1.345796875,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2062,1.355895379,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2063,1.365790897,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2064,1.375488815,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2065,1.384994336,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2066,1.394803897,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2067,1.404426708,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2068,1.41386749,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2069,1.423130811,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2070,1.432221097,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2071,1.442619774,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2072,1.45286726,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2073,1.462966918,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2074,1.47292201,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2075,1.482735705,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2076,1.492278314,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2077,1.501698351,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2078,1.510998521,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2079,1.520181448,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2080,1.529249677,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2081,1.53984758,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2082,1.550343041,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2083,1.560738115,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2084,1.571034802,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2085,1.581235039,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2086,1.587839055,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2087,1.594330373,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2088,1.600711585,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2089,1.606985204,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2090,1.613153669,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2091,1.590681232,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2092,1.567949932,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2093,1.544966817,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2094,1.52173872,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2095,1.498272273,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2096,1.474548958,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2097,1.450612764,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2098,1.426468815,forestryLoss_growthFactor_SSP2
-North Dakota,ND,2099,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2000,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2001,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2002,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2003,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2004,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2005,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2006,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2007,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2008,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2009,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2010,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2011,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2012,NA,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2013,1.016075487,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2014,1.007941777,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2015,1,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2016,0.98764819,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2017,0.975689955,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2018,0.964106827,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2019,0.952881472,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2020,0.941997605,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2021,0.93016848,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2022,0.918666969,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2023,0.907479578,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2024,0.896593547,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2025,0.885996799,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2026,0.879217572,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2027,0.872594961,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2028,0.866123537,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2029,0.859798124,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2030,0.85361378,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2031,0.847504486,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2032,0.841524671,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2033,0.83567018,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2034,0.829937039,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2035,0.824321442,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2036,0.818626473,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2037,0.813044213,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2038,0.807571266,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2039,0.802204371,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2040,0.7969404,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2041,0.79201228,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2042,0.787172635,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2043,0.782418998,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2044,0.777748993,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2045,0.773160335,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2046,0.771345556,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2047,0.769558942,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2048,0.767799814,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2049,0.766067516,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2050,0.764361413,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2051,0.763125154,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2052,0.761901631,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2053,0.760690634,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2054,0.759491961,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2055,0.758305411,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2056,0.756535396,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2057,0.754785594,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2058,0.753055635,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2059,0.751345155,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2060,0.749653803,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2061,0.747441683,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2062,0.745260986,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2063,0.743111005,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2064,0.740991054,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2065,0.73890047,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2066,0.737316077,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2067,0.735752655,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2068,0.734209757,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2069,0.732686946,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2070,0.7311838,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2071,0.7303749,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2072,0.729579425,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2073,0.728797061,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2074,0.728027502,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2075,0.727270454,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2076,0.726396084,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2077,0.725540603,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2078,0.72470353,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2079,0.723884396,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2080,0.723082749,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2081,0.722718418,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2082,0.722370016,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2083,0.722037122,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2084,0.721719327,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2085,0.721416238,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2086,0.719127017,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2087,0.716870751,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2088,0.714646702,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2089,0.712454151,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2090,0.710292404,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2091,0.695908808,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2092,0.681653263,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2093,0.667523098,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2094,0.653515721,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2095,0.639628613,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2096,0.625849911,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2097,0.61219004,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2098,0.598646409,forestryLoss_growthFactor_SSP2
-Nebraska,NE,2099,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2000,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2001,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2002,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2003,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2004,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2005,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2006,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2007,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2008,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2009,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2010,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2011,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2012,NA,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2013,1.010115353,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2014,1.004973028,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2015,1,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2016,0.990580282,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2017,0.981504595,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2018,0.972755741,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2019,0.964317613,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2020,0.95617511,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2021,0.938870396,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2022,0.922101572,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2023,0.905845289,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2024,0.890079504,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2025,0.874783393,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2026,0.861312906,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2027,0.84819475,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2028,0.835415844,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2029,0.822963736,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2030,0.810826561,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2031,0.799119127,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2032,0.787707226,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2033,0.776580455,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2034,0.765728881,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2035,0.755143013,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2036,0.745001738,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2037,0.735098555,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2038,0.725425627,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2039,0.715975445,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2040,0.70674082,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2041,0.703378489,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2042,0.700110823,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2043,0.696934615,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2044,0.69384679,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2045,0.690844402,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2046,0.689289898,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2047,0.68776942,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2048,0.686281998,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2049,0.684826694,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2050,0.683402605,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2051,0.684248605,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2052,0.685093429,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2053,0.685936935,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2054,0.686778992,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2055,0.687619475,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2056,0.685610001,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2057,0.683643352,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2058,0.681718372,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2059,0.679833947,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2060,0.677988996,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2061,0.671807027,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2062,0.665732469,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2063,0.659762628,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2064,0.6538949,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2065,0.648126762,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2066,0.643719446,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2067,0.639386332,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2068,0.635125631,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2069,0.63093561,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2070,0.626814589,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2071,0.619405201,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2072,0.612107569,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2073,0.604919169,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2074,0.597837553,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2075,0.590860346,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2076,0.583006791,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2077,0.575274456,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2078,0.567660489,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2079,0.56016213,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2080,0.552776701,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2081,0.543561001,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2082,0.5344808,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2083,0.525532996,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2084,0.516714585,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2085,0.508022652,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2086,0.49730392,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2087,0.486749504,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2088,0.476355685,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2089,0.466118852,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2090,0.456035504,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2091,0.463667925,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2092,0.471249421,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2093,0.478780994,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2094,0.486263614,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2095,0.493698227,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2096,0.501089812,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2097,0.508424592,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2098,0.515703796,forestryLoss_growthFactor_SSP2
-New Hampshire,NH,2099,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2000,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2001,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2002,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2003,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2004,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2005,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2006,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2007,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2008,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2009,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2010,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2011,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2012,NA,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2013,1.025727441,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2014,1.012688911,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2015,1,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2016,0.983073509,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2017,0.966725473,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2018,0.950927807,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2019,0.935654184,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2020,0.9208799,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2021,0.905629895,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2022,0.890851039,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2023,0.876522828,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2024,0.862625901,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2025,0.849141969,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2026,0.838360951,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2027,0.827860315,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2028,0.817629685,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2029,0.807659178,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2030,0.797939376,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2031,0.78792416,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2032,0.778154442,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2033,0.768621701,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2034,0.759317796,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2035,0.750234947,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2036,0.741796586,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2037,0.73354979,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2038,0.725488351,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2039,0.71760632,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2040,0.709897997,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2041,0.701940442,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2042,0.694155521,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2043,0.686537926,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2044,0.67908256,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2045,0.671784528,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2046,0.666463168,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2047,0.661237197,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2048,0.656104122,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2049,0.651061531,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2050,0.646107098,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2051,0.640982591,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2052,0.635947194,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2053,0.630998682,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2054,0.6261349,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2055,0.621353763,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2056,0.616500599,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2057,0.611730151,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2058,0.607040394,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2059,0.602429366,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2060,0.597895168,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2061,0.593178156,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2062,0.588541988,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2063,0.58398465,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2064,0.579504192,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2065,0.57509873,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2066,0.57070919,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2067,0.566391375,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2068,0.562143578,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2069,0.557964143,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2070,0.553851467,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2071,0.550157716,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2072,0.546519708,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2073,0.542936183,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2074,0.539405921,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2075,0.535927736,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2076,0.53219538,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2077,0.528520721,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2078,0.524902401,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2079,0.521339106,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2080,0.517829559,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2081,0.51444287,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2082,0.511105207,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2083,0.507815454,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2084,0.504572527,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2085,0.501375374,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2086,0.496950772,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2087,0.49259399,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2088,0.488303494,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2089,0.484077794,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2090,0.479915444,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2091,0.467914822,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2092,0.456122331,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2093,0.444533266,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2094,0.43314306,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2095,0.421947282,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2096,0.410855499,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2097,0.399955118,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2098,0.389241858,forestryLoss_growthFactor_SSP2
-New Jersey,NJ,2099,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2000,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2001,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2002,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2003,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2004,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2005,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2006,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2007,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2008,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2009,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2010,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2011,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2012,NA,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2013,1.022749738,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2014,1.011209951,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2015,1,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2016,0.984526235,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2017,0.969598844,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2018,0.955190906,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2019,0.941277199,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2020,0.927834064,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2021,0.911389158,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2022,0.895465516,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2023,0.880040183,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2024,0.865091498,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2025,0.850599,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2026,0.838360309,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2027,0.826446646,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2028,0.814845855,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2029,0.803546361,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2030,0.79253714,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2031,0.782208862,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2032,0.772144014,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2033,0.762333279,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2034,0.752767762,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2035,0.743438963,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2036,0.732635035,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2037,0.722079925,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2038,0.711765514,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2039,0.701684026,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2040,0.691828007,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2041,0.688191622,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2042,0.684648927,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2043,0.68119684,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2044,0.677832405,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2045,0.674552786,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2046,0.66859612,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2047,0.662747224,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2048,0.657003268,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2049,0.651361515,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2050,0.645819324,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2051,0.642666372,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2052,0.639572783,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2053,0.636537016,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2054,0.633557583,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2055,0.630633045,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2056,0.625768123,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2057,0.620988109,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2058,0.616290897,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2059,0.611674452,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2060,0.607136802,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2061,0.602323787,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2062,0.597594343,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2063,0.592946374,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2064,0.588377854,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2065,0.583886821,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2066,0.58092984,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2067,0.578022993,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2068,0.575165067,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2069,0.572354889,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2070,0.56959132,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2071,0.56362451,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2072,0.557747841,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2073,0.551959276,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2074,0.546256839,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2075,0.540638615,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2076,0.528541266,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2077,0.516634053,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2078,0.504912478,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2079,0.493372187,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2080,0.482008958,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2081,0.478507195,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2082,0.47505434,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2083,0.471649286,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2084,0.468290962,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2085,0.464978329,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2086,0.459661915,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2087,0.454427282,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2088,0.449272576,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2089,0.444196001,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2090,0.439195812,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2091,0.431824478,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2092,0.424609852,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2093,0.417548338,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2094,0.410636448,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2095,0.403870794,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2096,0.397348396,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2097,0.390958748,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2098,0.384698869,forestryLoss_growthFactor_SSP2
-New Mexico,NM,2099,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2000,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2001,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2002,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2003,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2004,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2005,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2006,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2007,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2008,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2009,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2010,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2011,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2012,NA,forestryLoss_growthFactor_SSP2
-Nevada,NV,2013,1.002618842,forestryLoss_growthFactor_SSP2
-Nevada,NV,2014,1.001324748,forestryLoss_growthFactor_SSP2
-Nevada,NV,2015,1,forestryLoss_growthFactor_SSP2
-Nevada,NV,2016,0.994022228,forestryLoss_growthFactor_SSP2
-Nevada,NV,2017,0.988177906,forestryLoss_growthFactor_SSP2
-Nevada,NV,2018,0.982462143,forestryLoss_growthFactor_SSP2
-Nevada,NV,2019,0.976870301,forestryLoss_growthFactor_SSP2
-Nevada,NV,2020,0.971397984,forestryLoss_growthFactor_SSP2
-Nevada,NV,2021,0.965350436,forestryLoss_growthFactor_SSP2
-Nevada,NV,2022,0.959410507,forestryLoss_growthFactor_SSP2
-Nevada,NV,2023,0.953575114,forestryLoss_growthFactor_SSP2
-Nevada,NV,2024,0.947841301,forestryLoss_growthFactor_SSP2
-Nevada,NV,2025,0.942206232,forestryLoss_growthFactor_SSP2
-Nevada,NV,2026,0.939231671,forestryLoss_growthFactor_SSP2
-Nevada,NV,2027,0.936293883,forestryLoss_growthFactor_SSP2
-Nevada,NV,2028,0.933392271,forestryLoss_growthFactor_SSP2
-Nevada,NV,2029,0.930526243,forestryLoss_growthFactor_SSP2
-Nevada,NV,2030,0.92769522,forestryLoss_growthFactor_SSP2
-Nevada,NV,2031,0.924632418,forestryLoss_growthFactor_SSP2
-Nevada,NV,2032,0.921603966,forestryLoss_growthFactor_SSP2
-Nevada,NV,2033,0.918609356,forestryLoss_growthFactor_SSP2
-Nevada,NV,2034,0.915648089,forestryLoss_growthFactor_SSP2
-Nevada,NV,2035,0.912719673,forestryLoss_growthFactor_SSP2
-Nevada,NV,2036,0.909409617,forestryLoss_growthFactor_SSP2
-Nevada,NV,2037,0.906146828,forestryLoss_growthFactor_SSP2
-Nevada,NV,2038,0.902930203,forestryLoss_growthFactor_SSP2
-Nevada,NV,2039,0.899758679,forestryLoss_growthFactor_SSP2
-Nevada,NV,2040,0.896631227,forestryLoss_growthFactor_SSP2
-Nevada,NV,2041,0.895144632,forestryLoss_growthFactor_SSP2
-Nevada,NV,2042,0.893665105,forestryLoss_growthFactor_SSP2
-Nevada,NV,2043,0.892192773,forestryLoss_growthFactor_SSP2
-Nevada,NV,2044,0.89072775,forestryLoss_growthFactor_SSP2
-Nevada,NV,2045,0.889270141,forestryLoss_growthFactor_SSP2
-Nevada,NV,2046,0.888207912,forestryLoss_growthFactor_SSP2
-Nevada,NV,2047,0.887158692,forestryLoss_growthFactor_SSP2
-Nevada,NV,2048,0.886122223,forestryLoss_growthFactor_SSP2
-Nevada,NV,2049,0.885098251,forestryLoss_growthFactor_SSP2
-Nevada,NV,2050,0.88408653,forestryLoss_growthFactor_SSP2
-Nevada,NV,2051,0.883022454,forestryLoss_growthFactor_SSP2
-Nevada,NV,2052,0.881967261,forestryLoss_growthFactor_SSP2
-Nevada,NV,2053,0.880920848,forestryLoss_growthFactor_SSP2
-Nevada,NV,2054,0.879883115,forestryLoss_growthFactor_SSP2
-Nevada,NV,2055,0.878853963,forestryLoss_growthFactor_SSP2
-Nevada,NV,2056,0.876790936,forestryLoss_growthFactor_SSP2
-Nevada,NV,2057,0.87475267,forestryLoss_growthFactor_SSP2
-Nevada,NV,2058,0.872738688,forestryLoss_growthFactor_SSP2
-Nevada,NV,2059,0.870748524,forestryLoss_growthFactor_SSP2
-Nevada,NV,2060,0.868781725,forestryLoss_growthFactor_SSP2
-Nevada,NV,2061,0.866589841,forestryLoss_growthFactor_SSP2
-Nevada,NV,2062,0.864428924,forestryLoss_growthFactor_SSP2
-Nevada,NV,2063,0.862298278,forestryLoss_growthFactor_SSP2
-Nevada,NV,2064,0.860197231,forestryLoss_growthFactor_SSP2
-Nevada,NV,2065,0.858125131,forestryLoss_growthFactor_SSP2
-Nevada,NV,2066,0.856645033,forestryLoss_growthFactor_SSP2
-Nevada,NV,2067,0.855183818,forestryLoss_growthFactor_SSP2
-Nevada,NV,2068,0.853741093,forestryLoss_growthFactor_SSP2
-Nevada,NV,2069,0.852316473,forestryLoss_growthFactor_SSP2
-Nevada,NV,2070,0.850909586,forestryLoss_growthFactor_SSP2
-Nevada,NV,2071,0.84851212,forestryLoss_growthFactor_SSP2
-Nevada,NV,2072,0.846152018,forestryLoss_growthFactor_SSP2
-Nevada,NV,2073,0.843828426,forestryLoss_growthFactor_SSP2
-Nevada,NV,2074,0.841540515,forestryLoss_growthFactor_SSP2
-Nevada,NV,2075,0.839287481,forestryLoss_growthFactor_SSP2
-Nevada,NV,2076,0.83411619,forestryLoss_growthFactor_SSP2
-Nevada,NV,2077,0.829030632,forestryLoss_growthFactor_SSP2
-Nevada,NV,2078,0.824028748,forestryLoss_growthFactor_SSP2
-Nevada,NV,2079,0.819108545,forestryLoss_growthFactor_SSP2
-Nevada,NV,2080,0.81426809,forestryLoss_growthFactor_SSP2
-Nevada,NV,2081,0.812362825,forestryLoss_growthFactor_SSP2
-Nevada,NV,2082,0.810492921,forestryLoss_growthFactor_SSP2
-Nevada,NV,2083,0.808657531,forestryLoss_growthFactor_SSP2
-Nevada,NV,2084,0.806855832,forestryLoss_growthFactor_SSP2
-Nevada,NV,2085,0.805087027,forestryLoss_growthFactor_SSP2
-Nevada,NV,2086,0.801053328,forestryLoss_growthFactor_SSP2
-Nevada,NV,2087,0.79707966,forestryLoss_growthFactor_SSP2
-Nevada,NV,2088,0.79316467,forestryLoss_growthFactor_SSP2
-Nevada,NV,2089,0.789307046,forestryLoss_growthFactor_SSP2
-Nevada,NV,2090,0.785505515,forestryLoss_growthFactor_SSP2
-Nevada,NV,2091,0.769573349,forestryLoss_growthFactor_SSP2
-Nevada,NV,2092,0.753824121,forestryLoss_growthFactor_SSP2
-Nevada,NV,2093,0.738253868,forestryLoss_growthFactor_SSP2
-Nevada,NV,2094,0.722858743,forestryLoss_growthFactor_SSP2
-Nevada,NV,2095,0.70763501,forestryLoss_growthFactor_SSP2
-Nevada,NV,2096,0.692318021,forestryLoss_growthFactor_SSP2
-Nevada,NV,2097,0.677181267,forestryLoss_growthFactor_SSP2
-Nevada,NV,2098,0.662220766,forestryLoss_growthFactor_SSP2
-Nevada,NV,2099,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2000,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2001,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2002,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2003,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2004,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2005,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2006,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2007,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2008,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2009,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2010,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2011,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2012,NA,forestryLoss_growthFactor_SSP2
-New York,NY,2013,1.022923275,forestryLoss_growthFactor_SSP2
-New York,NY,2014,1.011305902,forestryLoss_growthFactor_SSP2
-New York,NY,2015,1,forestryLoss_growthFactor_SSP2
-New York,NY,2016,0.984413577,forestryLoss_growthFactor_SSP2
-New York,NY,2017,0.969358523,forestryLoss_growthFactor_SSP2
-New York,NY,2018,0.954809068,forestryLoss_growthFactor_SSP2
-New York,NY,2019,0.940741054,forestryLoss_growthFactor_SSP2
-New York,NY,2020,0.927131813,forestryLoss_growthFactor_SSP2
-New York,NY,2021,0.911961074,forestryLoss_growthFactor_SSP2
-New York,NY,2022,0.897256388,forestryLoss_growthFactor_SSP2
-New York,NY,2023,0.882997524,forestryLoss_growthFactor_SSP2
-New York,NY,2024,0.869165382,forestryLoss_growthFactor_SSP2
-New York,NY,2025,0.855741913,forestryLoss_growthFactor_SSP2
-New York,NY,2026,0.844843677,forestryLoss_growthFactor_SSP2
-New York,NY,2027,0.834228059,forestryLoss_growthFactor_SSP2
-New York,NY,2028,0.823884616,forestryLoss_growthFactor_SSP2
-New York,NY,2029,0.813803399,forestryLoss_growthFactor_SSP2
-New York,NY,2030,0.80397493,forestryLoss_growthFactor_SSP2
-New York,NY,2031,0.793850148,forestryLoss_growthFactor_SSP2
-New York,NY,2032,0.783973805,forestryLoss_growthFactor_SSP2
-New York,NY,2033,0.774337273,forestryLoss_growthFactor_SSP2
-New York,NY,2034,0.764932308,forestryLoss_growthFactor_SSP2
-New York,NY,2035,0.755751036,forestryLoss_growthFactor_SSP2
-New York,NY,2036,0.747112841,forestryLoss_growthFactor_SSP2
-New York,NY,2037,0.738671453,forestryLoss_growthFactor_SSP2
-New York,NY,2038,0.730420482,forestryLoss_growthFactor_SSP2
-New York,NY,2039,0.722353807,forestryLoss_growthFactor_SSP2
-New York,NY,2040,0.714465562,forestryLoss_growthFactor_SSP2
-New York,NY,2041,0.707013484,forestryLoss_growthFactor_SSP2
-New York,NY,2042,0.699725243,forestryLoss_growthFactor_SSP2
-New York,NY,2043,0.692595772,forestryLoss_growthFactor_SSP2
-New York,NY,2044,0.685620205,forestryLoss_growthFactor_SSP2
-New York,NY,2045,0.678793872,forestryLoss_growthFactor_SSP2
-New York,NY,2046,0.673883903,forestryLoss_growthFactor_SSP2
-New York,NY,2047,0.669062595,forestryLoss_growthFactor_SSP2
-New York,NY,2048,0.66432762,forestryLoss_growthFactor_SSP2
-New York,NY,2049,0.65967673,forestryLoss_growthFactor_SSP2
-New York,NY,2050,0.655107754,forestryLoss_growthFactor_SSP2
-New York,NY,2051,0.650539743,forestryLoss_growthFactor_SSP2
-New York,NY,2052,0.646052787,forestryLoss_growthFactor_SSP2
-New York,NY,2053,0.64164484,forestryLoss_growthFactor_SSP2
-New York,NY,2054,0.637313924,forestryLoss_growthFactor_SSP2
-New York,NY,2055,0.633058124,forestryLoss_growthFactor_SSP2
-New York,NY,2056,0.628380672,forestryLoss_growthFactor_SSP2
-New York,NY,2057,0.623784119,forestryLoss_growthFactor_SSP2
-New York,NY,2058,0.619266469,forestryLoss_growthFactor_SSP2
-New York,NY,2059,0.614825792,forestryLoss_growthFactor_SSP2
-New York,NY,2060,0.610460215,forestryLoss_growthFactor_SSP2
-New York,NY,2061,0.605227156,forestryLoss_growthFactor_SSP2
-New York,NY,2062,0.600084433,forestryLoss_growthFactor_SSP2
-New York,NY,2063,0.595029789,forestryLoss_growthFactor_SSP2
-New York,NY,2064,0.590061038,forestryLoss_growthFactor_SSP2
-New York,NY,2065,0.585176065,forestryLoss_growthFactor_SSP2
-New York,NY,2066,0.580204661,forestryLoss_growthFactor_SSP2
-New York,NY,2067,0.575315468,forestryLoss_growthFactor_SSP2
-New York,NY,2068,0.57050652,forestryLoss_growthFactor_SSP2
-New York,NY,2069,0.565775908,forestryLoss_growthFactor_SSP2
-New York,NY,2070,0.561121787,forestryLoss_growthFactor_SSP2
-New York,NY,2071,0.556252373,forestryLoss_growthFactor_SSP2
-New York,NY,2072,0.551456214,forestryLoss_growthFactor_SSP2
-New York,NY,2073,0.546731659,forestryLoss_growthFactor_SSP2
-New York,NY,2074,0.542077105,forestryLoss_growthFactor_SSP2
-New York,NY,2075,0.537490996,forestryLoss_growthFactor_SSP2
-New York,NY,2076,0.532821879,forestryLoss_growthFactor_SSP2
-New York,NY,2077,0.528224273,forestryLoss_growthFactor_SSP2
-New York,NY,2078,0.5236965,forestryLoss_growthFactor_SSP2
-New York,NY,2079,0.519236933,forestryLoss_growthFactor_SSP2
-New York,NY,2080,0.514843998,forestryLoss_growthFactor_SSP2
-New York,NY,2081,0.510500039,forestryLoss_growthFactor_SSP2
-New York,NY,2082,0.506218296,forestryLoss_growthFactor_SSP2
-New York,NY,2083,0.501997354,forestryLoss_growthFactor_SSP2
-New York,NY,2084,0.497835841,forestryLoss_growthFactor_SSP2
-New York,NY,2085,0.493732428,forestryLoss_growthFactor_SSP2
-New York,NY,2086,0.488217214,forestryLoss_growthFactor_SSP2
-New York,NY,2087,0.482786809,forestryLoss_growthFactor_SSP2
-New York,NY,2088,0.477439292,forestryLoss_growthFactor_SSP2
-New York,NY,2089,0.472172797,forestryLoss_growthFactor_SSP2
-New York,NY,2090,0.466985518,forestryLoss_growthFactor_SSP2
-New York,NY,2091,0.456928806,forestryLoss_growthFactor_SSP2
-New York,NY,2092,0.447072087,forestryLoss_growthFactor_SSP2
-New York,NY,2093,0.437410791,forestryLoss_growthFactor_SSP2
-New York,NY,2094,0.427940486,forestryLoss_growthFactor_SSP2
-New York,NY,2095,0.41865687,forestryLoss_growthFactor_SSP2
-New York,NY,2096,0.409336954,forestryLoss_growthFactor_SSP2
-New York,NY,2097,0.400206529,forestryLoss_growthFactor_SSP2
-New York,NY,2098,0.391261338,forestryLoss_growthFactor_SSP2
-New York,NY,2099,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2000,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2001,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2002,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2003,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2004,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2005,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2006,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2007,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2008,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2009,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2010,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2011,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2012,NA,forestryLoss_growthFactor_SSP2
-Ohio,OH,2013,1.028587323,forestryLoss_growthFactor_SSP2
-Ohio,OH,2014,1.014092477,forestryLoss_growthFactor_SSP2
-Ohio,OH,2015,1,forestryLoss_growthFactor_SSP2
-Ohio,OH,2016,0.981726672,forestryLoss_growthFactor_SSP2
-Ohio,OH,2017,0.96409179,forestryLoss_growthFactor_SSP2
-Ohio,OH,2018,0.947064044,forestryLoss_growthFactor_SSP2
-Ohio,OH,2019,0.930614092,forestryLoss_growthFactor_SSP2
-Ohio,OH,2020,0.914714412,forestryLoss_growthFactor_SSP2
-Ohio,OH,2021,0.897563935,forestryLoss_growthFactor_SSP2
-Ohio,OH,2022,0.880954418,forestryLoss_growthFactor_SSP2
-Ohio,OH,2023,0.864862093,forestryLoss_growthFactor_SSP2
-Ohio,OH,2024,0.849264527,forestryLoss_growthFactor_SSP2
-Ohio,OH,2025,0.834140532,forestryLoss_growthFactor_SSP2
-Ohio,OH,2026,0.821292807,forestryLoss_growthFactor_SSP2
-Ohio,OH,2027,0.80878538,forestryLoss_growthFactor_SSP2
-Ohio,OH,2028,0.796605537,forestryLoss_growthFactor_SSP2
-Ohio,OH,2029,0.784741176,forestryLoss_growthFactor_SSP2
-Ohio,OH,2030,0.773180771,forestryLoss_growthFactor_SSP2
-Ohio,OH,2031,0.76223738,forestryLoss_growthFactor_SSP2
-Ohio,OH,2032,0.751572552,forestryLoss_growthFactor_SSP2
-Ohio,OH,2033,0.741176444,forestryLoss_growthFactor_SSP2
-Ohio,OH,2034,0.731039656,forestryLoss_growthFactor_SSP2
-Ohio,OH,2035,0.721153211,forestryLoss_growthFactor_SSP2
-Ohio,OH,2036,0.710766131,forestryLoss_growthFactor_SSP2
-Ohio,OH,2037,0.700621233,forestryLoss_growthFactor_SSP2
-Ohio,OH,2038,0.690710572,forestryLoss_growthFactor_SSP2
-Ohio,OH,2039,0.681026534,forestryLoss_growthFactor_SSP2
-Ohio,OH,2040,0.671561827,forestryLoss_growthFactor_SSP2
-Ohio,OH,2041,0.665022311,forestryLoss_growthFactor_SSP2
-Ohio,OH,2042,0.658637688,forestryLoss_growthFactor_SSP2
-Ohio,OH,2043,0.652403018,forestryLoss_growthFactor_SSP2
-Ohio,OH,2044,0.64631356,forestryLoss_growthFactor_SSP2
-Ohio,OH,2045,0.640364765,forestryLoss_growthFactor_SSP2
-Ohio,OH,2046,0.632088345,forestryLoss_growthFactor_SSP2
-Ohio,OH,2047,0.623960633,forestryLoss_growthFactor_SSP2
-Ohio,OH,2048,0.615977733,forestryLoss_growthFactor_SSP2
-Ohio,OH,2049,0.608135886,forestryLoss_growthFactor_SSP2
-Ohio,OH,2050,0.600431457,forestryLoss_growthFactor_SSP2
-Ohio,OH,2051,0.594995027,forestryLoss_growthFactor_SSP2
-Ohio,OH,2052,0.589656851,forestryLoss_growthFactor_SSP2
-Ohio,OH,2053,0.584414427,forestryLoss_growthFactor_SSP2
-Ohio,OH,2054,0.579265336,forestryLoss_growthFactor_SSP2
-Ohio,OH,2055,0.574207237,forestryLoss_growthFactor_SSP2
-Ohio,OH,2056,0.568430613,forestryLoss_growthFactor_SSP2
-Ohio,OH,2057,0.562755229,forestryLoss_growthFactor_SSP2
-Ohio,OH,2058,0.557178571,forestryLoss_growthFactor_SSP2
-Ohio,OH,2059,0.551698205,forestryLoss_growthFactor_SSP2
-Ohio,OH,2060,0.546311778,forestryLoss_growthFactor_SSP2
-Ohio,OH,2061,0.540745249,forestryLoss_growthFactor_SSP2
-Ohio,OH,2062,0.535275761,forestryLoss_growthFactor_SSP2
-Ohio,OH,2063,0.529900876,forestryLoss_growthFactor_SSP2
-Ohio,OH,2064,0.524618238,forestryLoss_growthFactor_SSP2
-Ohio,OH,2065,0.519425563,forestryLoss_growthFactor_SSP2
-Ohio,OH,2066,0.514551813,forestryLoss_growthFactor_SSP2
-Ohio,OH,2067,0.509759403,forestryLoss_growthFactor_SSP2
-Ohio,OH,2068,0.505046377,forestryLoss_growthFactor_SSP2
-Ohio,OH,2069,0.500410844,forestryLoss_growthFactor_SSP2
-Ohio,OH,2070,0.495850968,forestryLoss_growthFactor_SSP2
-Ohio,OH,2071,0.490017218,forestryLoss_growthFactor_SSP2
-Ohio,OH,2072,0.484271259,forestryLoss_growthFactor_SSP2
-Ohio,OH,2073,0.47861111,forestryLoss_growthFactor_SSP2
-Ohio,OH,2074,0.473034849,forestryLoss_growthFactor_SSP2
-Ohio,OH,2075,0.467540613,forestryLoss_growthFactor_SSP2
-Ohio,OH,2076,0.464254192,forestryLoss_growthFactor_SSP2
-Ohio,OH,2077,0.461016353,forestryLoss_growthFactor_SSP2
-Ohio,OH,2078,0.457825969,forestryLoss_growthFactor_SSP2
-Ohio,OH,2079,0.454681947,forestryLoss_growthFactor_SSP2
-Ohio,OH,2080,0.451583229,forestryLoss_growthFactor_SSP2
-Ohio,OH,2081,0.447494603,forestryLoss_growthFactor_SSP2
-Ohio,OH,2082,0.443462676,forestryLoss_growthFactor_SSP2
-Ohio,OH,2083,0.439486168,forestryLoss_growthFactor_SSP2
-Ohio,OH,2084,0.43556384,forestryLoss_growthFactor_SSP2
-Ohio,OH,2085,0.43169449,forestryLoss_growthFactor_SSP2
-Ohio,OH,2086,0.427381074,forestryLoss_growthFactor_SSP2
-Ohio,OH,2087,0.423134474,forestryLoss_growthFactor_SSP2
-Ohio,OH,2088,0.418953176,forestryLoss_growthFactor_SSP2
-Ohio,OH,2089,0.41483571,forestryLoss_growthFactor_SSP2
-Ohio,OH,2090,0.410780648,forestryLoss_growthFactor_SSP2
-Ohio,OH,2091,0.403215562,forestryLoss_growthFactor_SSP2
-Ohio,OH,2092,0.395821342,forestryLoss_growthFactor_SSP2
-Ohio,OH,2093,0.388594053,forestryLoss_growthFactor_SSP2
-Ohio,OH,2094,0.381529874,forestryLoss_growthFactor_SSP2
-Ohio,OH,2095,0.374625101,forestryLoss_growthFactor_SSP2
-Ohio,OH,2096,0.367872479,forestryLoss_growthFactor_SSP2
-Ohio,OH,2097,0.361270782,forestryLoss_growthFactor_SSP2
-Ohio,OH,2098,0.354816614,forestryLoss_growthFactor_SSP2
-Ohio,OH,2099,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2000,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2001,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2002,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2003,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2004,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2005,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2006,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2007,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2008,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2009,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2010,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2011,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2012,NA,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2013,1.0134892,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2014,1.006668664,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2015,1,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2016,0.988877141,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2017,0.978100215,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2018,0.967653191,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2019,0.957521017,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2020,0.947689551,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2021,0.937114433,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2022,0.926821437,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2023,0.916799185,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2024,0.907036911,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2025,0.897524419,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2026,0.891410538,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2027,0.885431,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2028,0.879581296,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2029,0.873857119,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2030,0.868254355,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2031,0.862506494,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2032,0.856872385,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2033,0.851348539,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2034,0.845931608,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2035,0.840618386,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2036,0.863478332,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2037,0.885846672,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2038,0.907738917,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2039,0.929169935,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2040,0.950153985,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2041,0.949106402,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2042,0.948064412,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2043,0.947028076,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2044,0.945997451,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2045,0.944972585,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2046,0.944947015,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2047,0.944917199,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2048,0.94488331,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2049,0.944845514,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2050,0.944803973,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2051,0.947622089,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2052,0.950384565,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2053,0.953092874,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2054,0.955748439,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2055,0.958352637,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2056,0.960378883,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2057,0.962362466,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2058,0.964304533,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2059,0.966206189,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2060,0.968068506,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2061,0.968487511,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2062,0.968892959,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2063,0.969285263,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2064,0.969664822,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2065,0.970032019,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2066,0.970308732,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2067,0.970575647,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2068,0.970833049,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2069,0.971081218,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2070,0.971320422,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2071,0.971173407,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2072,0.971029915,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2073,0.970889855,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2074,0.970753137,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2075,0.970619678,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2076,0.972005538,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2077,0.973374824,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2078,0.974727892,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2079,0.976065085,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2080,0.977386739,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2081,0.980033479,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2082,0.982650453,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2083,0.985238293,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2084,0.987797611,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2085,0.990329003,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2086,1.001518493,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2087,1.012535812,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2088,1.02338486,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2089,1.034069422,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2090,1.044593169,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2091,1.033288865,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2092,1.022048146,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2093,1.010869818,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2094,0.999752723,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2095,0.988695735,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2096,0.977562092,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2097,0.966491931,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2098,0.955483906,forestryLoss_growthFactor_SSP2
-Oklahoma,OK,2099,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2000,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2001,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2002,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2003,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2004,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2005,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2006,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2007,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2008,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2009,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2010,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2011,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2012,NA,forestryLoss_growthFactor_SSP2
-Oregon,OR,2013,0.974854208,forestryLoss_growthFactor_SSP2
-Oregon,OR,2014,0.987582207,forestryLoss_growthFactor_SSP2
-Oregon,OR,2015,1,forestryLoss_growthFactor_SSP2
-Oregon,OR,2016,1.007431324,forestryLoss_growthFactor_SSP2
-Oregon,OR,2017,1.014614763,forestryLoss_growthFactor_SSP2
-Oregon,OR,2018,1.021562217,forestryLoss_growthFactor_SSP2
-Oregon,OR,2019,1.028284845,forestryLoss_growthFactor_SSP2
-Oregon,OR,2020,1.034793121,forestryLoss_growthFactor_SSP2
-Oregon,OR,2021,1.025275841,forestryLoss_growthFactor_SSP2
-Oregon,OR,2022,1.016011376,forestryLoss_growthFactor_SSP2
-Oregon,OR,2023,1.006989553,forestryLoss_growthFactor_SSP2
-Oregon,OR,2024,0.99820075,forestryLoss_growthFactor_SSP2
-Oregon,OR,2025,0.989635849,forestryLoss_growthFactor_SSP2
-Oregon,OR,2026,0.986164176,forestryLoss_growthFactor_SSP2
-Oregon,OR,2027,0.982767904,forestryLoss_growthFactor_SSP2
-Oregon,OR,2028,0.979444522,forestryLoss_growthFactor_SSP2
-Oregon,OR,2029,0.976191632,forestryLoss_growthFactor_SSP2
-Oregon,OR,2030,0.973006942,forestryLoss_growthFactor_SSP2
-Oregon,OR,2031,0.965893408,forestryLoss_growthFactor_SSP2
-Oregon,OR,2032,0.958931558,forestryLoss_growthFactor_SSP2
-Oregon,OR,2033,0.95211651,forestryLoss_growthFactor_SSP2
-Oregon,OR,2034,0.945443588,forestryLoss_growthFactor_SSP2
-Oregon,OR,2035,0.938908319,forestryLoss_growthFactor_SSP2
-Oregon,OR,2036,0.933562433,forestryLoss_growthFactor_SSP2
-Oregon,OR,2037,0.928324806,forestryLoss_growthFactor_SSP2
-Oregon,OR,2038,0.923192133,forestryLoss_growthFactor_SSP2
-Oregon,OR,2039,0.918161242,forestryLoss_growthFactor_SSP2
-Oregon,OR,2040,0.913229089,forestryLoss_growthFactor_SSP2
-Oregon,OR,2041,0.923406925,forestryLoss_growthFactor_SSP2
-Oregon,OR,2042,0.933378333,forestryLoss_growthFactor_SSP2
-Oregon,OR,2043,0.943149463,forestryLoss_growthFactor_SSP2
-Oregon,OR,2044,0.952726226,forestryLoss_growthFactor_SSP2
-Oregon,OR,2045,0.962114301,forestryLoss_growthFactor_SSP2
-Oregon,OR,2046,0.975476835,forestryLoss_growthFactor_SSP2
-Oregon,OR,2047,0.988607962,forestryLoss_growthFactor_SSP2
-Oregon,OR,2048,1.001513626,forestryLoss_growthFactor_SSP2
-Oregon,OR,2049,1.014199571,forestryLoss_growthFactor_SSP2
-Oregon,OR,2050,1.026671348,forestryLoss_growthFactor_SSP2
-Oregon,OR,2051,1.02070155,forestryLoss_growthFactor_SSP2
-Oregon,OR,2052,1.014826326,forestryLoss_growthFactor_SSP2
-Oregon,OR,2053,1.009043429,forestryLoss_growthFactor_SSP2
-Oregon,OR,2054,1.003350683,forestryLoss_growthFactor_SSP2
-Oregon,OR,2055,0.997745978,forestryLoss_growthFactor_SSP2
-Oregon,OR,2056,0.976007549,forestryLoss_growthFactor_SSP2
-Oregon,OR,2057,0.954611425,forestryLoss_growthFactor_SSP2
-Oregon,OR,2058,0.933549573,forestryLoss_growthFactor_SSP2
-Oregon,OR,2059,0.912814206,forestryLoss_growthFactor_SSP2
-Oregon,OR,2060,0.892397779,forestryLoss_growthFactor_SSP2
-Oregon,OR,2061,0.893348134,forestryLoss_growthFactor_SSP2
-Oregon,OR,2062,0.894282417,forestryLoss_growthFactor_SSP2
-Oregon,OR,2063,0.895201025,forestryLoss_growthFactor_SSP2
-Oregon,OR,2064,0.896104343,forestryLoss_growthFactor_SSP2
-Oregon,OR,2065,0.896992744,forestryLoss_growthFactor_SSP2
-Oregon,OR,2066,0.890043965,forestryLoss_growthFactor_SSP2
-Oregon,OR,2067,0.883204114,forestryLoss_growthFactor_SSP2
-Oregon,OR,2068,0.876470647,forestryLoss_growthFactor_SSP2
-Oregon,OR,2069,0.869841094,forestryLoss_growthFactor_SSP2
-Oregon,OR,2070,0.863313065,forestryLoss_growthFactor_SSP2
-Oregon,OR,2071,0.858386466,forestryLoss_growthFactor_SSP2
-Oregon,OR,2072,0.853534946,forestryLoss_growthFactor_SSP2
-Oregon,OR,2073,0.848756803,forestryLoss_growthFactor_SSP2
-Oregon,OR,2074,0.844050385,forestryLoss_growthFactor_SSP2
-Oregon,OR,2075,0.839414092,forestryLoss_growthFactor_SSP2
-Oregon,OR,2076,0.834935283,forestryLoss_growthFactor_SSP2
-Oregon,OR,2077,0.830528115,forestryLoss_growthFactor_SSP2
-Oregon,OR,2078,0.826190885,forestryLoss_growthFactor_SSP2
-Oregon,OR,2079,0.821921944,forestryLoss_growthFactor_SSP2
-Oregon,OR,2080,0.817719693,forestryLoss_growthFactor_SSP2
-Oregon,OR,2081,0.813829903,forestryLoss_growthFactor_SSP2
-Oregon,OR,2082,0.810000867,forestryLoss_growthFactor_SSP2
-Oregon,OR,2083,0.806231176,forestryLoss_growthFactor_SSP2
-Oregon,OR,2084,0.802519463,forestryLoss_growthFactor_SSP2
-Oregon,OR,2085,0.798864405,forestryLoss_growthFactor_SSP2
-Oregon,OR,2086,0.795486895,forestryLoss_growthFactor_SSP2
-Oregon,OR,2087,0.792160631,forestryLoss_growthFactor_SSP2
-Oregon,OR,2088,0.788884455,forestryLoss_growthFactor_SSP2
-Oregon,OR,2089,0.785657243,forestryLoss_growthFactor_SSP2
-Oregon,OR,2090,0.782477904,forestryLoss_growthFactor_SSP2
-Oregon,OR,2091,0.802903538,forestryLoss_growthFactor_SSP2
-Oregon,OR,2092,0.823021451,forestryLoss_growthFactor_SSP2
-Oregon,OR,2093,0.842838516,forestryLoss_growthFactor_SSP2
-Oregon,OR,2094,0.8623614,forestryLoss_growthFactor_SSP2
-Oregon,OR,2095,0.881596575,forestryLoss_growthFactor_SSP2
-Oregon,OR,2096,0.900300905,forestryLoss_growthFactor_SSP2
-Oregon,OR,2097,0.918724288,forestryLoss_growthFactor_SSP2
-Oregon,OR,2098,0.936872984,forestryLoss_growthFactor_SSP2
-Oregon,OR,2099,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2000,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2001,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2002,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2003,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2004,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2005,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2006,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2007,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2008,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2009,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2010,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2011,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2012,NA,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2013,1.0243287,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2014,1.011988871,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2015,1,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2016,0.98377116,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2017,0.968114898,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2018,0.953003012,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2019,0.938409077,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2020,0.924308311,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2021,0.907234723,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2022,0.890699713,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2023,0.874679616,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2024,0.859152096,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2025,0.844096059,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2026,0.831518407,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2027,0.819273695,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2028,0.807349492,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2029,0.795733958,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2030,0.784415821,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2031,0.773107749,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2032,0.762084556,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2033,0.751336223,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2034,0.740853184,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2035,0.730626299,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2036,0.720907259,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2037,0.711414951,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2038,0.702141934,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2039,0.693081079,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2040,0.684225556,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2041,0.677092093,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2042,0.670123437,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2043,0.663314384,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2044,0.656659938,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2045,0.650155304,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2046,0.645626201,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2047,0.64118069,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2048,0.636816552,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2049,0.632531646,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2050,0.628323902,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2051,0.624814046,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2052,0.621370129,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2053,0.617990444,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2054,0.614673338,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2055,0.611417212,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2056,0.607361676,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2057,0.603378494,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2058,0.599465853,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2059,0.595622,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2060,0.591845238,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2061,0.586635199,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2062,0.581515327,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2063,0.576483366,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2064,0.571537133,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2065,0.566674514,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2066,0.5621057,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2067,0.55761273,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2068,0.553193784,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2069,0.548847102,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2070,0.544570976,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2071,0.539398775,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2072,0.534304447,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2073,0.529286234,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2074,0.524342432,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2075,0.519471387,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2076,0.514549325,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2077,0.509703071,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2078,0.504930842,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2079,0.500230913,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2080,0.49560161,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2081,0.490725642,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2082,0.485921022,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2083,0.48118612,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2084,0.476519354,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2085,0.471919193,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2086,0.465770495,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2087,0.459716111,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2088,0.453753906,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2089,0.447881808,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2090,0.442097807,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2091,0.436667853,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2092,0.431360295,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2093,0.426172312,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2094,0.421101169,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2095,0.416144213,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2096,0.411273805,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2097,0.406511218,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2098,0.401854027,forestryLoss_growthFactor_SSP2
-Pennsylvania,PA,2099,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2000,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2001,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2002,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2003,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2004,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2005,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2006,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2007,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2008,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2009,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2010,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2011,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2012,NA,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2013,1.031312971,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2014,1.015434012,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2015,1,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2016,0.980432013,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2017,0.961552992,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2018,0.943329034,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2019,0.925728372,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2020,0.908721208,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2021,0.891480317,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2022,0.874789657,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2023,0.858624926,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2024,0.842963191,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2025,0.827782794,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2026,0.814898359,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2027,0.802359688,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2028,0.790153782,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2029,0.778268268,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2030,0.766691361,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2031,0.754730978,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2032,0.743075716,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2033,0.731714784,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2034,0.720637876,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2035,0.709835149,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2036,0.699654744,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2037,0.689713618,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2038,0.68000389,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2039,0.670518013,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2040,0.661248755,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2041,0.651938589,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2042,0.64283899,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2043,0.633943367,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2044,0.625245394,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2045,0.616738995,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2046,0.610357638,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2047,0.604092294,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2048,0.59793991,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2049,0.591897533,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2050,0.585962314,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2051,0.58016964,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2052,0.574480409,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2053,0.568892002,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2054,0.563401886,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2055,0.558007611,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2056,0.552859002,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2057,0.547800153,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2058,0.542828841,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2059,0.537942912,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2060,0.533140285,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2061,0.528228958,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2062,0.523402866,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2063,0.518659872,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2064,0.513997908,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2065,0.509414976,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2066,0.504827026,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2067,0.500315,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2068,0.495877081,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2069,0.491511509,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2070,0.487216576,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2071,0.483120998,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2072,0.479086996,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2073,0.475113181,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2074,0.471198208,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2075,0.467340767,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2076,0.463760573,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2077,0.460235382,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2078,0.456763903,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2079,0.453344885,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2080,0.449977115,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2081,0.446992161,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2082,0.444050566,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2083,0.441151341,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2084,0.438293525,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2085,0.435476191,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2086,0.431288269,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2087,0.427164683,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2088,0.423103976,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2089,0.419104735,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2090,0.415165586,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2091,0.405037244,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2092,0.395087341,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2093,0.385311837,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2094,0.375706812,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2095,0.366268462,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2096,0.357024407,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2097,0.347938649,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2098,0.33900765,forestryLoss_growthFactor_SSP2
-Rhode Island,RI,2099,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2000,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2001,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2002,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2003,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2004,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2005,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2006,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2007,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2008,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2009,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2010,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2011,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2012,NA,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2013,0.98573891,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2014,0.992965535,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2015,1,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2016,1.002186616,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2017,1.004282152,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2018,1.006291397,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2019,1.008218828,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2020,1.010068635,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2021,1.002599333,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2022,0.995316502,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2023,0.98821292,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2024,0.981281746,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2025,0.974516492,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2026,0.970489932,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2027,0.966546664,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2028,0.962684007,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2029,0.958899398,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2030,0.955190385,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2031,0.946906612,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2032,0.938795137,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2033,0.930850497,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2034,0.923067461,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2035,0.91544102,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2036,0.913174438,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2037,0.910947832,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2038,0.908760082,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2039,0.906610114,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2040,0.904496894,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2041,0.897540423,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2042,0.890714455,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2043,0.884015258,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2044,0.877439239,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2045,0.870982946,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2046,0.874551578,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2047,0.87805699,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2048,0.881500825,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2049,0.88488467,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2050,0.888210059,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2051,0.875473654,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2052,0.862940161,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2053,0.850604741,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2054,0.83846271,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2055,0.826509531,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2056,0.821786742,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2057,0.817136365,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2058,0.812556727,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2059,0.808046205,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2060,0.803603228,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2061,0.803626133,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2062,0.803647195,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2063,0.803666477,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2064,0.803684041,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2065,0.803699944,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2066,0.796912637,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2067,0.790230634,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2068,0.783651483,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2069,0.77717281,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2070,0.770792316,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2071,0.764803729,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2072,0.758906603,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2073,0.753098864,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2074,0.747378496,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2075,0.741743549,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2076,0.741900898,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2077,0.742057088,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2078,0.742212139,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2079,0.742366067,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2080,0.74251889,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2081,0.736651032,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2082,0.730876832,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2083,0.725194108,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2084,0.719600743,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2085,0.714094686,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2086,0.71484255,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2087,0.715578695,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2088,0.716303386,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2089,0.717016883,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2090,0.717719436,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2091,0.722438076,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2092,0.727071791,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2093,0.731622505,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2094,0.736092086,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2095,0.74048235,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2096,0.744596106,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2097,0.748635164,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2098,0.752601195,forestryLoss_growthFactor_SSP2
-South Carolina,SC,2099,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2000,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2001,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2002,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2003,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2004,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2005,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2006,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2007,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2008,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2009,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2010,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2011,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2012,NA,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2013,1.00083969,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2014,1.000428052,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2015,1,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2016,0.9949276,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2017,0.989992016,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2018,0.985187421,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2019,0.980508333,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2020,0.975949578,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2021,0.961539556,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2022,0.947503287,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2023,0.933825949,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2024,0.920493505,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2025,0.907492659,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2026,0.903186307,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2027,0.898962182,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2028,0.894817798,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2029,0.890750777,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2030,0.886758835,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2031,0.885418338,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2032,0.884085082,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2033,0.882759246,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2034,0.881440993,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2035,0.880130469,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2036,0.872103429,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2037,0.864227155,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2038,0.856497247,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2039,0.848909479,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2040,0.84145979,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2041,0.837955165,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2042,0.834498122,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2043,0.831087589,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2044,0.827722524,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2045,0.824401924,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2046,0.82546086,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2047,0.826494532,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2048,0.827503685,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2049,0.828489035,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2050,0.829451274,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2051,0.834297085,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2052,0.839048653,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2053,0.843708458,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2054,0.848278896,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2055,0.852762285,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2056,0.853305266,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2057,0.853821284,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2058,0.854311218,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2059,0.854775915,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2060,0.855216191,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2061,0.853076054,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2062,0.850958657,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2063,0.848863599,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2064,0.846790485,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2065,0.844738933,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2066,0.848045908,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2067,0.85128958,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2068,0.854471551,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2069,0.857593373,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2070,0.86065655,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2071,0.862153724,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2072,0.863630936,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2073,0.865088613,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2074,0.866527171,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2075,0.867947012,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2076,0.870143893,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2077,0.872318856,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2078,0.874472331,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2079,0.876604735,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2080,0.878716473,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2081,0.882574,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2082,0.886400912,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2083,0.890197769,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2084,0.893965116,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2085,0.897703482,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2086,0.901032598,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2087,0.904304929,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2088,0.90752178,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2089,0.910684416,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2090,0.913794068,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2091,0.904660828,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2092,0.895341208,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2093,0.885840058,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2094,0.876162081,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2095,0.86631184,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2096,0.857032663,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2097,0.847554876,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2098,0.837883131,forestryLoss_growthFactor_SSP2
-South Dakota,SD,2099,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2000,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2001,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2002,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2003,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2004,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2005,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2006,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2007,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2008,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2009,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2010,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2011,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2012,NA,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2013,1.006574184,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2014,1.003247967,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2015,1,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2016,0.992211058,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2017,0.984669618,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2018,0.977364082,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2019,0.970283565,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2020,0.96341784,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2021,0.952245224,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2022,0.941385994,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2023,0.930827153,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2024,0.920556413,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2025,0.910562146,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2026,0.904769874,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2027,0.899115048,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2028,0.893592828,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2029,0.888198599,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2030,0.882927957,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2031,0.876815343,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2032,0.870837792,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2033,0.864990867,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2034,0.859270319,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2035,0.853672086,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2036,0.84589916,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2037,0.83828818,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2038,0.83083412,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2039,0.823532163,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2040,0.816377686,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2041,0.8136744,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2042,0.8110233,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2043,0.80842287,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2044,0.805871653,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2045,0.803368246,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2046,0.795119851,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2047,0.787013162,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2048,0.779044555,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2049,0.771210527,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2050,0.763507693,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2051,0.760782319,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2052,0.758100137,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2053,0.75546012,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2054,0.752861273,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2055,0.750302634,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2056,0.749699204,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2057,0.749104426,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2058,0.748518109,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2059,0.747940067,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2060,0.747370118,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2061,0.74238687,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2062,0.737484389,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2063,0.732660717,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2064,0.72791396,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2065,0.723242282,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2066,0.721955499,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2067,0.720687898,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2068,0.719439043,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2069,0.718208508,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2070,0.716995883,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2071,0.718078021,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2072,0.719143903,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2073,0.720193895,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2074,0.721228353,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2075,0.722247622,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2076,0.720489885,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2077,0.718761007,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2078,0.717060298,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2079,0.71538709,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2080,0.713740732,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2081,0.713030801,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2082,0.712333735,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2083,0.711649227,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2084,0.710976978,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2085,0.710316701,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2086,0.706386688,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2087,0.702515982,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2088,0.698703244,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2089,0.694947173,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2090,0.691246508,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2091,0.686319716,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2092,0.681446934,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2093,0.676627,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2094,0.671858785,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2095,0.667141192,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2096,0.662344844,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2097,0.657600031,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2098,0.652905621,forestryLoss_growthFactor_SSP2
-Tennessee,TN,2099,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2000,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2001,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2002,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2003,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2004,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2005,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2006,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2007,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2008,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2009,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2010,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2011,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2012,NA,forestryLoss_growthFactor_SSP2
-Texas,TX,2013,0.994208426,forestryLoss_growthFactor_SSP2
-Texas,TX,2014,0.997186286,forestryLoss_growthFactor_SSP2
-Texas,TX,2015,1,forestryLoss_growthFactor_SSP2
-Texas,TX,2016,0.998014074,forestryLoss_growthFactor_SSP2
-Texas,TX,2017,0.996003883,forestryLoss_growthFactor_SSP2
-Texas,TX,2018,0.993972667,forestryLoss_growthFactor_SSP2
-Texas,TX,2019,0.991923401,forestryLoss_growthFactor_SSP2
-Texas,TX,2020,0.989858817,forestryLoss_growthFactor_SSP2
-Texas,TX,2021,0.986558593,forestryLoss_growthFactor_SSP2
-Texas,TX,2022,0.983256866,forestryLoss_growthFactor_SSP2
-Texas,TX,2023,0.979955791,forestryLoss_growthFactor_SSP2
-Texas,TX,2024,0.976657345,forestryLoss_growthFactor_SSP2
-Texas,TX,2025,0.97336334,forestryLoss_growthFactor_SSP2
-Texas,TX,2026,0.973893893,forestryLoss_growthFactor_SSP2
-Texas,TX,2027,0.974356856,forestryLoss_growthFactor_SSP2
-Texas,TX,2028,0.974755739,forestryLoss_growthFactor_SSP2
-Texas,TX,2029,0.975093863,forestryLoss_growthFactor_SSP2
-Texas,TX,2030,0.975374363,forestryLoss_growthFactor_SSP2
-Texas,TX,2031,0.97518412,forestryLoss_growthFactor_SSP2
-Texas,TX,2032,0.974940718,forestryLoss_growthFactor_SSP2
-Texas,TX,2033,0.974646976,forestryLoss_growthFactor_SSP2
-Texas,TX,2034,0.974305566,forestryLoss_growthFactor_SSP2
-Texas,TX,2035,0.973919017,forestryLoss_growthFactor_SSP2
-Texas,TX,2036,0.97623393,forestryLoss_growthFactor_SSP2
-Texas,TX,2037,0.978460037,forestryLoss_growthFactor_SSP2
-Texas,TX,2038,0.980600775,forestryLoss_growthFactor_SSP2
-Texas,TX,2039,0.982659426,forestryLoss_growthFactor_SSP2
-Texas,TX,2040,0.984639125,forestryLoss_growthFactor_SSP2
-Texas,TX,2041,0.985490269,forestryLoss_growthFactor_SSP2
-Texas,TX,2042,0.986281788,forestryLoss_growthFactor_SSP2
-Texas,TX,2043,0.987016075,forestryLoss_growthFactor_SSP2
-Texas,TX,2044,0.987695422,forestryLoss_growthFactor_SSP2
-Texas,TX,2045,0.988322015,forestryLoss_growthFactor_SSP2
-Texas,TX,2046,0.988596656,forestryLoss_growthFactor_SSP2
-Texas,TX,2047,0.988855519,forestryLoss_growthFactor_SSP2
-Texas,TX,2048,0.98909916,forestryLoss_growthFactor_SSP2
-Texas,TX,2049,0.989328115,forestryLoss_growthFactor_SSP2
-Texas,TX,2050,0.989542897,forestryLoss_growthFactor_SSP2
-Texas,TX,2051,0.991251797,forestryLoss_growthFactor_SSP2
-Texas,TX,2052,0.992913329,forestryLoss_growthFactor_SSP2
-Texas,TX,2053,0.994528898,forestryLoss_growthFactor_SSP2
-Texas,TX,2054,0.996099858,forestryLoss_growthFactor_SSP2
-Texas,TX,2055,0.997627517,forestryLoss_growthFactor_SSP2
-Texas,TX,2056,0.999368208,forestryLoss_growthFactor_SSP2
-Texas,TX,2057,1.001062517,forestryLoss_growthFactor_SSP2
-Texas,TX,2058,1.002711786,forestryLoss_growthFactor_SSP2
-Texas,TX,2059,1.00431731,forestryLoss_growthFactor_SSP2
-Texas,TX,2060,1.005880342,forestryLoss_growthFactor_SSP2
-Texas,TX,2061,1.005397328,forestryLoss_growthFactor_SSP2
-Texas,TX,2062,1.004910855,forestryLoss_growthFactor_SSP2
-Texas,TX,2063,1.004421147,forestryLoss_growthFactor_SSP2
-Texas,TX,2064,1.003928419,forestryLoss_growthFactor_SSP2
-Texas,TX,2065,1.003432875,forestryLoss_growthFactor_SSP2
-Texas,TX,2066,1.00384535,forestryLoss_growthFactor_SSP2
-Texas,TX,2067,1.004242292,forestryLoss_growthFactor_SSP2
-Texas,TX,2068,1.004624162,forestryLoss_growthFactor_SSP2
-Texas,TX,2069,1.004991406,forestryLoss_growthFactor_SSP2
-Texas,TX,2070,1.005344453,forestryLoss_growthFactor_SSP2
-Texas,TX,2071,1.006790452,forestryLoss_growthFactor_SSP2
-Texas,TX,2072,1.008216311,forestryLoss_growthFactor_SSP2
-Texas,TX,2073,1.009622471,forestryLoss_growthFactor_SSP2
-Texas,TX,2074,1.011009358,forestryLoss_growthFactor_SSP2
-Texas,TX,2075,1.012377387,forestryLoss_growthFactor_SSP2
-Texas,TX,2076,1.012244514,forestryLoss_growthFactor_SSP2
-Texas,TX,2077,1.012120826,forestryLoss_growthFactor_SSP2
-Texas,TX,2078,1.012006055,forestryLoss_growthFactor_SSP2
-Texas,TX,2079,1.011899944,forestryLoss_growthFactor_SSP2
-Texas,TX,2080,1.011802242,forestryLoss_growthFactor_SSP2
-Texas,TX,2081,1.012055724,forestryLoss_growthFactor_SSP2
-Texas,TX,2082,1.012318165,forestryLoss_growthFactor_SSP2
-Texas,TX,2083,1.012589293,forestryLoss_growthFactor_SSP2
-Texas,TX,2084,1.012868842,forestryLoss_growthFactor_SSP2
-Texas,TX,2085,1.013156558,forestryLoss_growthFactor_SSP2
-Texas,TX,2086,1.011317686,forestryLoss_growthFactor_SSP2
-Texas,TX,2087,1.009504346,forestryLoss_growthFactor_SSP2
-Texas,TX,2088,1.007715968,forestryLoss_growthFactor_SSP2
-Texas,TX,2089,1.005952,forestryLoss_growthFactor_SSP2
-Texas,TX,2090,1.004211908,forestryLoss_growthFactor_SSP2
-Texas,TX,2091,0.987967285,forestryLoss_growthFactor_SSP2
-Texas,TX,2092,0.971858159,forestryLoss_growthFactor_SSP2
-Texas,TX,2093,0.955881735,forestryLoss_growthFactor_SSP2
-Texas,TX,2094,0.9400353,forestryLoss_growthFactor_SSP2
-Texas,TX,2095,0.924316223,forestryLoss_growthFactor_SSP2
-Texas,TX,2096,0.908286334,forestryLoss_growthFactor_SSP2
-Texas,TX,2097,0.892403355,forestryLoss_growthFactor_SSP2
-Texas,TX,2098,0.876664075,forestryLoss_growthFactor_SSP2
-Texas,TX,2099,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2000,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2001,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2002,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2003,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2004,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2005,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2006,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2007,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2008,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2009,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2010,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2011,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2012,NA,forestryLoss_growthFactor_SSP2
-Utah,UT,2013,0.99679714,forestryLoss_growthFactor_SSP2
-Utah,UT,2014,0.998459422,forestryLoss_growthFactor_SSP2
-Utah,UT,2015,1,forestryLoss_growthFactor_SSP2
-Utah,UT,2016,0.99678733,forestryLoss_growthFactor_SSP2
-Utah,UT,2017,0.993600108,forestryLoss_growthFactor_SSP2
-Utah,UT,2018,0.990438988,forestryLoss_growthFactor_SSP2
-Utah,UT,2019,0.987304524,forestryLoss_growthFactor_SSP2
-Utah,UT,2020,0.984197179,forestryLoss_growthFactor_SSP2
-Utah,UT,2021,0.980038277,forestryLoss_growthFactor_SSP2
-Utah,UT,2022,0.975912612,forestryLoss_growthFactor_SSP2
-Utah,UT,2023,0.971820661,forestryLoss_growthFactor_SSP2
-Utah,UT,2024,0.967762822,forestryLoss_growthFactor_SSP2
-Utah,UT,2025,0.96373942,forestryLoss_growthFactor_SSP2
-Utah,UT,2026,0.96277393,forestryLoss_growthFactor_SSP2
-Utah,UT,2027,0.961782592,forestryLoss_growthFactor_SSP2
-Utah,UT,2028,0.96076732,forestryLoss_growthFactor_SSP2
-Utah,UT,2029,0.959729912,forestryLoss_growthFactor_SSP2
-Utah,UT,2030,0.958672057,forestryLoss_growthFactor_SSP2
-Utah,UT,2031,0.957890894,forestryLoss_growthFactor_SSP2
-Utah,UT,2032,0.957076364,forestryLoss_growthFactor_SSP2
-Utah,UT,2033,0.956230512,forestryLoss_growthFactor_SSP2
-Utah,UT,2034,0.955355268,forestryLoss_growthFactor_SSP2
-Utah,UT,2035,0.954452458,forestryLoss_growthFactor_SSP2
-Utah,UT,2036,0.953227131,forestryLoss_growthFactor_SSP2
-Utah,UT,2037,0.951991061,forestryLoss_growthFactor_SSP2
-Utah,UT,2038,0.950745192,forestryLoss_growthFactor_SSP2
-Utah,UT,2039,0.949490416,forestryLoss_growthFactor_SSP2
-Utah,UT,2040,0.948227575,forestryLoss_growthFactor_SSP2
-Utah,UT,2041,0.950363351,forestryLoss_growthFactor_SSP2
-Utah,UT,2042,0.95241716,forestryLoss_growthFactor_SSP2
-Utah,UT,2043,0.954392007,forestryLoss_growthFactor_SSP2
-Utah,UT,2044,0.956290772,forestryLoss_growthFactor_SSP2
-Utah,UT,2045,0.958116209,forestryLoss_growthFactor_SSP2
-Utah,UT,2046,0.95986705,forestryLoss_growthFactor_SSP2
-Utah,UT,2047,0.961577269,forestryLoss_growthFactor_SSP2
-Utah,UT,2048,0.963248051,forestryLoss_growthFactor_SSP2
-Utah,UT,2049,0.964880539,forestryLoss_growthFactor_SSP2
-Utah,UT,2050,0.966475833,forestryLoss_growthFactor_SSP2
-Utah,UT,2051,0.968714122,forestryLoss_growthFactor_SSP2
-Utah,UT,2052,0.970897782,forestryLoss_growthFactor_SSP2
-Utah,UT,2053,0.973028373,forestryLoss_growthFactor_SSP2
-Utah,UT,2054,0.975107402,forestryLoss_growthFactor_SSP2
-Utah,UT,2055,0.977136326,forestryLoss_growthFactor_SSP2
-Utah,UT,2056,0.977246146,forestryLoss_growthFactor_SSP2
-Utah,UT,2057,0.977337614,forestryLoss_growthFactor_SSP2
-Utah,UT,2058,0.977411384,forestryLoss_growthFactor_SSP2
-Utah,UT,2059,0.977468082,forestryLoss_growthFactor_SSP2
-Utah,UT,2060,0.977508315,forestryLoss_growthFactor_SSP2
-Utah,UT,2061,0.97660232,forestryLoss_growthFactor_SSP2
-Utah,UT,2062,0.975702273,forestryLoss_growthFactor_SSP2
-Utah,UT,2063,0.974808138,forestryLoss_growthFactor_SSP2
-Utah,UT,2064,0.97391988,forestryLoss_growthFactor_SSP2
-Utah,UT,2065,0.973037461,forestryLoss_growthFactor_SSP2
-Utah,UT,2066,0.973161975,forestryLoss_growthFactor_SSP2
-Utah,UT,2067,0.973276752,forestryLoss_growthFactor_SSP2
-Utah,UT,2068,0.973382103,forestryLoss_growthFactor_SSP2
-Utah,UT,2069,0.97347833,forestryLoss_growthFactor_SSP2
-Utah,UT,2070,0.973565721,forestryLoss_growthFactor_SSP2
-Utah,UT,2071,0.972778553,forestryLoss_growthFactor_SSP2
-Utah,UT,2072,0.972005307,forestryLoss_growthFactor_SSP2
-Utah,UT,2073,0.971245649,forestryLoss_growthFactor_SSP2
-Utah,UT,2074,0.970499258,forestryLoss_growthFactor_SSP2
-Utah,UT,2075,0.96976582,forestryLoss_growthFactor_SSP2
-Utah,UT,2076,0.964584247,forestryLoss_growthFactor_SSP2
-Utah,UT,2077,0.959492727,forestryLoss_growthFactor_SSP2
-Utah,UT,2078,0.954489071,forestryLoss_growthFactor_SSP2
-Utah,UT,2079,0.949571157,forestryLoss_growthFactor_SSP2
-Utah,UT,2080,0.944736931,forestryLoss_growthFactor_SSP2
-Utah,UT,2081,0.94451319,forestryLoss_growthFactor_SSP2
-Utah,UT,2082,0.94430666,forestryLoss_growthFactor_SSP2
-Utah,UT,2083,0.944116873,forestryLoss_growthFactor_SSP2
-Utah,UT,2084,0.943943375,forestryLoss_growthFactor_SSP2
-Utah,UT,2085,0.943785726,forestryLoss_growthFactor_SSP2
-Utah,UT,2086,0.940237559,forestryLoss_growthFactor_SSP2
-Utah,UT,2087,0.936740915,forestryLoss_growthFactor_SSP2
-Utah,UT,2088,0.933294635,forestryLoss_growthFactor_SSP2
-Utah,UT,2089,0.9298976,forestryLoss_growthFactor_SSP2
-Utah,UT,2090,0.926548718,forestryLoss_growthFactor_SSP2
-Utah,UT,2091,0.909604952,forestryLoss_growthFactor_SSP2
-Utah,UT,2092,0.892808901,forestryLoss_growthFactor_SSP2
-Utah,UT,2093,0.876157494,forestryLoss_growthFactor_SSP2
-Utah,UT,2094,0.859647752,forestryLoss_growthFactor_SSP2
-Utah,UT,2095,0.84327678,forestryLoss_growthFactor_SSP2
-Utah,UT,2096,0.827127967,forestryLoss_growthFactor_SSP2
-Utah,UT,2097,0.811110372,forestryLoss_growthFactor_SSP2
-Utah,UT,2098,0.795221145,forestryLoss_growthFactor_SSP2
-Utah,UT,2099,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2000,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2001,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2002,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2003,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2004,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2005,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2006,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2007,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2008,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2009,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2010,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2011,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2012,NA,forestryLoss_growthFactor_SSP2
-Virginia,VA,2013,0.999428514,forestryLoss_growthFactor_SSP2
-Virginia,VA,2014,0.999721391,forestryLoss_growthFactor_SSP2
-Virginia,VA,2015,1,forestryLoss_growthFactor_SSP2
-Virginia,VA,2016,0.995632595,forestryLoss_growthFactor_SSP2
-Virginia,VA,2017,0.991396763,forestryLoss_growthFactor_SSP2
-Virginia,VA,2018,0.987286512,forestryLoss_growthFactor_SSP2
-Virginia,VA,2019,0.983296213,forestryLoss_growthFactor_SSP2
-Virginia,VA,2020,0.979420572,forestryLoss_growthFactor_SSP2
-Virginia,VA,2021,0.969619981,forestryLoss_growthFactor_SSP2
-Virginia,VA,2022,0.960088964,forestryLoss_growthFactor_SSP2
-Virginia,VA,2023,0.950816458,forestryLoss_growthFactor_SSP2
-Virginia,VA,2024,0.941792002,forestryLoss_growthFactor_SSP2
-Virginia,VA,2025,0.933005693,forestryLoss_growthFactor_SSP2
-Virginia,VA,2026,0.926839706,forestryLoss_growthFactor_SSP2
-Virginia,VA,2027,0.920818386,forestryLoss_growthFactor_SSP2
-Virginia,VA,2028,0.914936672,forestryLoss_growthFactor_SSP2
-Virginia,VA,2029,0.909189739,forestryLoss_growthFactor_SSP2
-Virginia,VA,2030,0.903572981,forestryLoss_growthFactor_SSP2
-Virginia,VA,2031,0.894892357,forestryLoss_growthFactor_SSP2
-Virginia,VA,2032,0.886403733,forestryLoss_growthFactor_SSP2
-Virginia,VA,2033,0.878100795,forestryLoss_growthFactor_SSP2
-Virginia,VA,2034,0.869977501,forestryLoss_growthFactor_SSP2
-Virginia,VA,2035,0.862028073,forestryLoss_growthFactor_SSP2
-Virginia,VA,2036,0.857516172,forestryLoss_growthFactor_SSP2
-Virginia,VA,2037,0.853098571,forestryLoss_growthFactor_SSP2
-Virginia,VA,2038,0.848772339,forestryLoss_growthFactor_SSP2
-Virginia,VA,2039,0.844534666,forestryLoss_growthFactor_SSP2
-Virginia,VA,2040,0.840382856,forestryLoss_growthFactor_SSP2
-Virginia,VA,2041,0.833037717,forestryLoss_growthFactor_SSP2
-Virginia,VA,2042,0.825838476,forestryLoss_growthFactor_SSP2
-Virginia,VA,2043,0.818780832,forestryLoss_growthFactor_SSP2
-Virginia,VA,2044,0.811860651,forestryLoss_growthFactor_SSP2
-Virginia,VA,2045,0.805073957,forestryLoss_growthFactor_SSP2
-Virginia,VA,2046,0.80513959,forestryLoss_growthFactor_SSP2
-Virginia,VA,2047,0.805204309,forestryLoss_growthFactor_SSP2
-Virginia,VA,2048,0.805268133,forestryLoss_growthFactor_SSP2
-Virginia,VA,2049,0.805331082,forestryLoss_growthFactor_SSP2
-Virginia,VA,2050,0.805393177,forestryLoss_growthFactor_SSP2
-Virginia,VA,2051,0.795636863,forestryLoss_growthFactor_SSP2
-Virginia,VA,2052,0.786038457,forestryLoss_growthFactor_SSP2
-Virginia,VA,2053,0.776594159,forestryLoss_growthFactor_SSP2
-Virginia,VA,2054,0.767300291,forestryLoss_growthFactor_SSP2
-Virginia,VA,2055,0.758153292,forestryLoss_growthFactor_SSP2
-Virginia,VA,2056,0.753471202,forestryLoss_growthFactor_SSP2
-Virginia,VA,2057,0.748863406,forestryLoss_growthFactor_SSP2
-Virginia,VA,2058,0.744328154,forestryLoss_growthFactor_SSP2
-Virginia,VA,2059,0.739863749,forestryLoss_growthFactor_SSP2
-Virginia,VA,2060,0.735468545,forestryLoss_growthFactor_SSP2
-Virginia,VA,2061,0.73368482,forestryLoss_growthFactor_SSP2
-Virginia,VA,2062,0.731930552,forestryLoss_growthFactor_SSP2
-Virginia,VA,2063,0.730205022,forestryLoss_growthFactor_SSP2
-Virginia,VA,2064,0.72850753,forestryLoss_growthFactor_SSP2
-Virginia,VA,2065,0.726837403,forestryLoss_growthFactor_SSP2
-Virginia,VA,2066,0.720854554,forestryLoss_growthFactor_SSP2
-Virginia,VA,2067,0.71496608,forestryLoss_growthFactor_SSP2
-Virginia,VA,2068,0.709169768,forestryLoss_growthFactor_SSP2
-Virginia,VA,2069,0.703463475,forestryLoss_growthFactor_SSP2
-Virginia,VA,2070,0.697845123,forestryLoss_growthFactor_SSP2
-Virginia,VA,2071,0.692724167,forestryLoss_growthFactor_SSP2
-Virginia,VA,2072,0.687681157,forestryLoss_growthFactor_SSP2
-Virginia,VA,2073,0.682714325,forestryLoss_growthFactor_SSP2
-Virginia,VA,2074,0.677821958,forestryLoss_growthFactor_SSP2
-Virginia,VA,2075,0.673002394,forestryLoss_growthFactor_SSP2
-Virginia,VA,2076,0.671512172,forestryLoss_growthFactor_SSP2
-Virginia,VA,2077,0.670045664,forestryLoss_growthFactor_SSP2
-Virginia,VA,2078,0.668602306,forestryLoss_growthFactor_SSP2
-Virginia,VA,2079,0.667181555,forestryLoss_growthFactor_SSP2
-Virginia,VA,2080,0.665782881,forestryLoss_growthFactor_SSP2
-Virginia,VA,2081,0.660709627,forestryLoss_growthFactor_SSP2
-Virginia,VA,2082,0.655714664,forestryLoss_growthFactor_SSP2
-Virginia,VA,2083,0.650796178,forestryLoss_growthFactor_SSP2
-Virginia,VA,2084,0.645952416,forestryLoss_growthFactor_SSP2
-Virginia,VA,2085,0.641181675,forestryLoss_growthFactor_SSP2
-Virginia,VA,2086,0.639624608,forestryLoss_growthFactor_SSP2
-Virginia,VA,2087,0.638091397,forestryLoss_growthFactor_SSP2
-Virginia,VA,2088,0.636581501,forestryLoss_growthFactor_SSP2
-Virginia,VA,2089,0.635094395,forestryLoss_growthFactor_SSP2
-Virginia,VA,2090,0.633629573,forestryLoss_growthFactor_SSP2
-Virginia,VA,2091,0.63112721,forestryLoss_growthFactor_SSP2
-Virginia,VA,2092,0.628672721,forestryLoss_growthFactor_SSP2
-Virginia,VA,2093,0.626265016,forestryLoss_growthFactor_SSP2
-Virginia,VA,2094,0.623903035,forestryLoss_growthFactor_SSP2
-Virginia,VA,2095,0.621585752,forestryLoss_growthFactor_SSP2
-Virginia,VA,2096,0.619075377,forestryLoss_growthFactor_SSP2
-Virginia,VA,2097,0.616614989,forestryLoss_growthFactor_SSP2
-Virginia,VA,2098,0.614203469,forestryLoss_growthFactor_SSP2
-Virginia,VA,2099,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2000,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2001,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2002,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2003,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2004,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2005,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2006,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2007,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2008,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2009,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2010,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2011,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2012,NA,forestryLoss_growthFactor_SSP2
-Vermont,VT,2013,1.01144434,forestryLoss_growthFactor_SSP2
-Vermont,VT,2014,1.005621275,forestryLoss_growthFactor_SSP2
-Vermont,VT,2015,1,forestryLoss_growthFactor_SSP2
-Vermont,VT,2016,0.989965855,forestryLoss_growthFactor_SSP2
-Vermont,VT,2017,0.980310519,forestryLoss_growthFactor_SSP2
-Vermont,VT,2018,0.971014797,forestryLoss_growthFactor_SSP2
-Vermont,VT,2019,0.962060719,forestryLoss_growthFactor_SSP2
-Vermont,VT,2020,0.953431448,forestryLoss_growthFactor_SSP2
-Vermont,VT,2021,0.934638238,forestryLoss_growthFactor_SSP2
-Vermont,VT,2022,0.916438012,forestryLoss_growthFactor_SSP2
-Vermont,VT,2023,0.89880471,forestryLoss_growthFactor_SSP2
-Vermont,VT,2024,0.88171374,forestryLoss_growthFactor_SSP2
-Vermont,VT,2025,0.865141871,forestryLoss_growthFactor_SSP2
-Vermont,VT,2026,0.850290805,forestryLoss_growthFactor_SSP2
-Vermont,VT,2027,0.835833744,forestryLoss_growthFactor_SSP2
-Vermont,VT,2028,0.821755958,forestryLoss_growthFactor_SSP2
-Vermont,VT,2029,0.808043424,forestryLoss_growthFactor_SSP2
-Vermont,VT,2030,0.794682785,forestryLoss_growthFactor_SSP2
-Vermont,VT,2031,0.782065307,forestryLoss_growthFactor_SSP2
-Vermont,VT,2032,0.769771439,forestryLoss_growthFactor_SSP2
-Vermont,VT,2033,0.757789708,forestryLoss_growthFactor_SSP2
-Vermont,VT,2034,0.746109159,forestryLoss_growthFactor_SSP2
-Vermont,VT,2035,0.734719325,forestryLoss_growthFactor_SSP2
-Vermont,VT,2036,0.72412755,forestryLoss_growthFactor_SSP2
-Vermont,VT,2037,0.71378683,forestryLoss_growthFactor_SSP2
-Vermont,VT,2038,0.703688865,forestryLoss_growthFactor_SSP2
-Vermont,VT,2039,0.693825704,forestryLoss_growthFactor_SSP2
-Vermont,VT,2040,0.684189735,forestryLoss_growthFactor_SSP2
-Vermont,VT,2041,0.681560808,forestryLoss_growthFactor_SSP2
-Vermont,VT,2042,0.679013584,forestryLoss_growthFactor_SSP2
-Vermont,VT,2043,0.676545213,forestryLoss_growthFactor_SSP2
-Vermont,VT,2044,0.674152967,forestryLoss_growthFactor_SSP2
-Vermont,VT,2045,0.67183423,forestryLoss_growthFactor_SSP2
-Vermont,VT,2046,0.671190118,forestryLoss_growthFactor_SSP2
-Vermont,VT,2047,0.670564182,forestryLoss_growthFactor_SSP2
-Vermont,VT,2048,0.669955857,forestryLoss_growthFactor_SSP2
-Vermont,VT,2049,0.669364602,forestryLoss_growthFactor_SSP2
-Vermont,VT,2050,0.668789894,forestryLoss_growthFactor_SSP2
-Vermont,VT,2051,0.670915546,forestryLoss_growthFactor_SSP2
-Vermont,VT,2052,0.673018593,forestryLoss_growthFactor_SSP2
-Vermont,VT,2053,0.67509942,forestryLoss_growthFactor_SSP2
-Vermont,VT,2054,0.677158403,forestryLoss_growthFactor_SSP2
-Vermont,VT,2055,0.679195909,forestryLoss_growthFactor_SSP2
-Vermont,VT,2056,0.677927779,forestryLoss_growthFactor_SSP2
-Vermont,VT,2057,0.676690279,forestryLoss_growthFactor_SSP2
-Vermont,VT,2058,0.67548255,forestryLoss_growthFactor_SSP2
-Vermont,VT,2059,0.674303757,forestryLoss_growthFactor_SSP2
-Vermont,VT,2060,0.673153099,forestryLoss_growthFactor_SSP2
-Vermont,VT,2061,0.666948177,forestryLoss_growthFactor_SSP2
-Vermont,VT,2062,0.660851178,forestryLoss_growthFactor_SSP2
-Vermont,VT,2063,0.654859393,forestryLoss_growthFactor_SSP2
-Vermont,VT,2064,0.648970203,forestryLoss_growthFactor_SSP2
-Vermont,VT,2065,0.643181073,forestryLoss_growthFactor_SSP2
-Vermont,VT,2066,0.638951812,forestryLoss_growthFactor_SSP2
-Vermont,VT,2067,0.634794013,forestryLoss_growthFactor_SSP2
-Vermont,VT,2068,0.630705948,forestryLoss_growthFactor_SSP2
-Vermont,VT,2069,0.626685945,forestryLoss_growthFactor_SSP2
-Vermont,VT,2070,0.622732387,forestryLoss_growthFactor_SSP2
-Vermont,VT,2071,0.615275169,forestryLoss_growthFactor_SSP2
-Vermont,VT,2072,0.607930512,forestryLoss_growthFactor_SSP2
-Vermont,VT,2073,0.600695874,forestryLoss_growthFactor_SSP2
-Vermont,VT,2074,0.593568789,forestryLoss_growthFactor_SSP2
-Vermont,VT,2075,0.586546864,forestryLoss_growthFactor_SSP2
-Vermont,VT,2076,0.578793285,forestryLoss_growthFactor_SSP2
-Vermont,VT,2077,0.571160019,forestryLoss_growthFactor_SSP2
-Vermont,VT,2078,0.563644231,forestryLoss_growthFactor_SSP2
-Vermont,VT,2079,0.556243176,forestryLoss_growthFactor_SSP2
-Vermont,VT,2080,0.548954194,forestryLoss_growthFactor_SSP2
-Vermont,VT,2081,0.539699017,forestryLoss_growthFactor_SSP2
-Vermont,VT,2082,0.530581714,forestryLoss_growthFactor_SSP2
-Vermont,VT,2083,0.521599121,forestryLoss_growthFactor_SSP2
-Vermont,VT,2084,0.512748171,forestryLoss_growthFactor_SSP2
-Vermont,VT,2085,0.504025889,forestryLoss_growthFactor_SSP2
-Vermont,VT,2086,0.492887224,forestryLoss_growthFactor_SSP2
-Vermont,VT,2087,0.481919143,forestryLoss_growthFactor_SSP2
-Vermont,VT,2088,0.471117785,forestryLoss_growthFactor_SSP2
-Vermont,VT,2089,0.460479402,forestryLoss_growthFactor_SSP2
-Vermont,VT,2090,0.450000359,forestryLoss_growthFactor_SSP2
-Vermont,VT,2091,0.460267615,forestryLoss_growthFactor_SSP2
-Vermont,VT,2092,0.470441925,forestryLoss_growthFactor_SSP2
-Vermont,VT,2093,0.480525233,forestryLoss_growthFactor_SSP2
-Vermont,VT,2094,0.490519427,forestryLoss_growthFactor_SSP2
-Vermont,VT,2095,0.500426339,forestryLoss_growthFactor_SSP2
-Vermont,VT,2096,0.510207454,forestryLoss_growthFactor_SSP2
-Vermont,VT,2097,0.519895253,forestryLoss_growthFactor_SSP2
-Vermont,VT,2098,0.52949178,forestryLoss_growthFactor_SSP2
-Vermont,VT,2099,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2000,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2001,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2002,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2003,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2004,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2005,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2006,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2007,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2008,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2009,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2010,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2011,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2012,NA,forestryLoss_growthFactor_SSP2
-Washington,WA,2013,0.986389225,forestryLoss_growthFactor_SSP2
-Washington,WA,2014,0.993294672,forestryLoss_growthFactor_SSP2
-Washington,WA,2015,1,forestryLoss_growthFactor_SSP2
-Washington,WA,2016,1.001851734,forestryLoss_growthFactor_SSP2
-Washington,WA,2017,1.003608776,forestryLoss_growthFactor_SSP2
-Washington,WA,2018,1.005276429,forestryLoss_growthFactor_SSP2
-Washington,WA,2019,1.006859639,forestryLoss_growthFactor_SSP2
-Washington,WA,2020,1.008363028,forestryLoss_growthFactor_SSP2
-Washington,WA,2021,1.000765647,forestryLoss_growthFactor_SSP2
-Washington,WA,2022,0.993342838,forestryLoss_growthFactor_SSP2
-Washington,WA,2023,0.986088218,forestryLoss_growthFactor_SSP2
-Washington,WA,2024,0.978995728,forestryLoss_growthFactor_SSP2
-Washington,WA,2025,0.972059611,forestryLoss_growthFactor_SSP2
-Washington,WA,2026,0.969046305,forestryLoss_growthFactor_SSP2
-Washington,WA,2027,0.966083168,forestryLoss_growthFactor_SSP2
-Washington,WA,2028,0.963168873,forestryLoss_growthFactor_SSP2
-Washington,WA,2029,0.960302141,forestryLoss_growthFactor_SSP2
-Washington,WA,2030,0.957481743,forestryLoss_growthFactor_SSP2
-Washington,WA,2031,0.952875664,forestryLoss_growthFactor_SSP2
-Washington,WA,2032,0.948350485,forestryLoss_growthFactor_SSP2
-Washington,WA,2033,0.943903937,forestryLoss_growthFactor_SSP2
-Washington,WA,2034,0.939533841,forestryLoss_growthFactor_SSP2
-Washington,WA,2035,0.9352381,forestryLoss_growthFactor_SSP2
-Washington,WA,2036,0.931217129,forestryLoss_growthFactor_SSP2
-Washington,WA,2037,0.927266127,forestryLoss_growthFactor_SSP2
-Washington,WA,2038,0.923383154,forestryLoss_growthFactor_SSP2
-Washington,WA,2039,0.919566347,forestryLoss_growthFactor_SSP2
-Washington,WA,2040,0.915813913,forestryLoss_growthFactor_SSP2
-Washington,WA,2041,0.920752134,forestryLoss_growthFactor_SSP2
-Washington,WA,2042,0.925576928,forestryLoss_growthFactor_SSP2
-Washington,WA,2043,0.930291868,forestryLoss_growthFactor_SSP2
-Washington,WA,2044,0.934900382,forestryLoss_growthFactor_SSP2
-Washington,WA,2045,0.939405765,forestryLoss_growthFactor_SSP2
-Washington,WA,2046,0.947115955,forestryLoss_growthFactor_SSP2
-Washington,WA,2047,0.954689178,forestryLoss_growthFactor_SSP2
-Washington,WA,2048,0.962129002,forestryLoss_growthFactor_SSP2
-Washington,WA,2049,0.96943887,forestryLoss_growthFactor_SSP2
-Washington,WA,2050,0.97662211,forestryLoss_growthFactor_SSP2
-Washington,WA,2051,0.973468697,forestryLoss_growthFactor_SSP2
-Washington,WA,2052,0.970358552,forestryLoss_growthFactor_SSP2
-Washington,WA,2053,0.967290739,forestryLoss_growthFactor_SSP2
-Washington,WA,2054,0.964264348,forestryLoss_growthFactor_SSP2
-Washington,WA,2055,0.961278499,forestryLoss_growthFactor_SSP2
-Washington,WA,2056,0.951132192,forestryLoss_growthFactor_SSP2
-Washington,WA,2057,0.94113845,forestryLoss_growthFactor_SSP2
-Washington,WA,2058,0.931293787,forestryLoss_growthFactor_SSP2
-Washington,WA,2059,0.921594825,forestryLoss_growthFactor_SSP2
-Washington,WA,2060,0.912038289,forestryLoss_growthFactor_SSP2
-Washington,WA,2061,0.912288079,forestryLoss_growthFactor_SSP2
-Washington,WA,2062,0.912529167,forestryLoss_growthFactor_SSP2
-Washington,WA,2063,0.91276182,forestryLoss_growthFactor_SSP2
-Washington,WA,2064,0.912986299,forestryLoss_growthFactor_SSP2
-Washington,WA,2065,0.913202853,forestryLoss_growthFactor_SSP2
-Washington,WA,2066,0.90919091,forestryLoss_growthFactor_SSP2
-Washington,WA,2067,0.905238561,forestryLoss_growthFactor_SSP2
-Washington,WA,2068,0.901344445,forestryLoss_growthFactor_SSP2
-Washington,WA,2069,0.897507249,forestryLoss_growthFactor_SSP2
-Washington,WA,2070,0.893725695,forestryLoss_growthFactor_SSP2
-Washington,WA,2071,0.890635347,forestryLoss_growthFactor_SSP2
-Washington,WA,2072,0.887592739,forestryLoss_growthFactor_SSP2
-Washington,WA,2073,0.88459678,forestryLoss_growthFactor_SSP2
-Washington,WA,2074,0.881646417,forestryLoss_growthFactor_SSP2
-Washington,WA,2075,0.878740625,forestryLoss_growthFactor_SSP2
-Washington,WA,2076,0.874980792,forestryLoss_growthFactor_SSP2
-Washington,WA,2077,0.871283703,forestryLoss_growthFactor_SSP2
-Washington,WA,2078,0.867647848,forestryLoss_growthFactor_SSP2
-Washington,WA,2079,0.864071765,forestryLoss_growthFactor_SSP2
-Washington,WA,2080,0.860554038,forestryLoss_growthFactor_SSP2
-Washington,WA,2081,0.856756902,forestryLoss_growthFactor_SSP2
-Washington,WA,2082,0.85302436,forestryLoss_growthFactor_SSP2
-Washington,WA,2083,0.849354888,forestryLoss_growthFactor_SSP2
-Washington,WA,2084,0.845747007,forestryLoss_growthFactor_SSP2
-Washington,WA,2085,0.842199286,forestryLoss_growthFactor_SSP2
-Washington,WA,2086,0.838606499,forestryLoss_growthFactor_SSP2
-Washington,WA,2087,0.835067158,forestryLoss_growthFactor_SSP2
-Washington,WA,2088,0.831580056,forestryLoss_growthFactor_SSP2
-Washington,WA,2089,0.828144026,forestryLoss_growthFactor_SSP2
-Washington,WA,2090,0.824757934,forestryLoss_growthFactor_SSP2
-Washington,WA,2091,0.828009088,forestryLoss_growthFactor_SSP2
-Washington,WA,2092,0.831161209,forestryLoss_growthFactor_SSP2
-Washington,WA,2093,0.834216614,forestryLoss_growthFactor_SSP2
-Washington,WA,2094,0.837177553,forestryLoss_growthFactor_SSP2
-Washington,WA,2095,0.840046207,forestryLoss_growthFactor_SSP2
-Washington,WA,2096,0.842542288,forestryLoss_growthFactor_SSP2
-Washington,WA,2097,0.844956501,forestryLoss_growthFactor_SSP2
-Washington,WA,2098,0.847290699,forestryLoss_growthFactor_SSP2
-Washington,WA,2099,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2000,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2001,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2002,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2003,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2004,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2005,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2006,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2007,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2008,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2009,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2010,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2011,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2012,NA,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2013,1.020240063,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2014,1.009978449,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2015,1,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2016,0.985707601,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2017,0.971908603,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2018,0.958578941,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2019,0.945696056,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2020,0.933238787,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2021,0.918573248,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2022,0.904361322,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2023,0.890583256,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2024,0.8772204,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2025,0.864255138,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2026,0.851968768,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2027,0.839999514,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2028,0.828335684,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2029,0.816966143,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2030,0.805880281,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2031,0.794578378,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2032,0.783554345,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2033,0.772798523,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2034,0.762301685,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2035,0.752055012,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2036,0.743910212,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2037,0.735954922,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2038,0.728182928,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2039,0.72058828,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2040,0.713165276,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2041,0.705966865,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2042,0.698931353,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2043,0.692053638,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2044,0.685328825,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2045,0.678752213,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2046,0.674673239,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2047,0.670669624,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2048,0.666739366,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2049,0.662880534,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2050,0.659091263,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2051,0.657300408,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2052,0.655546951,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2053,0.65382988,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2054,0.652148217,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2055,0.650501015,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2056,0.643859687,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2057,0.637330928,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2058,0.630911991,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2059,0.624600212,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2060,0.618393014,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2061,0.613349043,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2062,0.608392291,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2063,0.603520576,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2064,0.598731786,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2065,0.594023878,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2066,0.585966307,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2067,0.57803903,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2068,0.570238958,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2069,0.5625631,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2070,0.555008555,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2071,0.551665524,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2072,0.548372792,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2073,0.545129223,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2074,0.541933717,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2075,0.538785206,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2076,0.532827006,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2077,0.526961383,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2078,0.521186156,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2079,0.515499209,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2080,0.509898496,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2081,0.506653014,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2082,0.50345346,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2083,0.500298794,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2084,0.497188005,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2085,0.494120115,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2086,0.493329768,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2087,0.492552358,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2088,0.49178759,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2089,0.491035176,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2090,0.490294838,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2091,0.484381549,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2092,0.478598404,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2093,0.47294241,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2094,0.467410664,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2095,0.462000347,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2096,0.456747722,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2097,0.451606205,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2098,0.446573297,forestryLoss_growthFactor_SSP2
-Wisconsin,WI,2099,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2000,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2001,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2002,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2003,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2004,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2005,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2006,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2007,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2008,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2009,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2010,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2011,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2012,NA,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2013,1.009160393,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2014,1.004490924,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2015,1,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2016,0.991068544,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2017,0.982484312,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2018,0.974229507,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2019,0.966287473,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2020,0.958642607,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2021,0.939549812,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2022,0.921059025,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2023,0.903143801,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2024,0.885779179,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2025,0.868941583,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2026,0.854289706,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2027,0.840023923,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2028,0.826129847,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2029,0.812593782,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2030,0.799402682,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2031,0.787596524,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2032,0.776089781,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2033,0.764871892,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2034,0.75393277,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2035,0.74326278,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2036,0.733661794,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2037,0.724285662,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2038,0.715126992,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2039,0.706178702,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2040,0.697434007,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2041,0.697082237,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2042,0.696760035,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2043,0.696466194,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2044,0.696199558,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2045,0.695959023,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2046,0.697337141,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2047,0.698696832,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2048,0.700038495,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2049,0.701362516,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2050,0.70266927,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2051,0.706897542,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2052,0.711066626,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2053,0.715177822,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2054,0.71923239,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2055,0.723231553,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2056,0.723129237,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2057,0.723037242,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2058,0.72295521,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2059,0.722882795,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2060,0.722819664,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2061,0.716877504,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2062,0.711037821,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2063,0.705298054,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2064,0.699655724,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2065,0.694108435,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2066,0.690439809,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2067,0.68683277,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2068,0.683285835,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2069,0.679797566,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2070,0.676366571,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2071,0.668719705,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2072,0.661188469,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2073,0.65377025,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2074,0.646462511,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2075,0.639262794,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2076,0.631095748,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2077,0.623056173,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2078,0.615141062,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2079,0.607347499,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2080,0.599672661,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2081,0.589722052,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2082,0.579921417,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2083,0.570267304,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2084,0.560756368,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2085,0.551385366,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2086,0.539516643,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2087,0.527829226,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2088,0.516319013,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2089,0.504982023,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2090,0.493814394,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2091,0.50704947,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2092,0.520134341,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2093,0.533072255,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2094,0.545866367,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2095,0.558519739,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2096,0.570932971,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2097,0.583203372,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2098,0.595334095,forestryLoss_growthFactor_SSP2
-West Virginia,WV,2099,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2000,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2001,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2002,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2003,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2004,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2005,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2006,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2007,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2008,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2009,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2010,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2011,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2012,NA,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2013,1.000544276,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2014,1.000271349,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2015,1,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2016,0.995100346,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2017,0.990351579,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2018,0.985746742,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2019,0.981279305,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2020,0.976943128,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2021,0.966648189,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2022,0.956634267,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2023,0.94688988,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2024,0.937404167,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2025,0.928166846,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2026,0.921078268,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2027,0.914152875,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2028,0.907385026,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2029,0.900769337,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2030,0.894300669,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2031,0.890107651,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2032,0.886001723,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2033,0.881980126,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2034,0.87804022,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2035,0.874179472,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2036,0.865946054,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2037,0.857880321,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2038,0.849977134,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2039,0.842231567,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2040,0.834638888,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2041,0.842422721,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2042,0.850044749,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2043,0.857509851,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2044,0.864822712,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2045,0.871987835,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2046,0.870449911,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2047,0.868935484,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2048,0.867443994,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2049,0.865974898,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2050,0.864527673,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2051,0.868935074,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2052,0.873264422,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2053,0.877517683,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2054,0.881696762,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2055,0.885803501,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2056,0.885029244,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2057,0.884260043,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2058,0.883495875,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2059,0.882736716,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2060,0.881982539,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2061,0.880347143,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2062,0.878734347,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2063,0.877143652,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2064,0.875574574,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2065,0.874026643,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2066,0.875973891,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2067,0.877887304,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2068,0.879767709,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2069,0.881615907,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2070,0.883432674,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2071,0.877093785,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2072,0.870852195,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2073,0.864705694,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2074,0.858652135,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2075,0.852689435,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2076,0.831632921,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2077,0.810916063,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2078,0.790530766,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2079,0.770469192,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2080,0.750723746,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2081,0.749780585,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2082,0.748859274,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2083,0.74795927,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2084,0.747080047,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2085,0.746221095,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2086,0.74123517,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2087,0.736323686,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2088,0.731484966,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2089,0.72671738,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2090,0.722019348,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2091,0.71717476,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2092,0.712349206,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2093,0.707542378,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2094,0.702753972,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2095,0.697983696,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2096,0.693216025,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2097,0.688463456,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2098,0.68372569,forestryLoss_growthFactor_SSP2
-Wyoming,WY,2099,NA,forestryLoss_growthFactor_SSP2
+"state","postal","year","value","scalarName"
+"Alabama","AL",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2013,0.992744169441156,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2014,0.996400470263714,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2015,1,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2016,0.998896410603359,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2017,0.997854030034684,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2018,0.996869360440423,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2019,0.995939139105431,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2020,0.995060319865979,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2021,0.982151786596542,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2022,0.969631917314172,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2023,0.957484001434383,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2024,0.945692257020718,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2025,0.934241767708928,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2026,0.9293722690826,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2027,0.924633818873927,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2028,0.920021483540267,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2029,0.915530567302018,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2030,0.911156598202941,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2031,0.905225860398771,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2032,0.899442260941496,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2033,0.893800662821219,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2034,0.888296159478753,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2035,0.882924062195652,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2036,0.870253663564976,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2037,0.85785939264619,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2038,0.845732478208454,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2039,0.83386451328406,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2040,0.822247436542465,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2041,0.824062266999343,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2042,0.82585189328021,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2043,0.827616896900176,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2044,0.829357839939984,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2045,0.831075265903515,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2046,0.812569892520807,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2047,0.794386048136219,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2048,0.776515457649352,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2049,0.758950126923603,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2050,0.741682330975298,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2051,0.739232281713964,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2052,0.736826635424066,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2053,0.734464260244844,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2054,0.732144061443642,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2055,0.729864979927051,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2056,0.733263051022058,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2057,0.736612320490986,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2058,0.739913871054314,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2059,0.743168752888964,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2060,0.746377984859228,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2061,0.73708084832039,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2062,0.727938965234227,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2063,0.718948514539974,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2064,0.710105798982883,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2065,0.701407240151455,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2066,0.702122508743656,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2067,0.702828717298386,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2068,0.703526054427645,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2069,0.704214703235963,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2070,0.704894841526074,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2071,0.711250616574963,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2072,0.717509174945082,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2073,0.723672723909177,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2074,0.729743404495061,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2075,0.735723293951213,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2076,0.734791219101261,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2077,0.733872258573853,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2078,0.732966112968153,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2079,0.732072492182036,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2080,0.731191115050872,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2081,0.732452103537317,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2082,0.733690304916416,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2083,0.734906263298747,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2084,0.736100506000359,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2085,0.737273544182621,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2086,0.732524283074429,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2087,0.72784772727712,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2088,0.723242230781055,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2089,0.718706196841033,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2090,0.714238076147178,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2091,0.728246150734822,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2092,0.742069711203152,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2093,0.755712821312696,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2094,0.769179424943071,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2095,0.782473350486283,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2096,0.795432440265469,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2097,0.808219554456402,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2098,0.820838510491702,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2099,0.820838510491702,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2100,0.820838510491702,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2200,0.820838510491702,"forestryLoss_growthFactor_SSP2"
+"Alabama","AL",2300,0.820838510491702,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2013,0.988499828522147,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2014,0.994307763328538,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2015,1,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2016,1.00092301433292,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2017,1.00183494320924,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2018,1.00273586679409,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2019,1.00362587433541,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2020,1.00450506292204,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2021,0.992526622546333,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2022,0.980900871614848,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2023,0.969612811521447,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2024,0.958648272471042,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2025,0.947993857353582,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2026,0.94441492293829,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2027,0.94092981610367,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2028,0.937535049730717,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2029,0.934227303604763,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2030,0.931003414667617,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2031,0.926280090354218,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2032,0.921669364322312,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2033,0.917167381767748,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2034,0.912770459041585,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2035,0.908475074337315,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2036,0.896433845676833,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2037,0.884649259165308,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2038,0.873113255429955,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2039,0.86181810777977,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2040,0.850756405249456,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2041,0.854426229127962,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2042,0.858026548775294,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2043,0.86155936305404,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2044,0.865026594028196,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2045,0.868430090638422,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2046,0.849890468984291,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2047,0.831670909750562,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2048,0.813763203803415,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2049,0.796159420218259,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2050,0.778851894596362,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2051,0.777660315624361,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2052,0.776488855409255,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2053,0.77533701881054,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2054,0.774204326631714,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2055,0.773090314987334,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2056,0.778129277240723,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2057,0.783089514110752,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2058,0.78797286528738,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2059,0.792781113422086,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2060,0.797515986324948,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2061,0.788670945902384,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2062,0.779971362086693,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2063,0.771413681964791,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2064,0.762994467305531,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2065,0.754710389971478,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2066,0.756612582215384,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2067,0.758485119604348,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2068,0.760328693585525,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2069,0.762143974228026,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2070,0.763931611043629,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2071,0.771961081652053,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2072,0.779868298748678,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2073,0.787656033069575,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2074,0.795326972254043,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2075,0.80288372393656,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2076,0.802976905685019,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2077,0.80306868816609,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2078,0.803159104016102,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2079,0.803248184851171,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2080,0.803335961306903,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2081,0.805628471610557,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2082,0.80788540233663,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2083,0.810107577589443,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2084,0.812295796202764,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2085,0.814450832701193,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2086,0.810073492202769,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2087,0.805762630095483,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2088,0.801516743195097,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2089,0.797334373298484,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2090,0.7932141055136,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2091,0.808698713314751,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2092,0.823950722721617,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2093,0.838975325940547,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2094,0.853777561808092,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2095,0.868362321412288,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2096,0.882548671602205,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2097,0.896520421220548,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2098,0.910282353821211,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2099,0.910282353821211,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2100,0.910282353821211,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2200,0.910282353821211,"forestryLoss_growthFactor_SSP2"
+"Arkansas","AR",2300,0.910282353821211,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2013,1.00504992061355,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2014,1.00252054124297,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2015,1,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2016,0.992869659183939,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2017,0.985919139914909,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2018,0.979141141176151,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2019,0.972528774940401,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2020,0.966075536341186,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2021,0.958688339585588,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2022,0.951461480246458,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2023,0.94438935187098,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2024,0.937466622974645,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2025,0.930688219678517,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2026,0.926473624181649,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2027,0.922334348674037,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2028,0.918268249264151,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2029,0.914273267761819,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2030,0.910347427227405,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2031,0.906093204175666,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2032,0.90190933167575,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2033,0.897793939417937,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2034,0.893745227373476,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2035,0.889761462352858,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2036,0.885585900865303,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2037,0.881481681953594,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2038,0.877446855654791,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2039,0.873479546115523,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2040,0.869577947989853,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2041,0.867037358756519,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2042,0.864530892429559,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2043,0.862057786462951,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2044,0.859617303169351,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2045,0.857208728641198,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2046,0.855451514968473,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2047,0.853720690125299,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2048,0.852015631657512,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2049,0.850335737210636,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2050,0.848680423708487,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2051,0.847006158101818,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2052,0.84535279532824,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2053,0.843719915722424,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2054,0.8421071114803,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2055,0.840513986224442,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2056,0.838003886147244,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2057,0.835527742071653,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2058,0.833084831284075,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2059,0.830674452220053,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2060,0.82829592367737,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2061,0.825743569373654,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2062,0.823229327902653,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2063,0.82075231547568,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2064,0.818311676065161,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2065,0.815906580309465,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2066,0.81404112171017,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2067,0.812201589578495,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2068,0.810387413564622,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2069,0.808598040463697,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2070,0.806832933566327,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2071,0.80434149892314,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2072,0.801888701238841,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2073,0.799473658595968,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2074,0.797095515600484,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2075,0.794753442393773,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2076,0.789642606236498,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2077,0.784615605692843,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2078,0.779670433358547,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2079,0.774805145067831,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2080,0.770017857426493,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2081,0.767643722990167,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2082,0.765309880821108,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2083,0.76301538018703,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2084,0.76075929962675,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2085,0.758540745835626,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2086,0.754032281100777,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2087,0.749591649394054,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2088,0.745217319128818,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2089,0.740907804539071,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2090,0.736661663978319,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2091,0.721000020272789,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2092,0.705542436968083,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2093,0.690284425232072,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2094,0.675221628637561,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2095,0.660349818310077,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2096,0.645500179744659,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2097,0.630843993577723,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2098,0.616376968380786,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2099,0.616376968380786,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2100,0.616376968380786,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2200,0.616376968380786,"forestryLoss_growthFactor_SSP2"
+"Arizona","AZ",2300,0.616376968380786,"forestryLoss_growthFactor_SSP2"
+"California","CA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"California","CA",2013,1.00920545063451,"forestryLoss_growthFactor_SSP2"
+"California","CA",2014,1.00455552604652,"forestryLoss_growthFactor_SSP2"
+"California","CA",2015,1,"forestryLoss_growthFactor_SSP2"
+"California","CA",2016,0.990925432611391,"forestryLoss_growthFactor_SSP2"
+"California","CA",2017,0.982125562141256,"forestryLoss_growthFactor_SSP2"
+"California","CA",2018,0.973587844571456,"forestryLoss_growthFactor_SSP2"
+"California","CA",2019,0.965300496651401,"forestryLoss_growthFactor_SSP2"
+"California","CA",2020,0.957252438747778,"forestryLoss_growthFactor_SSP2"
+"California","CA",2021,0.946376588706835,"forestryLoss_growthFactor_SSP2"
+"California","CA",2022,0.935796478169736,"forestryLoss_growthFactor_SSP2"
+"California","CA",2023,0.925500049559013,"forestryLoss_growthFactor_SSP2"
+"California","CA",2024,0.915475896667343,"forestryLoss_growthFactor_SSP2"
+"California","CA",2025,0.905713221086302,"forestryLoss_growthFactor_SSP2"
+"California","CA",2026,0.898373409698093,"forestryLoss_growthFactor_SSP2"
+"California","CA",2027,0.891204168641645,"forestryLoss_growthFactor_SSP2"
+"California","CA",2028,0.884199565872123,"forestryLoss_growthFactor_SSP2"
+"California","CA",2029,0.877353942762376,"forestryLoss_growthFactor_SSP2"
+"California","CA",2030,0.870661898478803,"forestryLoss_growthFactor_SSP2"
+"California","CA",2031,0.864268565046754,"forestryLoss_growthFactor_SSP2"
+"California","CA",2032,0.85801438125563,"forestryLoss_growthFactor_SSP2"
+"California","CA",2033,0.851894813013476,"forestryLoss_growthFactor_SSP2"
+"California","CA",2034,0.845905522097108,"forestryLoss_growthFactor_SSP2"
+"California","CA",2035,0.840042355657841,"forestryLoss_growthFactor_SSP2"
+"California","CA",2036,0.833750292449731,"forestryLoss_growthFactor_SSP2"
+"California","CA",2037,0.827589596888196,"forestryLoss_growthFactor_SSP2"
+"California","CA",2038,0.821556188673481,"forestryLoss_growthFactor_SSP2"
+"California","CA",2039,0.815646154945704,"forestryLoss_growthFactor_SSP2"
+"California","CA",2040,0.80985574177797,"forestryLoss_growthFactor_SSP2"
+"California","CA",2041,0.803357233659131,"forestryLoss_growthFactor_SSP2"
+"California","CA",2042,0.796988714350475,"forestryLoss_growthFactor_SSP2"
+"California","CA",2043,0.790746337473414,"forestryLoss_growthFactor_SSP2"
+"California","CA",2044,0.78462640662392,"forestryLoss_growthFactor_SSP2"
+"California","CA",2045,0.778625368140691,"forestryLoss_growthFactor_SSP2"
+"California","CA",2046,0.774596917896506,"forestryLoss_growthFactor_SSP2"
+"California","CA",2047,0.77063860864839,"forestryLoss_growthFactor_SSP2"
+"California","CA",2048,0.766748633184114,"forestryLoss_growthFactor_SSP2"
+"California","CA",2049,0.762925245688302,"forestryLoss_growthFactor_SSP2"
+"California","CA",2050,0.759166759160657,"forestryLoss_growthFactor_SSP2"
+"California","CA",2051,0.755033644007235,"forestryLoss_growthFactor_SSP2"
+"California","CA",2052,0.750969667288864,"forestryLoss_growthFactor_SSP2"
+"California","CA",2053,0.74697313575338,"forestryLoss_growthFactor_SSP2"
+"California","CA",2054,0.743042410528158,"forestryLoss_growthFactor_SSP2"
+"California","CA",2055,0.73917590496452,"forestryLoss_growthFactor_SSP2"
+"California","CA",2056,0.735257335924113,"forestryLoss_growthFactor_SSP2"
+"California","CA",2057,0.731403712645078,"forestryLoss_growthFactor_SSP2"
+"California","CA",2058,0.727613467323223,"forestryLoss_growthFactor_SSP2"
+"California","CA",2059,0.723885081654075,"forestryLoss_growthFactor_SSP2"
+"California","CA",2060,0.720217084906542,"forestryLoss_growthFactor_SSP2"
+"California","CA",2061,0.715945182264906,"forestryLoss_growthFactor_SSP2"
+"California","CA",2062,0.711745410909984,"forestryLoss_growthFactor_SSP2"
+"California","CA",2063,0.707615986007334,"forestryLoss_growthFactor_SSP2"
+"California","CA",2064,0.703555180706942,"forestryLoss_growthFactor_SSP2"
+"California","CA",2065,0.699561323815805,"forestryLoss_growthFactor_SSP2"
+"California","CA",2066,0.694635696255337,"forestryLoss_growthFactor_SSP2"
+"California","CA",2067,0.689789592755175,"forestryLoss_growthFactor_SSP2"
+"California","CA",2068,0.685021129490548,"forestryLoss_growthFactor_SSP2"
+"California","CA",2069,0.680328481304166,"forestryLoss_growthFactor_SSP2"
+"California","CA",2070,0.675709879446424,"forestryLoss_growthFactor_SSP2"
+"California","CA",2071,0.671292683049111,"forestryLoss_growthFactor_SSP2"
+"California","CA",2072,0.666942193924748,"forestryLoss_growthFactor_SSP2"
+"California","CA",2073,0.662656905095377,"forestryLoss_growthFactor_SSP2"
+"California","CA",2074,0.658435354721081,"forestryLoss_growthFactor_SSP2"
+"California","CA",2075,0.654276124421283,"forestryLoss_growthFactor_SSP2"
+"California","CA",2076,0.650727671310705,"forestryLoss_growthFactor_SSP2"
+"California","CA",2077,0.647233474192401,"forestryLoss_growthFactor_SSP2"
+"California","CA",2078,0.643792260482728,"forestryLoss_growthFactor_SSP2"
+"California","CA",2079,0.640402797445779,"forestryLoss_growthFactor_SSP2"
+"California","CA",2080,0.63706389064172,"forestryLoss_growthFactor_SSP2"
+"California","CA",2081,0.6302302884588,"forestryLoss_growthFactor_SSP2"
+"California","CA",2082,0.62349871415643,"forestryLoss_growthFactor_SSP2"
+"California","CA",2083,0.616866824963946,"forestryLoss_growthFactor_SSP2"
+"California","CA",2084,0.610332349812519,"forestryLoss_growthFactor_SSP2"
+"California","CA",2085,0.603893086608512,"forestryLoss_growthFactor_SSP2"
+"California","CA",2086,0.600507659709719,"forestryLoss_growthFactor_SSP2"
+"California","CA",2087,0.597174421605913,"forestryLoss_growthFactor_SSP2"
+"California","CA",2088,0.593892189513474,"forestryLoss_growthFactor_SSP2"
+"California","CA",2089,0.590659816054895,"forestryLoss_growthFactor_SSP2"
+"California","CA",2090,0.587476187944168,"forestryLoss_growthFactor_SSP2"
+"California","CA",2091,0.575134836031712,"forestryLoss_growthFactor_SSP2"
+"California","CA",2092,0.563014727957263,"forestryLoss_growthFactor_SSP2"
+"California","CA",2093,0.551110848730441,"forestryLoss_growthFactor_SSP2"
+"California","CA",2094,0.539418331712388,"forestryLoss_growthFactor_SSP2"
+"California","CA",2095,0.527932453177656,"forestryLoss_growthFactor_SSP2"
+"California","CA",2096,0.516482247117485,"forestryLoss_growthFactor_SSP2"
+"California","CA",2097,0.505238247119177,"forestryLoss_growthFactor_SSP2"
+"California","CA",2098,0.494195834819115,"forestryLoss_growthFactor_SSP2"
+"California","CA",2099,0.494195834819115,"forestryLoss_growthFactor_SSP2"
+"California","CA",2100,0.494195834819115,"forestryLoss_growthFactor_SSP2"
+"California","CA",2200,0.494195834819115,"forestryLoss_growthFactor_SSP2"
+"California","CA",2300,0.494195834819115,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2013,0.996600143305735,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2014,0.998362595074595,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2015,1,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2016,0.996880520991329,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2017,0.993782610011302,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2018,0.990707123902638,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2019,0.987654807262187,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2020,0.984626303291896,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2021,0.980373998536556,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2022,0.976158511165519,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2023,0.971980149466683,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2024,0.967839150827994,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2025,0.963735688483258,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2026,0.962507124104144,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2027,0.96126074918097,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2028,0.959998157685891,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2029,0.958720843247857,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2030,0.95743020580156,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2031,0.956179080993832,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2032,0.954908585304939,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2033,0.953620234130324,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2034,0.952315455370967,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2035,0.950995594799582,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2036,0.948860238672548,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2037,0.946738320025705,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2038,0.944629944535214,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2039,0.94253520191848,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2040,0.940454167065611,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2041,0.941463951293866,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2042,0.942421317881116,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2043,0.943328294807873,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2044,0.944186821576277,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2045,0.94499875370772,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2046,0.945545624970241,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2047,0.946074755444094,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2048,0.94658671450167,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2049,0.947082050126155,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2050,0.94756128985747,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2051,0.948696622346414,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2052,0.949799069651817,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2053,0.950869617588672,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2054,0.951909217150792,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2055,0.952918785960643,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2056,0.952299704875408,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2057,0.951676765076609,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2058,0.951050238820438,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2059,0.950420386685532,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2060,0.949787458094168,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2061,0.948617462221608,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2062,0.947458662445509,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2063,0.946310883544457,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2064,0.945173954356597,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2065,0.944047707649527,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2066,0.943393492981134,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2067,0.942743573601419,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2068,0.942097913275146,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2069,0.941456475972534,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2070,0.940819225877648,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2071,0.938304461751121,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2072,0.93582913147787,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2073,0.933392331151862,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2074,0.930993184096385,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2075,0.928630839849097,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2076,0.921738064118915,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2077,0.914959273214634,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2078,0.908291731646692,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2079,0.901732790156891,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2080,0.895279882353914,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2081,0.893326083062498,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2082,0.891409387409666,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2083,0.889528901610291,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2084,0.887683759517923,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2085,0.885873121571371,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2086,0.880905812393213,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2087,0.876012877765065,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2088,0.871192639679793,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2089,0.866443470325409,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2090,0.861763790221564,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2091,0.844772406316161,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2092,0.827987931159011,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2093,0.811405848748578,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2094,0.795021776187446,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2095,0.778831458804853,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2096,0.762581561479554,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2097,0.746532226827712,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2098,0.730679014280739,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2099,0.730679014280739,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2100,0.730679014280739,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2200,0.730679014280739,"forestryLoss_growthFactor_SSP2"
+"Colorado","CO",2300,0.730679014280739,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2013,1.03118903305077,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2014,1.01537197892166,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2015,1,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2016,0.980493842676229,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2017,0.961676139671853,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2018,0.943512976053862,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2019,0.925972574819022,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2020,0.909025133035853,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2021,0.891340640684033,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2022,0.874223344244198,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2023,0.857648137030375,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2024,0.841591328069644,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2025,0.826030545208851,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2026,0.813022032293725,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2027,0.800362941080871,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2028,0.788040129055331,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2029,0.776041086774203,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2030,0.764353900760636,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2031,0.752548461859775,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2032,0.741043725176634,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2033,0.729829062262042,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2034,0.718894324493522,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2035,0.708229816730074,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2036,0.698383745755428,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2037,0.688768238485462,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2038,0.679375713823773,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2039,0.670198911100096,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2040,0.661230873533513,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2041,0.652413786993605,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2042,0.643795580723237,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2043,0.635370036577026,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2044,0.627131185433877,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2045,0.619073295027398,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2046,0.612983765880235,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2047,0.607004980161229,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2048,0.601134020095692,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2049,0.59536806820908,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2050,0.589704403082631,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2051,0.584207902078548,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2052,0.578809727943025,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2053,0.573507389697392,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2054,0.568298477813967,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2055,0.563180660955428,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2056,0.55814691111772,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2057,0.553201042083518,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2058,0.54834087591471,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2059,0.543564304408194,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2060,0.538869286361009,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2061,0.53394412614798,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2062,0.529104395902526,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2063,0.524347954740682,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2064,0.519672731762744,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2065,0.515076723235501,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2066,0.510567016931906,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2067,0.506131875052715,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2068,0.501769512909846,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2069,0.497478201653848,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2070,0.493256266118501,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2071,0.48931023195808,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2072,0.485423594826317,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2073,0.481595014637604,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2074,0.47782319142477,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2075,0.474106863847372,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2076,0.470183523372443,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2077,0.466320237274923,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2078,0.462515596490772,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2079,0.458768236081679,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2080,0.455076833516753,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2081,0.451385293080582,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2082,0.447746066962608,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2083,0.444157968683551,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2084,0.440619847976755,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2085,0.437130589411954,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2086,0.432509755814006,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2087,0.427960039824159,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2088,0.423479830064053,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2089,0.419067563389371,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2090,0.414721723098962,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2091,0.404758004976138,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2092,0.39498388782786,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2093,0.385395054357193,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2094,0.375987315034516,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2095,0.366756603413755,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2096,0.357779009649357,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2097,0.348966535262059,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2098,0.340315480178412,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2099,0.340315480178412,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2100,0.340315480178412,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2200,0.340315480178412,"forestryLoss_growthFactor_SSP2"
+"Connecticut","CT",2300,0.340315480178412,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2000,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2001,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2002,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2003,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2004,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2005,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2006,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2007,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2008,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2009,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2010,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2011,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2012,NA,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2013,0.989802518976512,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2014,0.995030894802467,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2015,1,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2016,1.00006911855965,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2017,1.00000956737711,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2018,0.999830421670422,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2019,0.999540101545139,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2020,0.999146425409673,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2021,0.999000148730165,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2022,0.998726245841163,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2023,0.998332941522244,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2024,0.997827925655626,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2025,0.997218392351351,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2026,1.00034453758737,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2027,1.00331793593142,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2028,1.00614558331951,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2029,1.00883410680256,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2030,1.01138978720674,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2031,1.0139020400722,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2032,1.01627505236088,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2033,1.01851496559558,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2034,1.02062761601425,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2035,1.0226185521576,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2036,1.02587006699524,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2037,1.02899300518316,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2038,1.03199237955872,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2039,1.03487297460416,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2040,1.03763935867323,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2041,1.04033023702007,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2042,1.04290061361671,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2043,1.04535504113035,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2044,1.04769787525089,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2045,1.0499332846677,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2046,1.05554508127511,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2047,1.06104207815958,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2048,1.06642746664395,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2049,1.07170432537754,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2050,1.07687562517084,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2051,1.08147831272085,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2052,1.0859730495472,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2053,1.09036288148284,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2054,1.09465074949845,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2055,1.09883949401407,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2056,1.10238003752582,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2057,1.10583234348989,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2058,1.10919891691769,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2059,1.11248217727958,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2060,1.11568446197357,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2061,1.11734980491463,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2062,1.11897091537655,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2063,1.12054907953176,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2064,1.1220855386945,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2065,1.12358149118312,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2066,1.12309202621198,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2067,1.12259984703732,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2068,1.12210512894061,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2069,1.12160804018098,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2070,1.12110874229326,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2071,1.1210638212793,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2072,1.12102166895032,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2073,1.12098220401801,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2074,1.12094534785117,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2075,1.1209110243736,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2076,1.12202509385176,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2077,1.12313295805086,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2078,1.12423468444928,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2079,1.12533033913875,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2080,1.12641998687008,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2081,1.12790301778346,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2082,1.12938601632998,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2083,1.13086886672536,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2084,1.13235145752017,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2085,1.13383368142831,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2086,1.131203031679,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2087,1.12860867948513,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2088,1.12604981688639,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2089,1.12352566004021,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2090,1.12103544832667,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2091,1.09769977183576,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2092,1.07456659839306,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2093,1.05163172233547,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2094,1.02889106133538,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2095,1.00634065188338,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2096,0.982798826019328,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2097,0.959507366550654,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2098,0.936460762966587,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2099,0.936460762966587,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2100,0.936460762966587,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2200,0.936460762966587,"forestryLoss_growthFactor_SSP2"
+"District of Columbia","DC",2300,0.936460762966587,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2013,1.01126167361425,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2014,1.00557365499573,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2015,1,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2016,0.989931308400918,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2017,0.980164916676348,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2018,0.970687083267445,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2019,0.961484897950921,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2020,0.952546219470251,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2021,0.94178682005634,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2022,0.93131818758697,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2023,0.92112850868239,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2024,0.911206606897988,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2025,0.901541900164524,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2026,0.894251359124886,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2027,0.887130612164563,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2028,0.880173746483604,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2029,0.873375122026464,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2030,0.866729355889069,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2031,0.859470284048912,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2032,0.852370750056998,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2033,0.845425526160463,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2034,0.838629611171425,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2035,0.831978218305567,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2036,0.825533681984319,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2037,0.819224832317218,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2038,0.813047435783929,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2039,0.806997433015351,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2040,0.801070929934063,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2041,0.795248891002156,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2042,0.789544113449309,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2043,0.783953115602534,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2044,0.778472551777794,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2045,0.773099205716795,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2046,0.769740891646856,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2047,0.766441089200628,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2048,0.763198290273676,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2049,0.760011038006373,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2050,0.756877924628813,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2051,0.753522821745739,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2052,0.750223404734873,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2053,0.74697831549609,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2054,0.743786239445576,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2055,0.74064590379305,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2056,0.737065985085035,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2057,0.733543813417184,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2058,0.730078014882473,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2059,0.726667258605591,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2060,0.723310255075808,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2061,0.719222850086914,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2062,0.71520309524198,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2063,0.711249332837012,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2064,0.707359958761744,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2065,0.703533420353699,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2066,0.699869867429744,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2067,0.696264245778879,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2068,0.692715195800978,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2069,0.689221400058412,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2070,0.685781581655167,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2071,0.682154983864888,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2072,0.678583476405871,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2073,0.675065811846336,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2074,0.671600780152732,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2075,0.668187207298375,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2076,0.664477404208891,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2077,0.660826604896018,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2078,0.657233408973742,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2079,0.653696460058574,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2080,0.650214444054327,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2081,0.646679067444018,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2082,0.643198336617984,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2083,0.639770986985539,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2084,0.636395792726126,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2085,0.633071565314428,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2086,0.627880792150376,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2087,0.622768994951174,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2088,0.61773438743819,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2089,0.612775236787537,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2090,0.607889861645427,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2091,0.595529068602854,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2092,0.583360194634866,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2093,0.571378942327624,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2094,0.559581141243973,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2095,0.547962743269387,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2096,0.536334403551057,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2097,0.52488792031831,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2098,0.513619235944116,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2099,0.513619235944116,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2100,0.513619235944116,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2200,0.513619235944116,"forestryLoss_growthFactor_SSP2"
+"Delaware","DE",2300,0.513619235944116,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2013,0.997944436483527,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2014,0.999016501874451,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2015,1,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2016,0.996264197831441,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2017,0.992588265096251,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2018,0.988970813044562,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2019,0.985410493123385,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2020,0.981905995723644,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2021,0.976116476902154,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2022,0.970428939296391,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2023,0.964840498029809,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2024,0.959348385906652,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2025,0.953949946949452,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2026,0.951361735918416,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2027,0.948801804326052,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2028,0.946269838580915,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2029,0.94376552107235,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2030,0.9412885310291,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2031,0.937151169351024,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2032,0.933073115786258,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2033,0.929053021093653,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2034,0.925089579785446,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2035,0.921181528230564,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2036,0.918854331445601,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2037,0.916554612428466,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2038,0.914281872236018,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2039,0.912035624522297,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2040,0.909815395115871,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2041,0.905718690916008,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2042,0.901682309278385,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2043,0.897704785343181,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2044,0.893784705054963,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2045,0.889920702868016,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2046,0.890118574033251,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2047,0.8903081738342,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2048,0.890489781312474,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2049,0.890663664828465,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2050,0.890830082537806,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2051,0.886445342811378,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2052,0.882123286092861,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2053,0.877862515727928,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2054,0.873661677489809,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2055,0.869519457950846,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2056,0.866870418685986,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2057,0.864255766448305,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2058,0.861674791862485,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2059,0.859126805872694,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2060,0.856611138996821,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2061,0.854957517750146,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2062,0.853326562554422,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2063,0.851717775071131,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2064,0.850130672148815,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2065,0.848564785233658,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2066,0.845097578445336,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2067,0.841681428129071,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2068,0.83831517626993,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2069,0.83499770019191,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2070,0.831727911209531,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2071,0.828680259319571,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2072,0.825679617140053,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2073,0.822724913848296,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2074,0.819815110800385,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2075,0.816949200332882,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2076,0.81494232718932,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2077,0.812969652222229,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2078,0.811030347981561,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2079,0.809123613162404,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2080,0.807248671584174,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2081,0.803901089065189,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2082,0.800609085221783,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2083,0.797371354348131,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2084,0.794186630900608,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2085,0.791053687968838,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2086,0.787889466455536,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2087,0.784772598624366,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2088,0.78170201618531,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2089,0.7786766828043,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2090,0.775695592916852,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2091,0.76284182775201,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2092,0.750152797564581,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2093,0.737624885304176,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2094,0.725254580591459,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2095,0.713038475809072,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2096,0.700479977991489,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2097,0.688095194222322,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2098,0.675880263135399,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2099,0.675880263135399,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2100,0.675880263135399,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2200,0.675880263135399,"forestryLoss_growthFactor_SSP2"
+"Florida","FL",2300,0.675880263135399,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2013,0.988798579480255,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2014,0.994475455401581,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2015,1,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2016,1.00072186963317,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2017,1.00140248247505,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2018,1.0020442130189,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2019,1.0026492756959,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2020,1.00321973754356,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2021,0.995344236179818,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2022,0.987669318088919,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2023,0.980187116835969,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2024,0.972890181603879,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2025,0.965771449736892,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2026,0.961494203918905,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2027,0.957306995081129,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2028,0.953206888747353,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2029,0.94919108026916,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2030,0.945256887591845,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2031,0.937189214733289,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2032,0.929289106650078,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2033,0.921551255657871,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2034,0.913970579565075,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2035,0.90654220970823,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2036,0.904109895846825,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2037,0.90172070491984,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2038,0.899373426157346,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2039,0.897066895616476,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2040,0.894799993881201,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2041,0.888057927904742,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2042,0.88144176794574,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2043,0.874947920991381,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2044,0.868572931510416,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2045,0.862313474887998,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2046,0.865340000931579,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2047,0.8683126323214,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2048,0.871232774048632,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2049,0.87410178307401,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2050,0.876920970354325,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2051,0.865012965335503,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2052,0.853294520858512,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2053,0.841761119580467,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2054,0.830408387042446,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2055,0.819232086053836,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2056,0.814676012051417,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2057,0.810189584996632,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2058,0.805771197992984,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2059,0.801419293597894,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2060,0.797132361925867,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2061,0.797008305209146,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2062,0.796884515920883,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2063,0.796761009180102,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2064,0.796637799266048,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2065,0.796514899658913,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2066,0.790197039229632,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2067,0.78397682376072,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2068,0.777851985710282,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2069,0.771820327512259,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2070,0.765879718892377,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2071,0.7603454591761,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2072,0.754895806811304,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2073,0.749528841201744,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2074,0.74424269938779,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2075,0.739035573901279,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2076,0.738854607552269,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2077,0.738677722968845,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2078,0.73850481493397,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2079,0.738335781613399,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2080,0.738170524422937,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2081,0.732452150136606,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2082,0.726824541577372,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2083,0.721285586176953,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2084,0.715833236216249,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2085,0.710465506357676,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2086,0.710695314600674,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2087,0.710921340537811,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2088,0.711143670715733,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2089,0.71136238908651,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2090,0.71157757710399,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2091,0.714529779180221,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2092,0.717423781312532,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2093,0.720260912132857,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2094,0.723042460943775,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2095,0.725769679160303,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2096,0.728264245259267,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2097,0.730707999849053,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2098,0.733102084232996,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2099,0.733102084232996,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2100,0.733102084232996,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2200,0.733102084232996,"forestryLoss_growthFactor_SSP2"
+"Georgia","GA",2300,0.733102084232996,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2013,1.02149541588332,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2014,1.01060741267937,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2015,1,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2016,0.985079496373023,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2017,0.970656481167978,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2018,0.956707078184926,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2019,0.943208897178829,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2020,0.930140920710452,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2021,0.916733175887121,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2022,0.903720091032486,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2023,0.891084885091623,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2024,0.878811704248217,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2025,0.86688555913565,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2026,0.857768074389866,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2027,0.84887635188636,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2028,0.840202248350469,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2029,0.831738003890563,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2030,0.82347621981614,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2031,0.815737143649135,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2032,0.808177291571377,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2033,0.800790619067326,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2034,0.793571347837585,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2035,0.786513951378566,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2036,0.779757031666093,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2037,0.773144304078541,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2038,0.766671237604864,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2039,0.760333488333272,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2040,0.754126889913428,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2041,0.750119965715001,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2042,0.746192744527322,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2043,0.742342874548873,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2044,0.738568095547004,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2045,0.734866234445652,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2046,0.730643721480918,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2047,0.726493231486177,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2048,0.722412929207823,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2049,0.718401041369161,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2050,0.71445585407271,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2051,0.712164084019267,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2052,0.709906616551239,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2053,0.707682663961206,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2054,0.705491462921432,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2055,0.703332273537649,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2056,0.700738331825246,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2057,0.698181827616872,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2058,0.695661927618217,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2059,0.693177823632028,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2060,0.690728731607676,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2061,0.688003662737897,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2062,0.685321043312822,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2063,0.682679865342183,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2064,0.680079152902758,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2065,0.677517960864914,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2066,0.675189019664221,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2067,0.672894738672367,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2068,0.670634327572058,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2069,0.668407020225577,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2070,0.66621207375107,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2071,0.663863429898417,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2072,0.661551153652553,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2073,0.659274415375566,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2074,0.657032410375041,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2075,0.654824357974922,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2076,0.654110961687754,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2077,0.653411855876734,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2078,0.65272668097034,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2079,0.652055088883002,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2080,0.651396742565231,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2081,0.650132187490281,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2082,0.648893499230251,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2083,0.647680047007458,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2084,0.646491219599543,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2085,0.645326424593727,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2086,0.642765374218176,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2087,0.640242129642558,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2088,0.637755839826147,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2089,0.635305679176907,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2090,0.632890846606755,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2091,0.621733662812782,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2092,0.610690717290552,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2093,0.599759573388654,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2094,0.588937866108617,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2095,0.578223299479841,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2096,0.56764471192833,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2097,0.557168233603709,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2098,0.546791626928522,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2099,0.546791626928522,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2100,0.546791626928522,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2200,0.546791626928522,"forestryLoss_growthFactor_SSP2"
+"Iowa","IA",2300,0.546791626928522,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2013,0.975509724106355,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2014,0.987911341940444,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2015,1,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2016,1.00710132041504,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2017,1.01395567182667,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2018,1.02057514104056,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2019,1.02697105534589,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2020,1.0331540406341,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2021,1.02511771138321,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2022,1.01728072888033,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2023,1.0096354058939,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2024,1.00217445726813,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2025,0.994890973514976,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2026,0.988527777018337,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2027,0.982301651997717,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2028,0.976208058517259,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2029,0.970242659631843,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2030,0.964401310000618,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2031,0.964415402939154,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2032,0.964415039295103,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2033,0.964400958603626,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2034,0.964373861763296,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2035,0.964334413312168,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2036,0.952839539336939,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2037,0.941576677510608,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2038,0.930538755537552,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2039,0.919718988363718,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2040,0.909110863665306,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2041,0.934913416009095,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2042,0.96019349342871,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2043,0.98496664999272,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2044,1.00924783144573,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2045,1.03305140458759,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2046,1.0319346959314,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2047,1.03083435829709,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2048,1.02975001184883,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2049,1.02868128889034,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2050,1.02762783337171,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2051,1.03992893678283,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2052,1.05202642475468,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2053,1.06392525597625,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2054,1.07563023037673,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2055,1.08714599540793,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2056,1.08703030108129,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2057,1.0869117852267,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2058,1.08679057607204,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2059,1.08666679676237,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2060,1.08654056558009,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2061,1.08476202669047,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2062,1.08300981530545,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2063,1.08128332402225,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2064,1.07958196446449,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2065,1.07790516653268,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2066,1.08517209249058,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2067,1.09232199782178,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2068,1.09935765142361,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2069,1.10628173600704,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2070,1.11309685141567,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2071,1.09950892164217,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2072,1.08612849191011,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2073,1.07295085399338,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2074,1.05997144093442,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2075,1.04718582178672,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2076,0.999000947165117,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2077,0.951588041232678,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2078,0.904928743423066,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2079,0.859005270446982,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2080,0.813800393785785,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2081,0.812364560729413,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2082,0.810955811921912,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2083,0.809573495692102,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2084,0.808216980515644,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2085,0.806885654247199,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2086,0.798660546682702,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2087,0.790559455948665,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2088,0.782579580963534,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2089,0.774718204450362,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2090,0.766972689825458,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2091,0.776222130227263,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2092,0.785288159499668,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2093,0.794174966417876,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2094,0.802886615758725,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2095,0.811427052846395,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2096,0.819770269569366,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2097,0.827939848934719,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2098,0.835939692923926,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2099,0.835939692923926,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2100,0.835939692923926,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2200,0.835939692923926,"forestryLoss_growthFactor_SSP2"
+"Idaho","ID",2300,0.835939692923926,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2013,1.03222093697049,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2014,1.0158810129584,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2015,1,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2016,0.980000421383652,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2017,0.960706449278698,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2018,0.942083329489161,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2019,0.924098498481497,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2020,0.906721415491643,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2021,0.888465603463719,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2022,0.870798758613532,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2023,0.853694743460503,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2024,0.837128896214321,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2025,0.821077929711182,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2026,0.807327650603459,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2027,0.793949104651837,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2028,0.780928266749745,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2029,0.768251788483746,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2030,0.755906958434723,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2031,0.743380100180818,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2032,0.731176922985983,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2033,0.719285911573358,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2034,0.707696072243275,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2035,0.696396904185192,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2036,0.685293115200255,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2037,0.674452921817224,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2038,0.663867603221313,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2039,0.653528808320938,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2040,0.64342853663662,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2041,0.633825032313071,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2042,0.624444071759383,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2043,0.615278619194922,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2044,0.606321922059562,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2045,0.597567497138224,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2046,0.589335727183458,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2047,0.581254023810697,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2048,0.573318428423102,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2049,0.565525118587805,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2050,0.557870402271994,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2051,0.550572489580953,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2052,0.54340755623251,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2053,0.536372203900465,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2054,0.529463145877626,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2055,0.52267720259672,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2056,0.515547182578533,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2057,0.508545223343123,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2058,0.501668108033331,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2059,0.494912723515059,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2060,0.488276056294016,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2061,0.481549036356842,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2062,0.474941544783418,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2063,0.468450553247694,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2064,0.462073132939357,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2065,0.455806450546612,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2066,0.449693060222928,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2067,0.443683105083967,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2068,0.43777408538377,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2069,0.431963579922681,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2070,0.426249243009521,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2071,0.420686495920194,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2072,0.415207035595393,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2073,0.409808986969398,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2074,0.404490531063146,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2075,0.399249902899475,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2076,0.394579651385377,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2077,0.389978536841053,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2078,0.385444954021677,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2079,0.380977347794265,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2080,0.376574211188068,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2081,0.372034635108976,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2082,0.367555418565161,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2083,0.363135214671967,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2084,0.35877271750147,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2085,0.354466660527225,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2086,0.349468302414363,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2087,0.344547794961888,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2088,0.33970337104826,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2089,0.334933316462728,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2090,0.330235967940718,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2091,0.32086138200581,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2092,0.311714551819877,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2093,0.302790208431345,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2094,0.294083239050028,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2095,0.28558868132167,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2096,0.277422776628406,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2097,0.269452784003454,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2098,0.261674288365664,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2099,0.261674288365664,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2100,0.261674288365664,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2200,0.261674288365664,"forestryLoss_growthFactor_SSP2"
+"Illinois","IL",2300,0.261674288365664,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2013,1.02329774911648,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2014,1.01149239248156,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2015,1,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2016,0.984229455270988,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2017,0.968993453773885,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2018,0.954266140985671,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2019,0.940023277687116,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2020,0.926242116720854,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2021,0.911252337755511,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2022,0.896717839513442,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2023,0.882618965280149,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2024,0.868937153042548,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2025,0.855654861050809,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2026,0.844851406851241,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2027,0.83432461381532,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2028,0.824064322183805,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2029,0.814060855316533,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2030,0.804304991579936,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2031,0.795180958311189,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2032,0.786279558780893,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2033,0.777593082287126,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2034,0.769114162593529,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2035,0.760835759123387,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2036,0.752208888655514,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2037,0.743776082935671,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2038,0.735531080003737,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2039,0.727467880072177,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2040,0.719580732062564,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2041,0.714525565352644,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2042,0.709584247493499,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2043,0.704753221232043,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2044,0.700029071732777,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2045,0.695408519619011,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2046,0.688531648044233,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2047,0.681776588311548,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2048,0.675140173531483,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2049,0.66861934492075,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2050,0.662211147244568,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2051,0.657928019911593,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2052,0.653719644420102,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2053,0.649584149729962,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2054,0.6455197255966,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2055,0.641524620145556,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2056,0.636658511007544,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2057,0.631874858570633,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2058,0.627171649396344,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2059,0.62254693401007,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2060,0.617998824403313,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2061,0.613213280089658,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2062,0.608509376588315,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2063,0.603885083806293,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2064,0.599338437762429,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2065,0.594867537930537,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2066,0.590766324782934,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2067,0.586732049932593,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2068,0.582763120123026,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2069,0.578857991822821,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2070,0.575015169308405,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2071,0.570151760336226,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2072,0.565361919895735,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2073,0.560643984906972,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2074,0.555996342116741,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2075,0.551417426245339,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2076,0.548832070552126,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2077,0.546286089512464,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2078,0.543778560708388,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2079,0.541308590594689,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2080,0.538875313374729,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2081,0.535276580760505,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2082,0.531730055575009,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2083,0.528234547053771,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2084,0.524788900821854,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2085,0.521391997510512,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2086,0.517214700667394,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2087,0.513101613759662,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2088,0.509051282203494,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2089,0.505062294954419,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2090,0.50113328289074,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2091,0.491925745821547,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2092,0.482891503954574,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2093,0.474026614498706,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2094,0.46532725133796,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2095,0.456789700754376,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2096,0.448374318291833,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2097,0.440114532019076,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2098,0.432006854816085,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2099,0.432006854816085,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2100,0.432006854816085,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2200,0.432006854816085,"forestryLoss_growthFactor_SSP2"
+"Indiana","IN",2300,0.432006854816085,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2013,1.023606069514,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2014,1.01164375119153,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2015,1,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2016,0.984084134080406,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2017,0.968709206380576,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2018,0.953849019898525,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2019,0.939479015357964,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2020,0.925576146215733,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2021,0.91036711117227,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2022,0.895620146081354,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2023,0.881315298435658,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2024,0.867433726977806,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2025,0.853957626134222,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2026,0.843977801844608,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2027,0.834254184484228,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2028,0.824777353263669,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2029,0.815538335690659,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2030,0.806528581473377,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2031,0.797396534960051,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2032,0.788486281440267,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2033,0.779790156868549,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2034,0.771300839169558,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2035,0.763011329580645,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2036,0.754412340641349,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2037,0.746005544991622,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2038,0.737784760452085,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2039,0.729744063260916,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2040,0.721877774814425,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2041,0.714152104307999,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2042,0.706591113601497,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2043,0.699189779642498,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2044,0.691943278194188,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2045,0.684846974175609,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2046,0.680097731319781,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2047,0.675432873156449,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2048,0.67085020234244,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2049,0.666347596607015,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2050,0.661923005585451,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2051,0.657850176219343,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2052,0.653846809467547,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2053,0.649911186831743,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2054,0.646041645307165,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2055,0.642236575176188,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2056,0.63787306295926,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2057,0.633581890765005,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2058,0.629361312038534,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2059,0.625209635372637,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2060,0.621125222361555,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2061,0.616537221043222,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2062,0.612026507842252,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2063,0.607591172469578,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2064,0.603229366661798,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2065,0.598939301692254,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2066,0.595129540106475,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2067,0.591381398973031,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2068,0.587693417410182,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2069,0.584064180048554,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2070,0.580492315277773,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2071,0.577322258182035,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2072,0.574200290340423,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2073,0.57112532343695,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2074,0.568096301776583,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2075,0.565112201071717,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2076,0.561847580181289,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2077,0.558634371559887,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2078,0.555471358538335,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2079,0.552357362644722,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2080,0.54929124211585,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2081,0.54643701241622,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2082,0.543625713924008,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2083,0.54085635918129,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2084,0.538127990963185,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2085,0.535439681128075,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2086,0.531407868389381,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2087,0.527437626763835,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2088,0.523527562838143,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2089,0.519676324900898,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2090,0.515882601394269,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2091,0.503398599284198,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2092,0.491115263191545,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2093,0.479028085785168,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2094,0.467132692952857,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2095,0.455424838918348,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2096,0.443960773861027,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2097,0.43267407894426,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2098,0.421560797873876,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2099,0.421560797873876,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2100,0.421560797873876,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2200,0.421560797873876,"forestryLoss_growthFactor_SSP2"
+"Kansas","KS",2300,0.421560797873876,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2013,1.01275823912858,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2014,1.00628620626264,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2015,1,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2016,0.989289425232525,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2017,0.978950464843102,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2018,0.968964951102766,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2019,0.959315857325823,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2020,0.949987210579207,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2021,0.935958520648939,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2022,0.922356692997474,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2023,0.909163281997565,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2024,0.896360869726266,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2025,0.883932996066375,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2026,0.875656711789919,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2027,0.867596028119176,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2028,0.859742957851631,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2029,0.852089895415628,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2030,0.844629594603329,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2031,0.836294341473801,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2032,0.828163052880972,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2033,0.820228654935951,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2034,0.812484389995789,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2035,0.804923799391371,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2036,0.794982606391674,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2037,0.785262211381151,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2038,0.775755533944191,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2039,0.766455789160005,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2040,0.757356472453469,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2041,0.753063700871206,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2042,0.748868479713768,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2043,0.744767749518217,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2044,0.740758573523789,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2045,0.736838131671327,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2046,0.726590239663833,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2047,0.716521977728765,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2048,0.706628701231856,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2049,0.696905923630758,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2050,0.687349309820396,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2051,0.683270949244771,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2052,0.679263569400963,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2053,0.675325396096836,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2054,0.671454712746819,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2055,0.667649858074597,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2056,0.666007381464227,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2057,0.66439571126292,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2058,0.662814058330497,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2059,0.661261659224326,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2060,0.65973777518233,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2061,0.653556474961907,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2062,0.647479117875194,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2063,0.641503137023849,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2064,0.635626048819358,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2065,0.629845449640739,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2066,0.627716790339479,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2067,0.625623332577547,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2068,0.62356423375185,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2069,0.621538677623163,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2070,0.619545873298463,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2071,0.620031559297798,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2072,0.620509544205683,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2073,0.620980005281812,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2074,0.621443114437506,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2075,0.6218990384352,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2076,0.619538577561592,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2077,0.617214540136989,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2078,0.614926069450342,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2079,0.612672335638607,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2080,0.610452534641025,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2081,0.609153244593542,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2082,0.607871843463567,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2083,0.606607928442438,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2084,0.605361108995651,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2085,0.604131006396558,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2086,0.599751553307391,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2087,0.59543908940878,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2088,0.591192098291312,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2089,0.587009108930239,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2090,0.582888694000426,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2091,0.580162440095156,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2092,0.577497191980962,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2093,0.574891545209938,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2094,0.572344136940433,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2095,0.569853644411681,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2096,0.56734828525336,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2097,0.564896108638217,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2098,0.562495918944205,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2099,0.562495918944205,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2100,0.562495918944205,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2200,0.562495918944205,"forestryLoss_growthFactor_SSP2"
+"Kentucky","KY",2300,0.562495918944205,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2013,0.995299523068413,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2014,0.997671968811452,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2015,1,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2016,0.997643105944693,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2017,0.995370955308355,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2018,0.993179339631701,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2019,0.991064316773588,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2020,0.989022190459931,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2021,0.977473024525187,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2022,0.966256647979369,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2023,0.955359062436517,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2024,0.944767038625585,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2025,0.934468064466707,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2026,0.930089157022831,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2027,0.925819060661624,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2028,0.921653842997766,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2029,0.917589756982377,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2030,0.913623230173063,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2031,0.908276898001195,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2032,0.903054213981622,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2033,0.89795101087816,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2034,0.892963304920132,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2035,0.888087285866566,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2036,0.877477443669279,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2037,0.86709345132557,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2038,0.856928221114327,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2039,0.84697495778476,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2040,0.837227143652637,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2041,0.838140044725654,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2042,0.839037882313499,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2043,0.839921054818334,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2044,0.840789946041473,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2045,0.8416449258645,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2046,0.82696777209944,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2047,0.81254401269668,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2048,0.798367148289661,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2049,0.78443089977982,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2050,0.770729199086385,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2051,0.768847770509624,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2052,0.766997267296677,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2053,0.765176939166383,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2054,0.763386059808718,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2055,0.761623925937325,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2056,0.764416490760187,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2057,0.767165310039242,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2058,0.76987140760597,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2059,0.772535775520738,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2060,0.775159375297209,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2061,0.767570676400045,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2062,0.760106902136959,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2063,0.752764999537318,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2064,0.745542014200649,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2065,0.738435086352504,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2066,0.738619292504321,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2067,0.738801290033563,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2068,0.738981123258484,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2069,0.739158835229871,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2070,0.739334467777876,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2071,0.744218925841246,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2072,0.749028909499626,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2073,0.753766107569322,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2074,0.758432158206475,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2075,0.763028650792241,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2076,0.762110224805182,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2077,0.761206247856429,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2078,0.760316378112436,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2079,0.759440284470563,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2080,0.758577646140897,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2081,0.759513734357627,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2082,0.760435216435881,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2083,0.761342431083305,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2084,0.762235706618659,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2085,0.763115361367068,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2086,0.758814460058409,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2087,0.754578850709758,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2088,0.75040705705343,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2089,0.746297646996984,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2090,0.742249230983127,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2091,0.749818223499132,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2092,0.757272836687627,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2093,0.764615625248482,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2094,0.771849068415532,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2095,0.778975572722562,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2096,0.785806363076115,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2097,0.792533418209306,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2098,0.799159050700538,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2099,0.799159050700538,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2100,0.799159050700538,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2200,0.799159050700538,"forestryLoss_growthFactor_SSP2"
+"Louisiana","LA",2300,0.799159050700538,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2013,1.0183177248897,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2014,1.00904513413522,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2015,1,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2016,0.986583859791834,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2017,0.973603286776044,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2018,0.961037646486197,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2019,0.94886758025303,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2020,0.937074908386656,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2021,0.924408890705484,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2022,0.912110781469279,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2023,0.90016504142207,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2024,0.888556986931996,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2025,0.877272732160111,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2026,0.868645832446421,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2027,0.860231582007166,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2028,0.852022329599556,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2029,0.844010783692741,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2030,0.836189991672355,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2031,0.827869971741053,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2032,0.819742816346801,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2033,0.811802017605689,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2034,0.804041354338068,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2035,0.796454876535991,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2036,0.789345309977238,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2037,0.78239034846292,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2038,0.775585086329696,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2039,0.768924821526016,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2040,0.762405045203981,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2041,0.755726833121028,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2042,0.749186983859593,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2043,0.742781332503788,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2044,0.736505877927575,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2045,0.730356774862475,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2046,0.726265913889861,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2047,0.722247042222431,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2048,0.718298294621154,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2049,0.714417869404791,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2050,0.710604025772948,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2051,0.706639310382674,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2052,0.702741003689048,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2053,0.698907478160274,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2054,0.695137158553306,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2055,0.6914285198407,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2056,0.687649923351855,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2057,0.683932624697627,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2058,0.680275160982058,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2059,0.676676115206814,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2060,0.673134114491308,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2061,0.669158989546192,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2062,0.665250000213387,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2063,0.66140552172883,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2064,0.657623981924799,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2065,0.653903859122555,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2066,0.649905715442145,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2067,0.645971697496847,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2068,0.642100290662696,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2069,0.638290027422814,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2070,0.634539485554008,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2071,0.630845835164865,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2072,0.627208108055655,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2073,0.623625039588334,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2074,0.620095403019352,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2075,0.616618008090123,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2076,0.613159051737051,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2077,0.609754765144496,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2078,0.606403853175748,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2079,0.603105061367564,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2080,0.599857174344971,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2081,0.596553517301564,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2082,0.593299762367473,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2083,0.590094760643924,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2084,0.586937398415508,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2085,0.583826595812073,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2086,0.578883436262264,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2087,0.574015815042215,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2088,0.569222022474025,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2089,0.564500400047608,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2090,0.559849338520929,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2091,0.546828160128101,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2092,0.534022389782267,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2093,0.521427176883531,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2094,0.509037814230836,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2095,0.496849732765713,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2096,0.484733169453045,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2097,0.472816636042466,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2098,0.461095662643251,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2099,0.461095662643251,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2100,0.461095662643251,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2200,0.461095662643251,"forestryLoss_growthFactor_SSP2"
+"Massachusetts","MA",2300,0.461095662643251,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2013,1.01547726375593,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2014,1.0076455794537,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2015,1,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2016,0.987937385849966,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2017,0.976260300654044,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2018,0.964950624090491,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2019,0.953991351657185,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2020,0.943366510172593,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2021,0.931177768625334,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2022,0.919336652173935,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2023,0.907828616243115,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2024,0.896639913119404,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2025,0.885757538236331,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2026,0.877513024720734,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2027,0.869468297208952,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2028,0.861616235413459,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2029,0.853950051980722,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2030,0.846463273304422,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2031,0.838589600654562,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2032,0.830894973013341,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2033,0.823373410681643,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2034,0.816019195906926,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2035,0.808826858736891,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2036,0.802143491671538,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2037,0.795603097103037,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2038,0.789201176594879,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2039,0.782933417591007,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2040,0.776795683936677,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2041,0.771013699829765,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2042,0.765349398338919,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2043,0.759799267230818,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2044,0.754359931809519,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2045,0.749028148269818,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2046,0.745711989983349,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2047,0.742453810936846,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2048,0.739252113988947,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2049,0.736105452920834,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2050,0.733012430293546,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2051,0.729897012227939,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2052,0.726833210378948,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2053,0.72381976709752,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2054,0.720855465011177,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2055,0.717939125429963,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2056,0.714677847132907,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2057,0.711468691825126,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2058,0.708310425715796,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2059,0.705201853547117,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2060,0.702141817103867,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2061,0.698326400122843,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2062,0.694573816061046,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2063,0.69088252908593,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2064,0.687251052956535,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2065,0.683677949039057,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2066,0.680141759473165,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2067,0.676661473590131,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2068,0.673235779521003,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2069,0.66986340607707,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2070,0.666543121186003,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2071,0.663243653087732,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2072,0.659994402418436,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2073,0.656794231226057,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2074,0.653642035684712,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2075,0.65053674482492,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2076,0.647219921430331,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2077,0.643956402358765,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2078,0.640744918676633,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2079,0.63758424135751,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2080,0.63447317972615,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2081,0.631309307864697,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2082,0.628195504371472,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2083,0.625130604654258,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2084,0.622113479865144,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2085,0.619143035540408,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2086,0.614541549250354,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2087,0.61000971163506,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2088,0.605545948643184,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2089,0.601148733321302,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2090,0.596816584065315,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2091,0.585395980589482,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2092,0.574133984651302,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2093,0.563027083236629,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2094,0.552071867022237,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2095,0.541265026575642,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2096,0.530422944724429,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2097,0.519732948781147,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2098,0.509191656599816,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2099,0.509191656599816,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2100,0.509191656599816,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2200,0.509191656599816,"forestryLoss_growthFactor_SSP2"
+"Maryland","MD",2300,0.509191656599816,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2013,0.980951823644405,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2014,0.990570344754656,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2015,1,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2016,1.0045724284677,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2017,1.00903255027189,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2018,1.01338483401173,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2019,1.01763349887324,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2020,1.0217825324991,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2021,1.00360338694809,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2022,0.985968324664552,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2023,0.968854020703582,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2024,0.952238444414626,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2025,0.936100771599419,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2026,0.921617944991165,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2027,0.907500757281041,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2028,0.893735881271189,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2029,0.880310620888233,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2030,0.867212874544673,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2031,0.856924997812118,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2032,0.84688819021814,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2033,0.837093755607665,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2034,0.827533386329572,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2035,0.818199142026083,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2036,0.809861794334105,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2037,0.801715101362151,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2038,0.793752862819085,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2039,0.785969139038879,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2040,0.778358237568628,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2041,0.78719831745835,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2042,0.795879346186422,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2043,0.804405766953432,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2044,0.81278185490365,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2045,0.821011725101229,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2046,0.83031151604844,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2047,0.839455144074268,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2048,0.84844655410511,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2049,0.857289558479034,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2050,0.865987842488609,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2051,0.880547777636832,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2052,0.894879454140544,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2053,0.908988263541186,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2054,0.922879427709561,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2055,0.936558005494965,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2056,0.942160376311462,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2057,0.947680304698355,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2058,0.95311964877477,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2059,0.958480210266308,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2060,0.963763736650449,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2061,0.957420368258552,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2062,0.951184381512143,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2063,0.945053116079063,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2064,0.939023998106312,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2065,0.933094536747849,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2066,0.930762112899822,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2067,0.928469077253125,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2068,0.926214478651854,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2069,0.923997395816704,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2070,0.921816936189656,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2071,0.910860626983053,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2072,0.900070540102428,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2073,0.889442913591697,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2074,0.878974098256636,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2075,0.868660553470032,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2076,0.856519024181343,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2077,0.844569302704554,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2078,0.832806845721722,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2079,0.821227252590815,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2080,0.80982625978515,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2081,0.79344592992938,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2082,0.777316981031162,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2083,0.761433604934741,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2084,0.745790171490237,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2085,0.730381221782485,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2086,0.711231142568617,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2087,0.69237262626113,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2088,0.673799077588804,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2089,0.655504098648481,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2090,0.637481481577267,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2091,0.673927344474045,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2092,0.70985589874012,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2093,0.745278627947424,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2094,0.780206676642794,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2095,0.814650862773209,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2096,0.848486611234025,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2097,0.881839523940698,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2098,0.914720344266998,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2099,0.914720344266998,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2100,0.914720344266998,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2200,0.914720344266998,"forestryLoss_growthFactor_SSP2"
+"Maine","ME",2300,0.914720344266998,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2013,1.02600262307133,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2014,1.01281559748119,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2015,1,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2016,0.982967915686207,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2017,0.966534526496203,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2018,0.950670392124578,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2019,0.935347926519988,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2020,0.920541255830902,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2021,0.904421166245651,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2022,0.888810967960156,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2023,0.873688229621177,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2024,0.859031780900168,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2025,0.844821626322646,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2026,0.831798264219769,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2027,0.819118392917364,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2028,0.806769208091464,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2029,0.794738519264358,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2030,0.783014713921072,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2031,0.771034105831929,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2032,0.759354592168965,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2033,0.747965596599837,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2034,0.736857018750545,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2035,0.726019208117269,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2036,0.71681385437856,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2037,0.707825253897055,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2038,0.699046261808702,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2039,0.690470035612572,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2040,0.682090019556226,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2041,0.673823337054615,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2042,0.665745199028111,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2043,0.657849683193028,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2044,0.650131104950702,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2045,0.642584005759857,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2046,0.637407054861579,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2047,0.63232532160397,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2048,0.627336283275465,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2049,0.622437504133546,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2050,0.617626631718903,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2051,0.614137866303889,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2052,0.610715748790983,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2053,0.607358539286547,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2054,0.604064555660259,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2055,0.600832171213918,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2056,0.594235710520984,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2057,0.587753022871039,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2058,0.581381305382012,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2059,0.575117844636252,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2060,0.568960013177901,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2061,0.563675029408405,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2062,0.558482172744731,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2063,0.55337912919422,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2064,0.548363660490872,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2065,0.543433601044702,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2066,0.536178753318735,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2067,0.52904241953637,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2068,0.522021777775868,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2069,0.515114094201836,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2070,0.508316719668645,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2071,0.504225237537315,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2072,0.500195119038423,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2073,0.496224981720327,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2074,0.492313484494349,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2075,0.488459326097139,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2076,0.482609758311238,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2077,0.476849718262402,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2078,0.471177105430552,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2079,0.465589885073965,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2080,0.460086085667792,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2081,0.456296389767805,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2082,0.45255861279559,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2083,0.448871587158463,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2084,0.445234180831737,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2085,0.44164529600756,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2086,0.439485566297115,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2087,0.437359922880385,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2088,0.435267590508725,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2089,0.433207817152924,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2090,0.431179873141003,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2091,0.424021081180572,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2092,0.417024966489606,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2093,0.410187780439924,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2094,0.403505885464839,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2095,0.396975750987378,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2096,0.390589799235203,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2097,0.384347122556843,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2098,0.378244496262522,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2099,0.378244496262522,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2100,0.378244496262522,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2200,0.378244496262522,"forestryLoss_growthFactor_SSP2"
+"Michigan","MI",2300,0.378244496262522,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2013,1.01343987759301,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2014,1.00663636732555,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2015,1,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2016,0.988923579606425,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2017,0.978206047305519,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2018,0.967830418131337,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2019,0.957780756738274,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2020,0.948042097768407,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2021,0.936365726481091,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2022,0.925024223361492,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2023,0.914003536956958,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2024,0.903290386846505,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2025,0.892872211623948,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2026,0.883423369702281,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2027,0.874203675731504,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2028,0.865204959389801,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2029,0.85641943248391,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2030,0.847839666924047,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2031,0.839116066328713,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2032,0.830591499895703,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2033,0.822259308310336,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2034,0.814113124267993,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2035,0.806146856695345,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2036,0.800249420013303,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2037,0.794479639698891,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2038,0.788833474685202,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2039,0.783307051424864,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2040,0.77789665533249,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2041,0.77268520085485,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2042,0.767581508061594,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2043,0.762582336204825,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2044,0.757684571923846,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2045,0.752885223077249,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2046,0.750779997813159,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2047,0.748712027367923,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2048,0.746680343660966,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2049,0.744684011649859,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2050,0.742722127937657,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2051,0.742590389215113,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2052,0.742461798452264,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2053,0.742336266290437,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2054,0.742213706455599,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2055,0.742094035631367,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2056,0.737143826348194,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2057,0.732272068109172,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2058,0.72747691266732,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2059,0.722756569345483,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2060,0.718109302812924,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2061,0.714426568773001,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2062,0.710804483183472,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2063,0.707241563600002,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2064,0.703736375446063,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2065,0.700287530097486,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2066,0.693475161742298,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2067,0.686770287460917,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2068,0.680170386898569,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2069,0.673673017824333,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2070,0.667275813128379,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2071,0.664974401235871,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2072,0.662708088443223,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2073,0.660476078747261,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2074,0.658277600023813,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2075,0.656111903139095,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2076,0.651382644387343,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2077,0.646729382266321,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2078,0.642150307688362,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2079,0.637643668460037,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2080,0.633207767063855,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2081,0.631033564367154,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2082,0.6288944632455,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2083,0.626789643780271,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2084,0.624718311241393,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2085,0.622679695128692,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2086,0.622441073874394,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2087,0.622205871347425,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2088,0.621974010962867,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2089,0.621745418424175,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2090,0.621520021638234,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2091,0.61358515899278,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2092,0.605757189054783,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2093,0.598033751848518,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2094,0.590412557034093,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2095,0.582891381355437,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2096,0.575373594801822,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2097,0.567954907512645,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2098,0.560633120234417,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2099,0.560633120234417,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2100,0.560633120234417,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2200,0.560633120234417,"forestryLoss_growthFactor_SSP2"
+"Minnesota","MN",2300,0.560633120234417,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2013,1.02259059161192,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2014,1.01113934384332,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2015,1,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2016,0.984579673495907,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2017,0.969689417228605,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2018,0.955303426023194,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2019,0.941397512085933,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2020,0.927948981402804,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2021,0.911458528979737,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2022,0.895472887725223,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2023,0.879970181245473,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2024,0.864929753763223,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2025,0.850332087035171,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2026,0.837838499834222,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2027,0.825666481569625,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2028,0.813804192330221,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2029,0.802240356028837,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2030,0.790964227566902,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2031,0.782114635577265,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2032,0.773486925287152,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2033,0.765073311434325,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2034,0.756866358911323,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2035,0.748858963578721,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2036,0.738973872638195,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2037,0.729313298744843,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2038,0.7198699638404,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2039,0.710636895296823,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2040,0.701607410212017,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2041,0.700841714623551,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2042,0.700109243936784,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2043,0.699408749920605,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2044,0.698739038241629,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2045,0.698098965736735,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2046,0.688054448378495,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2047,0.678187457557,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2048,0.668493383199793,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2049,0.658967772509968,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2050,0.649606323337716,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2051,0.646306427323036,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2052,0.643067288811615,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2053,0.639887347637326,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2054,0.636765095003922,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2055,0.633699071420937,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2056,0.62849194436599,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2057,0.623374468466111,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2058,0.618344437040562,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2059,0.613399713810315,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2060,0.60853823014245,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2061,0.603024593204691,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2062,0.597605887317416,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2063,0.592279741678515,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2064,0.587043862856497,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2065,0.581896031677913,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2066,0.57766353760607,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2067,0.573501382136103,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2068,0.569407878073385,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2069,0.565381391062488,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2070,0.561420337546669,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2071,0.55405545192351,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2072,0.546801955022014,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2073,0.53965732897897,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2074,0.532619131365618,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2075,0.525684992381958,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2076,0.524582829684146,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2077,0.523495387239428,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2078,0.522422335150714,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2079,0.521363353707821,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2080,0.520318132992437,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2081,0.516055668110744,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2082,0.51185428898705,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2083,0.507712606428064,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2084,0.503629273666145,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2085,0.499602984746732,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2086,0.495934747495052,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2087,0.492323264381919,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2088,0.488767248447958,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2089,0.485265451261653,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2090,0.481816661488819,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2091,0.479388995077897,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2092,0.477045788972732,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2093,0.474785055754095,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2094,0.4726048669977,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2095,0.470503351110907,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2096,0.468442560000741,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2097,0.466453959379102,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2098,0.464535912826345,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2099,0.464535912826345,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2100,0.464535912826345,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2200,0.464535912826345,"forestryLoss_growthFactor_SSP2"
+"Missouri","MO",2300,0.464535912826345,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2013,0.986470892983995,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2014,0.993299518473752,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2015,1,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2016,1.00191435139009,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2017,1.00379665288628,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2018,1.00564771337641,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2019,1.00746831411826,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2020,1.00925920995543,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2021,0.996463317378559,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2022,0.98405396103848,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2023,0.972014495630676,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2024,0.960329201615817,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2025,0.948983222313011,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2026,0.945164045377388,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2027,0.941451105426257,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2028,0.937840340271977,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2029,0.934327885094189,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2030,0.930910060816462,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2031,0.925726832935874,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2032,0.920674097747446,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2033,0.915747267766986,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2034,0.910941962044115,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2035,0.906253994839202,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2036,0.892547601812157,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2037,0.879138833798914,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2038,0.866018254084413,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2039,0.853176817476199,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2040,0.840605850294889,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2041,0.844684703769255,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2042,0.848692806166578,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2043,0.852632090586117,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2044,0.856504417917119,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2045,0.860311580243052,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2046,0.838905746886077,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2047,0.817871166234764,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2048,0.797198292655827,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2049,0.776877904450393,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2050,0.756901090240593,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2051,0.755180245524038,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2052,0.753491547031634,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2053,0.751834163841493,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2054,0.750207292481694,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2055,0.748610155825364,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2056,0.754003076390554,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2057,0.759315171857782,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2058,0.76454828482267,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2059,0.769704201572763,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2060,0.77478465423837,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2061,0.764513884000455,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2062,0.754414098678714,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2063,0.744481096375793,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2064,0.734710811237553,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2065,0.725099308001848,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2066,0.727061378500853,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2067,0.728994556711998,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2068,0.730899497940169,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2069,0.73277683749247,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2070,0.734627191441273,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2071,0.743438417086429,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2072,0.752115125993909,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2073,0.760660370037969,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2074,0.769077109526606,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2075,0.77736821660921,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2076,0.777225958132281,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2077,0.777084506750592,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2078,0.77694385339607,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2079,0.776803989192823,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2080,0.776664905450722,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2081,0.779057572796494,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2082,0.781410304017571,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2083,0.783724038333121,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2084,0.78599968606622,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2085,0.788238129743961,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2086,0.783469451406639,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2087,0.778773714095595,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2088,0.774149266678349,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2089,0.769594507439185,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2090,0.765107882244396,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2091,0.785207358432336,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2092,0.805029096732211,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2093,0.8245792455675,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2094,0.843863771892634,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2095,0.862888467843642,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2096,0.881537906778061,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2097,0.89992584636587,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2098,0.918058101857942,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2099,0.918058101857942,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2100,0.918058101857942,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2200,0.918058101857942,"forestryLoss_growthFactor_SSP2"
+"Mississippi","MS",2300,0.918058101857942,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2013,0.978205571062739,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2014,0.98923386847774,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2015,1,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2016,1.00583326893146,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2017,1.0114770436618,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2018,1.01694030388396,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2019,1.02223147400718,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2020,1.0273584652997,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2021,1.01775266176293,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2022,1.00840881777603,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2023,0.99931623565629,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2024,0.990464796147413,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2025,0.981844919708426,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2026,0.974111977599842,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2027,0.966558695612077,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2028,0.959178826549461,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2029,0.951966411133047,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2030,0.944915761548856,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2031,0.943913462755358,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2032,0.942929401372596,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2033,0.941963051025183,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2034,0.941013906385465,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2035,0.940081482097899,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2036,0.927496774692657,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2037,0.915172995419278,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2038,0.903102070361837,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2039,0.891276256248108,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2040,0.879688123669727,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2041,0.90566412889561,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2042,0.931119959605496,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2043,0.956071016385955,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2044,0.980532099168361,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2045,1.00451743619689,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2046,1.00311167434486,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2047,1.00172809171479,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2048,1.00036614822831,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2049,0.999025321583507,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2050,0.997705106520418,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2051,1.010630807603,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2052,1.02334276545977,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2053,1.03584618265536,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2054,1.04814609523533,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2055,1.06024737931459,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2056,1.060690105042,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2057,1.06112014377531,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2058,1.06153786963857,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2059,1.0619436437762,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2060,1.06233781488337,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2061,1.06100223833044,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2062,1.0596851894832,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2063,1.05838625774984,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2064,1.05710504510999,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2065,1.05584116562552,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2066,1.06361147710858,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2067,1.07125672871006,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2068,1.07877987884836,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2069,1.08618379386625,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2070,1.09347125157653,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2071,1.079831914035,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2072,1.06640092047384,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2073,1.05317354299559,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2074,1.0401451955677,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2075,1.0273114287428,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2076,0.978067843979338,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2077,0.929613304290787,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2078,0.88192904217469,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2079,0.834996880207403,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2080,0.788799208038536,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2081,0.787923314371184,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2082,0.787067342893554,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2083,0.786230800076087,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2084,0.78541320773892,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2085,0.784614102466114,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2086,0.776800175209955,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2087,0.769103754456951,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2088,0.761522187264575,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2089,0.754052900057679,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2090,0.74669339568191,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2091,0.757480844272594,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2092,0.76805144302414,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2093,0.77841014912751,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2094,0.788561773015103,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2095,0.79851098374089,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2096,0.808119733784953,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2097,0.817530668701189,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2098,0.82674823275082,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2099,0.82674823275082,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2100,0.82674823275082,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2200,0.82674823275082,"forestryLoss_growthFactor_SSP2"
+"Montana","MT",2300,0.82674823275082,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2000,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2001,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2002,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2003,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2004,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2005,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2006,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2007,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2008,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2009,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2010,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2011,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2012,NA,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2013,0.996501170856684,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2014,0.998280607126818,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2015,1,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2016,0.997022990329683,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2017,0.994123254179586,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2018,0.991297587513376,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2019,0.988542969986671,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2020,0.985856551574149,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2021,0.977201293012965,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2022,0.968770926113072,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2023,0.960556522079928,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2024,0.952549627264335,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2025,0.944742231645146,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2026,0.939703533421617,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2027,0.93477482659406,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2028,0.929952435231379,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2029,0.925232848714619,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2030,0.920612712430586,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2031,0.912918360861291,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2032,0.905385387019488,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2033,0.898008648045884,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2034,0.890783220369926,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2035,0.883704388049369,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2036,0.880214125929907,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2037,0.876790772434812,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2038,0.873432349499049,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2039,0.870136958004947,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2040,0.866902773832607,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2041,0.860461038939795,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2042,0.854140339542085,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2043,0.84793720991535,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2044,0.841848317185799,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2045,0.835870454979969,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2046,0.837041744470368,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2047,0.838191260294195,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2048,0.839319582308442,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2049,0.840427270327014,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2050,0.841514864971374,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2051,0.832166788154808,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2052,0.822967280164019,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2053,0.813912803800667,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2054,0.804999933689125,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2055,0.796225351882929,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2056,0.791979577096199,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2057,0.787798894618644,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2058,0.783681800042074,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2059,0.779626835304775,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2060,0.775632586912824,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2061,0.77457136232573,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2062,0.773525873519093,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2063,0.772495757091301,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2064,0.771480661030201,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2065,0.770480244264323,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2066,0.76525664134253,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2067,0.760113403844174,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2068,0.755048669509971,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2069,0.750060633491886,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2070,0.74514754615205,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2071,0.740722123330786,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2072,0.736364474836112,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2073,0.732073061131227,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2074,0.727846388892863,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2075,0.723683009291111,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2076,0.723031426300278,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2077,0.722391944628003,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2078,0.72176426501828,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2079,0.72114809772899,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2080,0.72054316215978,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2081,0.716143726317136,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2082,0.711815710423263,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2083,0.707557444303211,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2084,0.703367309103911,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2085,0.699243735340808,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2086,0.69838012174302,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2087,0.697529150200723,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2088,0.696690536513772,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2089,0.695864004978671,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2090,0.695049288073163,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2091,0.692567887883016,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2092,0.690100546709103,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2093,0.687647000076247,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2094,0.685206991181365,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2095,0.682780270612765,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2096,0.680257848973046,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2097,0.677748939413189,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2098,0.67525325712029,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2099,0.67525325712029,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2100,0.67525325712029,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2200,0.67525325712029,"forestryLoss_growthFactor_SSP2"
+"North Carolina","NC",2300,0.67525325712029,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2000,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2001,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2002,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2003,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2004,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2005,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2006,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2007,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2008,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2009,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2010,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2011,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2012,NA,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2013,0.984561087192729,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2014,0.992451746981392,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2015,1,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2016,1.00255694829361,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2017,1.00488698653584,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2018,1.00700425571435,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2019,1.00892191550507,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2020,1.01065222295346,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2021,1.01362944874296,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2022,1.01635030295592,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2023,1.01882926522705,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2024,1.02107991224221,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2025,1.02311498259671,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2026,1.0306697269528,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2027,1.03793520658917,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2028,1.04492387155451,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2029,1.05164753214564,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2030,1.05811739770927,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2031,1.06554863202473,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2032,1.07269426168592,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2033,1.07956594312348,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2034,1.08617477066342,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2035,1.09253130844681,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2036,1.10040923655931,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2037,1.10803116033684,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2038,1.11540656839524,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2039,1.1225445258196,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2040,1.12945369662435,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2041,1.13724495872737,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2042,1.14477882659831,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2043,1.15206441974611,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2044,1.15911047245717,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2045,1.16592535309949,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2046,1.17767860128184,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2047,1.189200074384,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2048,1.2004961148521,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2049,1.2115728429048,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2050,1.22243616603166,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2051,1.23452905228614,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2052,1.24636734319647,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2053,1.25795795329108,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2054,1.26930756313346,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2055,1.2804226288583,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2056,1.29191290992975,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2057,1.30315827510547,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2058,1.31416532776837,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2059,1.32494045092466,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2060,1.33548981603759,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2061,1.3457968751424,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2062,1.3558953785119,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2063,1.36579089733963,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2064,1.37548881524051,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2065,1.38499433591242,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2066,1.39480389720839,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2067,1.40442670842844,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2068,1.41386749007857,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2069,1.42313081147611,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2070,1.43222109664715,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2071,1.44261977399884,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2072,1.45286726001626,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2073,1.46296691782973,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2074,1.47292201045656,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2075,1.4827357045151,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2076,1.49227831430145,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2077,1.50169835091538,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2078,1.51099852111453,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2079,1.52018144846627,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2080,1.52924967656918,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2081,1.53984758041631,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2082,1.55034304050564,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2083,1.56073811514033,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2084,1.57103480162428,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2085,1.58123503856504,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2086,1.58783905515514,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2087,1.59433037343584,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2088,1.60071158510243,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2089,1.60698520409432,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2090,1.61315366948314,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2091,1.59068123220462,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2092,1.56794993236804,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2093,1.54496681658116,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2094,1.52173871970641,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2095,1.49827227263456,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2096,1.47454895844214,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2097,1.45061276432101,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2098,1.42646881542914,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2099,1.42646881542914,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2100,1.42646881542914,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2200,1.42646881542914,"forestryLoss_growthFactor_SSP2"
+"North Dakota","ND",2300,1.42646881542914,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2013,1.0160754865094,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2014,1.00794177708639,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2015,1,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2016,0.987648189728414,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2017,0.975689955436507,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2018,0.964106827212947,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2019,0.952881471582751,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2020,0.941997605482969,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2021,0.930168479872727,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2022,0.918666968668772,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2023,0.907479578052773,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2024,0.896593547262105,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2025,0.8859967994032,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2026,0.87921757227858,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2027,0.872594960574297,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2028,0.866123537061494,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2029,0.859798124123579,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2030,0.853613779510724,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2031,0.847504486337297,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2032,0.841524670756058,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2033,0.835670180050143,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2034,0.829937039246515,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2035,0.824321441643598,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2036,0.818626472588036,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2037,0.813044212828406,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2038,0.807571265584237,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2039,0.802204371155286,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2040,0.796940400020839,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2041,0.792012279559478,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2042,0.787172635090654,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2043,0.782418998121674,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2044,0.777748993460623,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2045,0.77316033478983,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2046,0.771345555612218,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2047,0.769558941662411,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2048,0.767799814142166,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2049,0.766067516459803,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2050,0.764361413315831,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2051,0.763125154138913,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2052,0.76190163065797,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2053,0.760690634138544,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2054,0.759491960742125,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2055,0.758305411371835,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2056,0.756535395511066,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2057,0.754785594131401,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2058,0.753055634959179,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2059,0.75134515548352,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2060,0.74965380261952,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2061,0.747441683116531,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2062,0.745260986219804,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2063,0.743111004930621,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2064,0.740991054087597,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2065,0.738900469512918,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2066,0.737316076504492,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2067,0.735752655053206,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2068,0.734209756545357,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2069,0.732686945659574,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2070,0.731183799866802,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2071,0.730374900203439,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2072,0.729579425195571,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2073,0.728797060729479,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2074,0.72802750222856,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2075,0.727270454296737,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2076,0.726396083812016,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2077,0.72554060323792,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2078,0.72470352970819,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2079,0.723884395846594,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2080,0.723082749159482,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2081,0.722718418170739,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2082,0.722370015997869,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2083,0.722037121599827,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2084,0.721719327197123,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2085,0.721416237764365,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2086,0.719127017241494,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2087,0.716870751452556,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2088,0.714646701576603,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2089,0.712454150871538,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2090,0.710292403854564,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2091,0.695908807581518,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2092,0.681653262751889,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2093,0.667523098043932,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2094,0.653515720511527,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2095,0.639628612713454,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2096,0.625849911297174,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2097,0.612190039862365,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2098,0.598646409176128,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2099,0.598646409176128,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2100,0.598646409176128,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2200,0.598646409176128,"forestryLoss_growthFactor_SSP2"
+"Nebraska","NE",2300,0.598646409176128,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2000,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2001,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2002,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2003,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2004,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2005,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2006,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2007,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2008,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2009,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2010,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2011,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2012,NA,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2013,1.01011535252067,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2014,1.00497302797752,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2015,1,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2016,0.990580282200774,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2017,0.981504595491297,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2018,0.972755741237718,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2019,0.964317612583795,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2020,0.95617511047965,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2021,0.938870396354335,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2022,0.922101571928012,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2023,0.905845288534725,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2024,0.89007950381074,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2025,0.874783392653173,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2026,0.861312906258377,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2027,0.848194749894444,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2028,0.835415844443826,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2029,0.822963736401542,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2030,0.810826561349908,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2031,0.799119126994148,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2032,0.787707225605684,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2033,0.776580454780224,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2034,0.765728880739867,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2035,0.755143012632188,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2036,0.745001738098664,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2037,0.735098555368033,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2038,0.725425626600645,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2039,0.715975445428027,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2040,0.706740819840876,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2041,0.703378489068141,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2042,0.700110822946998,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2043,0.696934614617084,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2044,0.693846790257944,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2045,0.690844402477141,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2046,0.689289897618543,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2047,0.687769420024019,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2048,0.686281997875795,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2049,0.684826694104583,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2050,0.683402604888999,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2051,0.684248605475897,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2052,0.685093428807918,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2053,0.685936935217733,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2054,0.686778992475717,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2055,0.687619475430185,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2056,0.685610001161951,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2057,0.683643351553806,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2058,0.68171837204697,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2059,0.679833946612982,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2060,0.677988996209242,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2061,0.671807026689785,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2062,0.665732468693946,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2063,0.659762628376915,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2064,0.65389489998738,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2065,0.648126762319962,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2066,0.64371944564268,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2067,0.63938633172355,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2068,0.635125630941565,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2069,0.630935609858172,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2070,0.626814589045273,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2071,0.619405201048739,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2072,0.612107568694081,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2073,0.604919168564868,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2074,0.597837552813004,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2075,0.590860346348533,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2076,0.58300679089613,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2077,0.575274455740939,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2078,0.567660489427902,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2079,0.56016212986448,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2080,0.552776700839986,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2081,0.543561001265381,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2082,0.534480799836076,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2083,0.525532996277714,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2084,0.516714585126625,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2085,0.508022652125049,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2086,0.497303919660808,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2087,0.486749504230435,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2088,0.476355684997224,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2089,0.466118852491344,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2090,0.456035504474943,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2091,0.463667925442464,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2092,0.471249421371225,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2093,0.478780993553329,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2094,0.486263614088813,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2095,0.49369822695422,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2096,0.501089812429066,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2097,0.508424592262549,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2098,0.515703796124453,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2099,0.515703796124453,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2100,0.515703796124453,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2200,0.515703796124453,"forestryLoss_growthFactor_SSP2"
+"New Hampshire","NH",2300,0.515703796124453,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2000,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2001,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2002,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2003,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2004,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2005,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2006,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2007,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2008,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2009,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2010,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2011,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2012,NA,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2013,1.02572744086211,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2014,1.01268891059758,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2015,1,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2016,0.983073508962325,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2017,0.966725473157894,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2018,0.950927807345642,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2019,0.935654184256431,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2020,0.9208799003375,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2021,0.905629895071606,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2022,0.890851039423926,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2023,0.876522827827889,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2024,0.862625901326653,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2025,0.849141969439228,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2026,0.838360950561817,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2027,0.827860315301362,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2028,0.817629685230438,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2029,0.807659177579509,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2030,0.79793937632418,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2031,0.787924160195498,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2032,0.778154442196552,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2033,0.768621700804603,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2034,0.75931779562869,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2035,0.750234946588729,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2036,0.741796585767497,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2037,0.733549789923231,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2038,0.725488350623285,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2039,0.717606319946895,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2040,0.709897997091293,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2041,0.70194044206902,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2042,0.694155520721147,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2043,0.686537925559903,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2044,0.679082559971417,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2045,0.67178452795072,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2046,0.666463167676266,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2047,0.661237197299027,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2048,0.65610412166306,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2049,0.651061531062345,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2050,0.646107097632073,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2051,0.640982590771804,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2052,0.635947194433741,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2053,0.630998682232688,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2054,0.626134900055729,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2055,0.621353763180419,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2056,0.616500598793241,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2057,0.61173015086564,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2058,0.607040393671878,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2059,0.602429365941553,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2060,0.597895168340466,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2061,0.593178156009022,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2062,0.588541988077485,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2063,0.58398464986815,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2064,0.57950419238316,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2065,0.575098729663615,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2066,0.570709189758246,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2067,0.566391375075529,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2068,0.562143577583857,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2069,0.557964142570534,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2070,0.553851466585773,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2071,0.550157716164156,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2072,0.546519708048805,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2073,0.54293618332615,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2074,0.53940592078625,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2075,0.535927735520637,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2076,0.532195379666613,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2077,0.528520720851394,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2078,0.524902401245215,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2079,0.52133910557752,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2080,0.517829559479218,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2081,0.514442869951997,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2082,0.511105207386264,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2083,0.507815454124566,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2084,0.504572526660978,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2085,0.501375374342869,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2086,0.496950771610102,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2087,0.492593990159021,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2088,0.488303494252961,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2089,0.484077794120659,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2090,0.47991544424962,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2091,0.467914822372664,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2092,0.456122331397328,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2093,0.444533266046695,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2094,0.433143060198671,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2095,0.421947281785107,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2096,0.410855498576939,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2097,0.399955117874513,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2098,0.389241857527451,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2099,0.389241857527451,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2100,0.389241857527451,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2200,0.389241857527451,"forestryLoss_growthFactor_SSP2"
+"New Jersey","NJ",2300,0.389241857527451,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2000,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2001,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2002,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2003,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2004,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2005,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2006,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2007,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2008,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2009,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2010,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2011,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2012,NA,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2013,1.02274973784419,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2014,1.01120995134527,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2015,1,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2016,0.984526234874154,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2017,0.969598844016474,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2018,0.955190906498886,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2019,0.941277198592843,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2020,0.927834063684231,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2021,0.911389158220485,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2022,0.895465515735296,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2023,0.880040182947212,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2024,0.865091497542582,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2025,0.850598999937444,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2026,0.838360308743205,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2027,0.826446646122333,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2028,0.814845854600986,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2029,0.803546360605487,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2030,0.792537140294522,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2031,0.782208862184088,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2032,0.772144014138685,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2033,0.762333279380694,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2034,0.752767761874702,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2035,0.743438963222484,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2036,0.732635034974858,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2037,0.722079924892828,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2038,0.711765514181677,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2039,0.701684025887118,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2040,0.691828007288491,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2041,0.688191621797899,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2042,0.684648926819273,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2043,0.681196839885558,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2044,0.677832404834781,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2045,0.674552785569229,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2046,0.668596119575409,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2047,0.662747224380162,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2048,0.657003267805986,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2049,0.651361514903406,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2050,0.645819323839528,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2051,0.642666372030942,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2052,0.639572782743197,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2053,0.636537016168135,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2054,0.633557583455561,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2055,0.63063304466016,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2056,0.625768123212891,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2057,0.620988108711308,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2058,0.61629089723592,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2059,0.611674452226928,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2060,0.607136801842623,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2061,0.602323787093796,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2062,0.597594342960528,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2063,0.592946374159939,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2064,0.588377853918491,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2065,0.583886821213278,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2066,0.580929839801402,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2067,0.578022992749029,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2068,0.57516506740946,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2069,0.572354889253743,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2070,0.569591320396195,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2071,0.563624509897098,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2072,0.557747840517931,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2073,0.551959275601869,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2074,0.546256839498839,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2075,0.540638615296604,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2076,0.528541266162564,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2077,0.516634052735546,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2078,0.504912478101711,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2079,0.493372186503263,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2080,0.482008957837837,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2081,0.478507195396041,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2082,0.475054339828602,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2083,0.471649285923382,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2084,0.468290962173099,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2085,0.46497832949463,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2086,0.459661915311113,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2087,0.45442728179175,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2088,0.449272576101645,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2089,0.444196000866883,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2090,0.439195812115326,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2091,0.431824477717989,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2092,0.424609851729579,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2093,0.417548338241653,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2094,0.41063644784087,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2095,0.403870793704771,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2096,0.397348396056741,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2097,0.390958748392187,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2098,0.384698868997024,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2099,0.384698868997024,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2100,0.384698868997024,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2200,0.384698868997024,"forestryLoss_growthFactor_SSP2"
+"New Mexico","NM",2300,0.384698868997024,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2013,1.00261884234269,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2014,1.00132474766001,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2015,1,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2016,0.994022227790773,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2017,0.988177906447804,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2018,0.982462142680843,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2019,0.976870300667106,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2020,0.971397984286822,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2021,0.965350436213647,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2022,0.959410507052082,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2023,0.953575113723759,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2024,0.947841300589339,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2025,0.942206232368303,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2026,0.939231670848598,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2027,0.936293883252048,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2028,0.933392270741425,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2029,0.930526243327212,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2030,0.927695220000493,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2031,0.924632418320198,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2032,0.921603965611023,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2033,0.918609355726213,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2034,0.91564808910852,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2035,0.912719672907547,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2036,0.909409617325299,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2037,0.90614682788102,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2038,0.902930203295783,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2039,0.899758679332221,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2040,0.896631227137494,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2041,0.895144631816291,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2042,0.893665104832035,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2043,0.892192772583989,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2044,0.890727749925929,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2045,0.88927014088551,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2046,0.888207911655996,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2047,0.887158692483979,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2048,0.886122223084338,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2049,0.88509825064945,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2050,0.884086529565799,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2051,0.883022453993369,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2052,0.881967260647141,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2053,0.880920847805789,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2054,0.879883114985722,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2055,0.878853962936649,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2056,0.876790935938953,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2057,0.874752670287399,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2058,0.872738687871581,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2059,0.87074852361788,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2060,0.868781725026704,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2061,0.866589841333705,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2062,0.864428923801044,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2063,0.862298278089578,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2064,0.860197231264332,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2065,0.858125130958555,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2066,0.856645032611704,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2067,0.855183818130887,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2068,0.853741092579085,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2069,0.852316472580494,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2070,0.850909585888234,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2071,0.848512120015439,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2072,0.846152018266962,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2073,0.843828426168534,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2074,0.841540514962866,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2075,0.839287480651411,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2076,0.834116189523679,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2077,0.829030631589066,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2078,0.824028747919121,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2079,0.819108544502503,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2080,0.81426808971196,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2081,0.812362824580382,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2082,0.8104929211906,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2083,0.80865753111644,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2084,0.806855832145765,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2085,0.805087027281541,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2086,0.801053327601113,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2087,0.797079659515829,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2088,0.793164669910918,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2089,0.78930704614203,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2090,0.785505514532806,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2091,0.76957334881772,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2092,0.753824121378991,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2093,0.738253868435288,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2094,0.722858742949028,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2095,0.707635010348712,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2096,0.692318021153592,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2097,0.677181267331002,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2098,0.662220765548222,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2099,0.662220765548222,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2100,0.662220765548222,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2200,0.662220765548222,"forestryLoss_growthFactor_SSP2"
+"Nevada","NV",2300,0.662220765548222,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2000,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2001,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2002,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2003,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2004,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2005,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2006,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2007,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2008,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2009,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2010,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2011,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2012,NA,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2013,1.02292327497621,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2014,1.0113059018099,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2015,1,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2016,0.984413576848697,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2017,0.969358522994563,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2018,0.954809068196381,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2019,0.940741054390472,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2020,0.927131812603957,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2021,0.911961074316503,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2022,0.89725638827113,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2023,0.882997524266291,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2024,0.869165381809612,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2025,0.85574191318929,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2026,0.844843676542132,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2027,0.8342280594572,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2028,0.8238846160061,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2029,0.813803398746631,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2030,0.803974929658045,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2031,0.793850148435684,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2032,0.783973805411181,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2033,0.774337272723566,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2034,0.764932308499938,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2035,0.755751035766281,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2036,0.747112841016961,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2037,0.738671452700292,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2038,0.730420481626199,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2039,0.722353806933092,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2040,0.714465562285838,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2041,0.707013484420948,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2042,0.699725243091558,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2043,0.692595771668903,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2044,0.685620205390294,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2045,0.678793871519053,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2046,0.673883903240817,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2047,0.669062595406222,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2048,0.664327620325335,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2049,0.659676730176677,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2050,0.655107753630759,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2051,0.650539742852596,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2052,0.646052786750427,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2053,0.641644839957916,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2054,0.637313923852654,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2055,0.633058123887219,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2056,0.628380671588731,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2057,0.623784118643194,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2058,0.619266469298379,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2059,0.61482579155008,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2060,0.610460214645314,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2061,0.605227155684821,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2062,0.600084433448785,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2063,0.595029789114243,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2064,0.590061037618286,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2065,0.585176064689846,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2066,0.58020466072535,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2067,0.575315468310881,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2068,0.570506519589607,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2069,0.565775908276133,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2070,0.561121787279785,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2071,0.55625237265612,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2072,0.551456214108301,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2073,0.546731659229603,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2074,0.542077105077496,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2075,0.537490996334495,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2076,0.53282187946549,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2077,0.528224273301797,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2078,0.523696499684427,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2079,0.519236933009732,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2080,0.514843998182803,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2081,0.510500039226058,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2082,0.506218295931823,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2083,0.501997353619489,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2084,0.497835840811044,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2085,0.493732427588981,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2086,0.488217214100678,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2087,0.482786809208329,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2088,0.477439291579867,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2089,0.472172797394054,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2090,0.466985518205162,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2091,0.456928806149661,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2092,0.447072086520918,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2093,0.437410790933383,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2094,0.427940486239866,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2095,0.418656869573761,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2096,0.409336953561792,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2097,0.400206528537622,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2098,0.391261338417493,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2099,0.391261338417493,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2100,0.391261338417493,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2200,0.391261338417493,"forestryLoss_growthFactor_SSP2"
+"New York","NY",2300,0.391261338417493,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2013,1.02858732282037,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2014,1.0140924767163,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2015,1,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2016,0.98172667217665,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2017,0.964091790378274,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2018,0.947064044045381,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2019,0.930614092100581,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2020,0.914714412165924,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2021,0.897563935141322,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2022,0.880954418094778,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2023,0.864862092951011,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2024,0.849264526970679,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2025,0.834140531531411,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2026,0.821292807391036,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2027,0.808785379694053,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2028,0.796605536556823,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2029,0.784741176195586,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2030,0.77318077123951,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2031,0.762237380310337,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2032,0.751572552116545,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2033,0.74117644368643,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2034,0.731039656346493,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2035,0.721153211328935,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2036,0.710766130757463,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2037,0.70062123338803,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2038,0.690710571777411,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2039,0.681026534062948,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2040,0.671561826652479,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2041,0.665022311173094,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2042,0.658637688211933,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2043,0.652403017980711,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2044,0.646313560329233,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2045,0.640364764945969,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2046,0.632088345216847,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2047,0.623960632778806,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2048,0.615977733245671,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2049,0.608135885681948,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2050,0.600431456965095,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2051,0.594995027084776,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2052,0.589656850744812,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2053,0.584414426664646,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2054,0.57926533555752,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2055,0.574207236843665,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2056,0.568430612816032,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2057,0.562755228625237,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2058,0.557178570565062,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2059,0.55169820549385,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2060,0.546311777673244,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2061,0.540745248882997,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2062,0.535275760972957,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2063,0.529900876461046,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2064,0.524618237634182,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2065,0.519425563334768,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2066,0.514551813155654,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2067,0.509759402680838,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2068,0.505046377338771,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2069,0.500410843819406,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2070,0.495850967707574,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2071,0.490017218245383,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2072,0.48427125906253,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2073,0.478611109670645,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2074,0.473034848869409,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2075,0.467540612542091,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2076,0.46425419163809,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2077,0.461016352881481,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2078,0.457825968789958,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2079,0.454681947073643,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2080,0.451583229265975,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2081,0.447494603004497,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2082,0.443462675615686,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2083,0.439486168079698,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2084,0.435563840366312,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2085,0.431694489953566,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2086,0.427381073773947,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2087,0.423134474404425,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2088,0.418953176427155,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2089,0.414835709792826,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2090,0.410780648136133,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2091,0.403215561879064,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2092,0.395821341980044,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2093,0.388594052573647,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2094,0.381529874399234,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2095,0.374625100525952,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2096,0.367872478911621,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2097,0.361270782345273,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2098,0.354816614217655,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2099,0.354816614217655,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2100,0.354816614217655,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2200,0.354816614217655,"forestryLoss_growthFactor_SSP2"
+"Ohio","OH",2300,0.354816614217655,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2013,1.01348920028098,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2014,1.00666866435591,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2015,1,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2016,0.9888771414039,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2017,0.978100215023323,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2018,0.96765319054283,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2019,0.95752101748818,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2020,0.947689551312374,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2021,0.937114433351233,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2022,0.926821437201971,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2023,0.916799185385965,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2024,0.907036911310329,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2025,0.897524418543016,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2026,0.891410537695685,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2027,0.885430999894062,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2028,0.879581295652208,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2029,0.873857118848383,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2030,0.86825435525675,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2031,0.862506493543785,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2032,0.856872385064568,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2033,0.851348538563675,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2034,0.845931608240159,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2035,0.840618386119586,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2036,0.863478331844372,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2037,0.885846672287456,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2038,0.90773891741237,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2039,0.929169935366372,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2040,0.95015398523585,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2041,0.949106401799171,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2042,0.948064411574475,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2043,0.947028076453881,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2044,0.945997451432048,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2045,0.944972585048996,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2046,0.944947014964752,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2047,0.94491719868979,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2048,0.94488330971476,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2049,0.944845514468543,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2050,0.944803972641744,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2051,0.947622089000927,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2052,0.950384564998721,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2053,0.953092873686392,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2054,0.955748438873632,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2055,0.958352637123016,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2056,0.960378882519265,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2057,0.962362466021317,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2058,0.964304532668018,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2059,0.966206189364659,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2060,0.968068506409908,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2061,0.968487510921675,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2062,0.968892959104156,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2063,0.969285263498172,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2064,0.969664822005712,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2065,0.970032018502396,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2066,0.970308732486104,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2067,0.970575646810204,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2068,0.970833049358064,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2069,0.97108121826225,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2070,0.971320422293982,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2071,0.971173407204492,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2072,0.971029915044578,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2073,0.970889854547887,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2074,0.970753137320284,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2075,0.970619677730991,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2076,0.972005538157957,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2077,0.973374824368625,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2078,0.974727891839016,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2079,0.976065085223896,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2080,0.977386738774603,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2081,0.980033479011932,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2082,0.98265045292019,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2083,0.985238292607358,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2084,0.987797611184306,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2085,0.990329003484269,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2086,1.00151849323614,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2087,1.01253581173841,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2088,1.02338485989085,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2089,1.03406942182667,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2090,1.04459316924796,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2091,1.03328886494081,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2092,1.02204814567596,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2093,1.01086981791203,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2094,0.999752722721989,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2095,0.988695734526779,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2096,0.977562091884016,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2097,0.966491930643798,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2098,0.955483905512357,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2099,0.955483905512357,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2100,0.955483905512357,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2200,0.955483905512357,"forestryLoss_growthFactor_SSP2"
+"Oklahoma","OK",2300,0.955483905512357,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2013,0.974854208327765,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2014,0.987582206946385,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2015,1,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2016,1.00743132353734,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2017,1.01461476281868,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2018,1.02156221707195,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2019,1.02828484489208,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2020,1.03479312064004,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2021,1.02527584129586,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2022,1.01601137550411,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2023,1.00698955318175,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2024,0.998200749532092,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2025,0.989635848721793,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2026,0.986164175503805,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2027,0.982767903840802,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2028,0.97944452236518,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2029,0.976191632403526,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2030,0.973006941640975,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2031,0.965893408096386,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2032,0.958931558377079,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2033,0.952116509567366,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2034,0.945443588204383,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2035,0.938908319101739,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2036,0.933562432560684,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2037,0.928324805987984,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2038,0.923192133123544,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2039,0.918161242132267,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2040,0.913229088809025,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2041,0.923406924739592,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2042,0.933378332814469,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2043,0.943149463318402,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2044,0.952726225900124,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2045,0.962114301196317,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2046,0.975476835251614,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2047,0.988607961763818,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2048,1.00151362592909,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2049,1.01419957127791,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2050,1.02667134814814,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2051,1.02070154976229,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2052,1.01482632590137,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2053,1.00904342903634,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2054,1.0033506826154,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2055,0.997745978276858,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2056,0.976007548780904,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2057,0.954611425422699,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2058,0.933549572982412,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2059,0.912814206008253,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2060,0.892397779181464,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2061,0.893348134202237,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2062,0.894282416646122,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2063,0.895201024523676,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2064,0.896104342910257,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2065,0.89699274446532,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2066,0.890043964995592,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2067,0.883204114495738,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2068,0.876470646643053,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2069,0.869841093934367,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2070,0.863313064658484,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2071,0.858386465578584,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2072,0.853534945597792,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2073,0.848756802523495,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2074,0.844050385220532,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2075,0.839414091711287,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2076,0.834935282584809,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2077,0.830528114767331,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2078,0.826190885117584,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2079,0.821921944035822,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2080,0.817719693376477,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2081,0.813829903372642,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2082,0.810000867284741,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2083,0.806231175962828,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2084,0.802519463480632,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2085,0.79886440549106,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2086,0.79548689522006,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2087,0.792160631320385,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2088,0.788884455195253,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2089,0.785657242916816,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2090,0.782477903939013,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2091,0.802903537583211,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2092,0.823021451219704,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2093,0.842838515882349,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2094,0.862361399639785,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2095,0.881596575034488,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2096,0.900300905356089,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2097,0.918724288008923,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2098,0.936872984129329,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2099,0.936872984129329,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2100,0.936872984129329,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2200,0.936872984129329,"forestryLoss_growthFactor_SSP2"
+"Oregon","OR",2300,0.936872984129329,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2013,1.02432869986845,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2014,1.01198887101015,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2015,1,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2016,0.983771159972997,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2017,0.968114897914979,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2018,0.953003011710497,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2019,0.938409076913722,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2020,0.924308310507185,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2021,0.907234723202513,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2022,0.89069971294401,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2023,0.874679615517274,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2024,0.85915209623204,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2025,0.844096059099399,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2026,0.831518406890486,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2027,0.819273695486349,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2028,0.807349491506149,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2029,0.795733958206559,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2030,0.784415820585413,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2031,0.773107748863181,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2032,0.762084555734482,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2033,0.751336223193134,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2034,0.740853184326007,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2035,0.730626298580063,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2036,0.720907258548646,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2037,0.71141495103288,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2038,0.702141933733583,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2039,0.69308107864205,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2040,0.684225555827121,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2041,0.677092093290743,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2042,0.670123437220881,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2043,0.663314383587789,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2044,0.656659937728777,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2045,0.650155304093758,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2046,0.645626201391388,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2047,0.641180690333555,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2048,0.636816552484445,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2049,0.632531645953927,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2050,0.628323902151976,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2051,0.62481404554696,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2052,0.621370129012273,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2053,0.617990443764053,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2054,0.614673337541311,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2055,0.611417212329211,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2056,0.607361676288519,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2057,0.603378493725335,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2058,0.599465852839481,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2059,0.595622000155452,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2060,0.591845238228353,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2061,0.58663519871136,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2062,0.581515327204222,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2063,0.576483366442044,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2064,0.571537132911328,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2065,0.566674513881272,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2066,0.562105700466677,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2067,0.557612730059307,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2068,0.553193784292841,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2069,0.54884710173618,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2070,0.544570975694973,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2071,0.539398775287214,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2072,0.534304447144109,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2073,0.529286234184103,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2074,0.524342431929768,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2075,0.519471386551802,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2076,0.514549325075459,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2077,0.509703071027589,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2078,0.504930842374712,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2079,0.500230912920039,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2080,0.495601610128767,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2081,0.490725641974757,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2082,0.485921022097055,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2083,0.481186119842002,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2084,0.476519354411085,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2085,0.471919192965508,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2086,0.465770494522928,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2087,0.459716110847401,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2088,0.453753906057672,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2089,0.447881808201588,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2090,0.442097806882507,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2091,0.43666785328902,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2092,0.431360294598345,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2093,0.426172311822599,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2094,0.421101169488871,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2095,0.416144212577375,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2096,0.41127380496119,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2097,0.406511218408919,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2098,0.401854026843899,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2099,0.401854026843899,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2100,0.401854026843899,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2200,0.401854026843899,"forestryLoss_growthFactor_SSP2"
+"Pennsylvania","PA",2300,0.401854026843899,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2013,1.03131297065778,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2014,1.01543401177571,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2015,1,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2016,0.980432012561408,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2017,0.961552991966916,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2018,0.943329034234328,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2019,0.925728371522636,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2020,0.90872120845348,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2021,0.891480316593052,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2022,0.874789656630623,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2023,0.858624926046659,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2024,0.842963191218646,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2025,0.827782793783997,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2026,0.814898359287745,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2027,0.80235968843117,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2028,0.790153782201181,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2029,0.778268267593494,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2030,0.766691360925533,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2031,0.754730977690892,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2032,0.743075716187623,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2033,0.73171478409076,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2034,0.720637876476372,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2035,0.709835149055286,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2036,0.69965474381047,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2037,0.689713617794348,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2038,0.680003890064489,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2039,0.67051801305664,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2040,0.661248755372034,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2041,0.651938588910089,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2042,0.642838989908307,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2043,0.633943367393174,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2044,0.625245394484946,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2045,0.616738995488321,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2046,0.610357637507003,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2047,0.604092294443626,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2048,0.597939910101278,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2049,0.591897533333224,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2050,0.585962313597716,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2051,0.58016964014831,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2052,0.574480409025558,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2053,0.568892001877095,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2054,0.563401885928861,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2055,0.558007610560067,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2056,0.552859002459747,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2057,0.54780015348193,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2058,0.542828840666739,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2059,0.537942912205232,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2060,0.533140284649554,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2061,0.528228958197559,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2062,0.523402865997307,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2063,0.518659871557215,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2064,0.513997908234492,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2065,0.509414976422657,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2066,0.504827025758318,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2067,0.500315000063215,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2068,0.495877081402582,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2069,0.491511508730002,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2070,0.487216575691327,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2071,0.483120997630675,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2072,0.479086995741647,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2073,0.475113181420148,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2074,0.471198207625358,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2075,0.467340767334405,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2076,0.463760572564273,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2077,0.460235381862988,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2078,0.456763903206457,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2079,0.453344885044682,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2080,0.449977114725491,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2081,0.446992161196295,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2082,0.444050566247769,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2083,0.441151340642699,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2084,0.438293525376822,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2085,0.435476190529505,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2086,0.431288268790398,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2087,0.427164683148787,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2088,0.42310397629129,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2089,0.419104734524974,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2090,0.415165586157784,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2091,0.405037244424274,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2092,0.395087341010749,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2093,0.385311836791678,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2094,0.375706812109792,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2095,0.366268462396799,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2096,0.35702440655601,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2097,0.347938649314043,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2098,0.339007649847493,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2099,0.339007649847493,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2100,0.339007649847493,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2200,0.339007649847493,"forestryLoss_growthFactor_SSP2"
+"Rhode Island","RI",2300,0.339007649847493,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2000,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2001,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2002,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2003,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2004,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2005,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2006,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2007,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2008,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2009,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2010,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2011,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2012,NA,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2013,0.985738910483781,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2014,0.99296553465154,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2015,1,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2016,1.0021866157423,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2017,1.0042821519735,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2018,1.00629139694019,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2019,1.0082188279016,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2020,1.0100686353177,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2021,1.00259933324821,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2022,0.995316501677538,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2023,0.988212919979872,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2024,0.981281746148382,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2025,0.974516491891608,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2026,0.970489932405888,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2027,0.966546664352947,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2028,0.962684007187088,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2029,0.958899397953135,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2030,0.95519038476978,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2031,0.946906612187453,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2032,0.938795136967972,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2033,0.930850496664592,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2034,0.923067461022728,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2035,0.915441019655976,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2036,0.913174438263582,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2037,0.91094783189081,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2038,0.908760082297761,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2039,0.906610114391058,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2040,0.9044968941074,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2041,0.897540423045207,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2042,0.890714455494089,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2043,0.88401525783023,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2044,0.877439239484101,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2045,0.87098294610435,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2046,0.874551578449011,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2047,0.878056990034341,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2048,0.881500824602631,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2049,0.884884669782647,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2050,0.888210059455378,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2051,0.875473654335847,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2052,0.862940160769118,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2053,0.850604741012616,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2054,0.838462710382277,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2055,0.826509531236115,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2056,0.82178674164959,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2057,0.817136364690254,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2058,0.812556726665044,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2059,0.808046205444316,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2060,0.803603228482907,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2061,0.803626132686728,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2062,0.803647194550326,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2063,0.803666476976119,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2064,0.803684040545307,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2065,0.80369994361662,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2066,0.796912637330494,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2067,0.790230633611783,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2068,0.783651482699704,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2069,0.777172810495662,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2070,0.770792315659958,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2071,0.764803728988574,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2072,0.758906603404862,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2073,0.753098863546639,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2074,0.74737849632321,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2075,0.741743548597856,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2076,0.741900897654948,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2077,0.742057088399799,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2078,0.742212139006913,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2079,0.742366067165383,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2080,0.742518890096829,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2081,0.736651032405549,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2082,0.730876832378714,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2083,0.725194107564184,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2084,0.719600742521462,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2085,0.714094686271588,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2086,0.714842550265922,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2087,0.715578694897767,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2088,0.716303386426263,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2089,0.717016883137145,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2090,0.71771943563881,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2091,0.722438076463609,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2092,0.727071790899258,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2093,0.731622504590927,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2094,0.736092086218423,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2095,0.740482349584364,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2096,0.744596106444362,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2097,0.748635163806856,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2098,0.752601195047699,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2099,0.752601195047699,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2100,0.752601195047699,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2200,0.752601195047699,"forestryLoss_growthFactor_SSP2"
+"South Carolina","SC",2300,0.752601195047699,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2000,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2001,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2002,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2003,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2004,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2005,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2006,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2007,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2008,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2009,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2010,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2011,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2012,NA,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2013,1.00083969019623,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2014,1.00042805186209,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2015,1,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2016,0.994927600210752,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2017,0.989992015615897,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2018,0.985187421490857,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2019,0.980508332525426,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2020,0.97594957788178,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2021,0.961539556146466,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2022,0.94750328741616,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2023,0.933825948709334,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2024,0.920493505355984,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2025,0.907492658725907,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2026,0.903186306940994,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2027,0.898962181633075,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2028,0.89481779836095,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2029,0.89075077684873,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2030,0.886758835385687,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2031,0.885418338320472,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2032,0.884085081806795,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2033,0.882759246110611,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2034,0.881440993340763,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2035,0.88013046874113,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2036,0.872103428602207,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2037,0.864227154674841,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2038,0.856497246690041,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2039,0.848909478670605,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2040,0.841459790249344,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2041,0.837955164566809,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2042,0.834498122209001,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2043,0.831087588534103,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2044,0.827722524228102,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2045,0.82440192376285,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2046,0.825460859819137,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2047,0.826494532045922,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2048,0.827503684624865,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2049,0.828489034756249,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2050,0.82945127383219,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2051,0.834297084752243,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2052,0.839048653042431,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2053,0.843708457971996,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2054,0.848278896187873,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2055,0.852762285055784,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2056,0.85330526625831,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2057,0.853821284421714,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2058,0.854311218313546,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2059,0.854775915035521,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2060,0.855216191340762,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2061,0.853076053879334,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2062,0.850958657493496,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2063,0.848863598815528,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2064,0.846790485026548,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2065,0.8447389334845,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2066,0.848045908318461,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2067,0.851289579658327,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2068,0.854471550709112,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2069,0.857593373287692,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2070,0.860656549827991,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2071,0.862153723590535,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2072,0.863630935707378,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2073,0.865088613386534,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2074,0.866527171321631,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2075,0.867947012153164,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2076,0.870143892975155,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2077,0.872318855844274,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2078,0.874472330700994,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2079,0.876604734806176,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2080,0.878716473225821,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2081,0.88257400019066,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2082,0.886400911745865,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2083,0.890197768695589,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2084,0.89396511564568,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2085,0.897703481611538,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2086,0.901032598426472,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2087,0.904304929124287,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2088,0.907521779521466,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2089,0.91068441625785,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2090,0.913794068251751,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2091,0.904660827715831,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2092,0.895341208255426,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2093,0.885840058311689,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2094,0.876162081157568,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2095,0.866311840225409,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2096,0.857032663383549,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2097,0.847554876034253,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2098,0.837883130574896,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2099,0.837883130574896,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2100,0.837883130574896,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2200,0.837883130574896,"forestryLoss_growthFactor_SSP2"
+"South Dakota","SD",2300,0.837883130574896,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2013,1.00657418414507,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2014,1.00324796678948,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2015,1,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2016,0.992211057779509,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2017,0.984669617965277,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2018,0.977364082056884,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2019,0.970283564676327,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2020,0.96341783960777,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2021,0.952245223810299,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2022,0.94138599389905,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2023,0.930827152978111,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2024,0.920556412856716,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2025,0.910562146399356,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2026,0.904769874222021,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2027,0.899115047894748,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2028,0.893592827689953,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2029,0.888198598596664,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2030,0.882927957423332,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2031,0.876815342540295,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2032,0.870837792040604,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2033,0.864990866534382,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2034,0.859270319366562,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2035,0.853672086261067,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2036,0.845899160470976,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2037,0.838288179852296,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2038,0.830834120078882,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2039,0.823532162876673,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2040,0.816377685558591,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2041,0.813674399576052,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2042,0.811023299935844,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2043,0.80842287037545,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2044,0.805871653202229,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2045,0.803368246482691,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2046,0.795119851023031,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2047,0.787013162206018,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2048,0.779044554985378,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2049,0.771210526994098,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2050,0.763507693396497,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2051,0.760782319378861,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2052,0.75810013698676,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2053,0.755460119570284,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2054,0.752861272905149,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2055,0.750302633919353,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2056,0.749699203700506,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2057,0.749104425943321,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2058,0.748518108884107,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2059,0.747940066519287,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2060,0.747370118387619,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2061,0.742386869594203,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2062,0.737484388737462,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2063,0.732660717416463,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2064,0.727913960209639,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2065,0.72324228215984,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2066,0.721955498508229,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2067,0.720687897891064,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2068,0.719439042529509,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2069,0.718208508043889,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2070,0.716995882941707,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2071,0.718078020754908,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2072,0.719143902575376,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2073,0.720193894868349,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2074,0.721228353131609,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2075,0.72224762230323,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2076,0.720489884504292,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2077,0.718761006973474,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2078,0.717060298482395,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2079,0.715387089579846,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2080,0.713740731742246,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2081,0.713030800974919,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2082,0.712333735109043,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2083,0.711649226800318,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2084,0.710976978191957,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2085,0.71031670055322,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2086,0.706386687983946,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2087,0.702515982288145,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2088,0.698703243763882,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2089,0.69494717279214,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2090,0.691246508348693,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2091,0.686319716057388,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2092,0.681446934456543,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2093,0.676627000401048,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2094,0.671858784982635,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2095,0.667141192275474,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2096,0.66234484358493,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2097,0.65760003140282,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2098,0.652905620922968,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2099,0.652905620922968,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2100,0.652905620922968,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2200,0.652905620922968,"forestryLoss_growthFactor_SSP2"
+"Tennessee","TN",2300,0.652905620922968,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2013,0.994208425718523,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2014,0.997186285717231,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2015,1,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2016,0.99801407427329,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2017,0.99600388297138,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2018,0.993972667112026,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2019,0.991923401341552,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2020,0.989858816746446,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2021,0.986558592971445,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2022,0.983256865553932,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2023,0.979955790572058,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2024,0.976657344826739,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2025,0.973363340152993,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2026,0.973893893398176,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2027,0.974356855742917,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2028,0.9747557394958,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2029,0.975093863043761,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2030,0.975374363024116,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2031,0.975184119871473,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2032,0.974940717869787,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2033,0.974646976355688,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2034,0.974305565784734,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2035,0.973919016542322,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2036,0.976233929857188,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2037,0.978460036516346,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2038,0.980600774601874,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2039,0.982659426006295,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2040,0.984639124784613,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2041,0.985490269055326,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2042,0.986281787631859,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2043,0.987016075456016,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2044,0.987695421652554,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2045,0.98832201493738,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2046,0.988596656214266,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2047,0.988855519076905,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2048,0.989099160278108,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2049,0.989328114918859,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2050,0.989542897421009,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2051,0.991251796670412,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2052,0.992913328741542,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2053,0.994528897596526,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2054,0.996099857835256,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2055,0.997627516746075,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2056,0.999368208136539,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2057,1.001062517196,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2058,1.00271178600569,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2059,1.00431731044713,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2060,1.00588034208293,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2061,1.00539732796828,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2062,1.00491085516573,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2063,1.00442114741696,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2064,1.00392841897915,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2065,1.00343287505025,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2066,1.00384534962258,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2067,1.00424229178749,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2068,1.00462416224633,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2069,1.00499140604608,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2070,1.00534445320547,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2071,1.00679045153921,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2072,1.00821631080646,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2073,1.00962247074313,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2074,1.01100935809446,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2075,1.01237738709546,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2076,1.01224451407423,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2077,1.0121208257041,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2078,1.01200605499005,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2079,1.01189994377705,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2080,1.0118022424004,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2081,1.01205572436901,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2082,1.01231816538606,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2083,1.01258929256927,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2084,1.01286884184407,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2085,1.01315655760488,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2086,1.01131768599879,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2087,1.00950434570453,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2088,1.00771596780036,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2089,1.00595200034984,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2090,1.00421190777141,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2091,0.987967285440644,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2092,0.97185815900554,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2093,0.955881734573869,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2094,0.940035300125796,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2095,0.924316222515426,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2096,0.908286333579488,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2097,0.892403354672226,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2098,0.876664074612678,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2099,0.876664074612678,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2100,0.876664074612678,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2200,0.876664074612678,"forestryLoss_growthFactor_SSP2"
+"Texas","TX",2300,0.876664074612678,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2013,0.996797140016506,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2014,0.99845942214891,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2015,1,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2016,0.996787329696314,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2017,0.993600108162798,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2018,0.990438988241076,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2019,0.987304523775874,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2020,0.98419717943552,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2021,0.98003827721128,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2022,0.975912611624261,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2023,0.971820660849973,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2024,0.967762822269917,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2025,0.963739419905686,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2026,0.962773929615656,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2027,0.961782591620323,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2028,0.960767319841278,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2029,0.959729911994869,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2030,0.958672057185533,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2031,0.957890893566889,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2032,0.957076364294598,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2033,0.956230512232491,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2034,0.955355268183324,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2035,0.954452457626029,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2036,0.953227130513143,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2037,0.951991060813753,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2038,0.950745192236089,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2039,0.949490416206938,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2040,0.948227574901842,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2041,0.950363351024031,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2042,0.952417159761798,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2043,0.954392007490604,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2044,0.956290771907653,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2045,0.958116208518393,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2046,0.959867049824058,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2047,0.961577269003195,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2048,0.963248051182993,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2049,0.964880538704712,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2050,0.966475832980227,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2051,0.968714122372512,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2052,0.970897781989168,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2053,0.973028372970686,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2054,0.975107402409944,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2055,0.977136325580641,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2056,0.977246145991424,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2057,0.97733761443223,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2058,0.977411383633274,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2059,0.97746808210807,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2060,0.977508315174013,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2061,0.976602319669293,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2062,0.975702272766867,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2063,0.974808138486094,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2064,0.973919880231651,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2065,0.973037460854086,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2066,0.973161975010996,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2067,0.973276752039699,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2068,0.973382103376658,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2069,0.97347832962133,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2070,0.973565720973687,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2071,0.972778553060174,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2072,0.972005306698805,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2073,0.971245649152986,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2074,0.970499257868793,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2075,0.969765820093077,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2076,0.964584246994078,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2077,0.959492727455261,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2078,0.954489071200238,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2079,0.949571157261784,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2080,0.944736931274591,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2081,0.944513190388169,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2082,0.944306660394794,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2083,0.944116872994335,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2084,0.943943374715599,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2085,0.943785726348249,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2086,0.940237559295704,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2087,0.936740914552707,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2088,0.933294635386807,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2089,0.929897599640938,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2090,0.926548718449959,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2091,0.909604952320835,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2092,0.892808900999506,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2093,0.876157494185143,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2094,0.859647751624358,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2095,0.84327677981308,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2096,0.82712796681398,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2097,0.811110371817375,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2098,0.795221145049138,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2099,0.795221145049138,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2100,0.795221145049138,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2200,0.795221145049138,"forestryLoss_growthFactor_SSP2"
+"Utah","UT",2300,0.795221145049138,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2013,0.999428513789658,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2014,0.99972139088843,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2015,1,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2016,0.995632594648193,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2017,0.991396762747256,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2018,0.987286511994084,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2019,0.983296212982414,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2020,0.97942057196234,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2021,0.969619981325238,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2022,0.960088963609643,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2023,0.950816457543017,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2024,0.941792001515496,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2025,0.933005693389361,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2026,0.926839706325286,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2027,0.920818385958205,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2028,0.914936672209543,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2029,0.909189739025072,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2030,0.903572980974728,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2031,0.894892357255951,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2032,0.886403733317829,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2033,0.878100794777708,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2034,0.869977501478947,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2035,0.862028072753767,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2036,0.857516171752,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2037,0.85309857069273,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2038,0.848772338941077,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2039,0.844534666161164,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2040,0.84038285620323,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2041,0.833037716654573,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2042,0.825838476028179,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2043,0.818780832336327,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2044,0.811860651031368,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2045,0.805073956939046,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2046,0.805139590189104,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2047,0.805204308644622,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2048,0.805268132761497,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2049,0.805331082357418,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2050,0.805393176637413,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2051,0.795636863380151,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2052,0.786038456829712,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2053,0.77659415851285,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2054,0.767300290740871,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2055,0.758153291848283,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2056,0.753471201629745,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2057,0.74886340630763,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2058,0.744328154316747,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2059,0.739863748672012,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2060,0.73546854486002,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2061,0.733684819579537,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2062,0.731930552247048,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2063,0.730205021802868,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2064,0.728507530486609,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2065,0.72683740290451,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2066,0.72085455379106,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2067,0.714966079682776,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2068,0.709169768140073,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2069,0.703463475298172,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2070,0.697845123231446,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2071,0.692724167449531,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2072,0.687681156649859,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2073,0.682714324517683,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2074,0.677821957708975,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2075,0.67300239387947,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2076,0.671512171947008,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2077,0.670045663782554,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2078,0.668602306483921,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2079,0.667181554837037,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2080,0.665782880626457,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2081,0.660709627288224,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2082,0.655714663600503,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2083,0.650796178461635,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2084,0.645952416290812,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2085,0.641181674915992,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2086,0.639624608337229,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2087,0.638091396950383,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2088,0.636581500622599,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2089,0.635094395387287,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2090,0.633629572843894,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2091,0.631127210262067,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2092,0.628672721439318,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2093,0.626265015839672,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2094,0.623903035201983,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2095,0.621585752356776,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2096,0.619075376529566,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2097,0.616614989463197,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2098,0.6142034688995,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2099,0.6142034688995,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2100,0.6142034688995,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2200,0.6142034688995,"forestryLoss_growthFactor_SSP2"
+"Virginia","VA",2300,0.6142034688995,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2013,1.01144434021614,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2014,1.00562127489857,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2015,1,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2016,0.989965854860801,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2017,0.980310519110741,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2018,0.971014797009355,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2019,0.962060719099135,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2020,0.953431447592897,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2021,0.934638238120343,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2022,0.916438011635666,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2023,0.89880471022032,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2024,0.881713740053991,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2025,0.865141871395595,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2026,0.850290804881761,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2027,0.835833743628622,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2028,0.82175595751901,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2029,0.80804342370575,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2030,0.794682785230876,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2031,0.782065306958067,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2032,0.769771439430169,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2033,0.757789708418297,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2034,0.746109158531869,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2035,0.73471932470702,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2036,0.724127550431382,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2037,0.713786830449715,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2038,0.703688864572753,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2039,0.693825704382736,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2040,0.684189735053417,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2041,0.681560808175624,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2042,0.679013583639096,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2043,0.676545212857577,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2044,0.674152966813762,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2045,0.671834230084733,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2046,0.671190118164387,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2047,0.67056418164512,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2048,0.669955857147794,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2049,0.669364602165617,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2050,0.66878989414706,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2051,0.670915546135943,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2052,0.673018592926899,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2053,0.675099419925134,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2054,0.677158403105607,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2055,0.679195909322022,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2056,0.677927778814264,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2057,0.676690279337115,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2058,0.675482549505166,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2059,0.674303757227434,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2060,0.67315309852188,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2061,0.666948177287075,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2062,0.660851178123731,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2063,0.654859393090686,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2064,0.648970202821696,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2065,0.643181072958075,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2066,0.638951812357113,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2067,0.634794012567887,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2068,0.630705947534759,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2069,0.626685945424499,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2070,0.622732386529436,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2071,0.615275168591026,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2072,0.607930511966089,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2073,0.600695874289977,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2074,0.593568789342793,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2075,0.586546864217627,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2076,0.578793284790204,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2077,0.571160018650764,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2078,0.563644231136872,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2079,0.556243176464483,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2080,0.548954194265654,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2081,0.539699017172176,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2082,0.530581714292945,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2083,0.521599121377744,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2084,0.512748171008999,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2085,0.504025888919569,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2086,0.492887223943702,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2087,0.481919143227189,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2088,0.471117784607038,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2089,0.460479401514359,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2090,0.450000358682546,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2091,0.460267615055821,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2092,0.470441925133374,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2093,0.480525233425635,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2094,0.490519427375004,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2095,0.500426339446185,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2096,0.510207454426462,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2097,0.519895253224183,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2098,0.529491779588902,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2099,0.529491779588902,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2100,0.529491779588902,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2200,0.529491779588902,"forestryLoss_growthFactor_SSP2"
+"Vermont","VT",2300,0.529491779588902,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2013,0.98638922524118,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2014,0.993294671626723,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2015,1,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2016,1.00185173359884,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2017,1.00360877645479,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2018,1.00527642924392,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2019,1.00685963920277,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2020,1.00836302796203,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2021,1.00076564683456,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2022,0.993342837616268,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2023,0.986088217920722,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2024,0.978995728110582,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2025,0.972059610522201,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2026,0.969046305006795,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2027,0.96608316820664,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2028,0.963168872798419,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2029,0.96030214112634,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2030,0.957481742755844,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2031,0.952875663715042,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2032,0.948350484818295,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2033,0.943903937141633,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2034,0.939533840628797,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2035,0.935238099611579,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2036,0.931217129017427,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2037,0.927266126666246,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2038,0.923383154158688,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2039,0.91956634742202,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2040,0.915813913077875,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2041,0.920752134419125,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2042,0.925576928243856,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2043,0.930291867728638,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2044,0.934900382451717,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2045,0.939405765422487,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2046,0.947115954857158,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2047,0.954689178327271,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2048,0.962129001983913,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2049,0.969438870147261,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2050,0.976622110445035,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2051,0.973468697466846,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2052,0.970358552496604,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2053,0.967290739010408,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2054,0.964264348403696,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2055,0.961278498931987,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2056,0.951132191998219,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2057,0.941138449675306,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2058,0.931293786895039,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2059,0.921594825217399,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2060,0.912038288754735,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2061,0.912288079209815,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2062,0.912529166888544,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2063,0.912761820486475,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2064,0.912986299114337,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2065,0.913202852699965,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2066,0.909190910494948,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2067,0.905238560505164,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2068,0.901344445222135,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2069,0.897507248650945,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2070,0.89372569472467,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2071,0.890635347433553,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2072,0.887592738580526,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2073,0.88459678012758,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2074,0.881646416740042,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2075,0.87874062456865,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2076,0.874980792329303,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2077,0.871283703462245,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2078,0.867647848423793,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2079,0.864071765290301,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2080,0.860554037899778,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2081,0.856756901725169,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2082,0.853024359975113,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2083,0.849354887781783,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2084,0.845747007229574,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2085,0.842199285567245,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2086,0.83860649931854,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2087,0.835067157709781,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2088,0.831580056185918,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2089,0.828144026218624,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2090,0.824757933968828,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2091,0.828009087715397,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2092,0.831161208608833,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2093,0.834216614049263,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2094,0.837177552681449,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2095,0.84004620691587,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2096,0.842542288172438,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2097,0.844956500769776,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2098,0.847290698914536,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2099,0.847290698914536,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2100,0.847290698914536,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2200,0.847290698914536,"forestryLoss_growthFactor_SSP2"
+"Washington","WA",2300,0.847290698914536,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2013,1.02024006294097,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2014,1.00997844861915,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2015,1,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2016,0.985707600738385,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2017,0.97190860326549,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2018,0.958578940690663,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2019,0.945696055992352,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2020,0.933238786576992,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2021,0.918573248300216,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2022,0.904361322255414,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2023,0.890583255643087,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2024,0.877220400475952,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2025,0.864255138282757,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2026,0.85196876762514,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2027,0.839999513870984,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2028,0.828335684299775,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2029,0.816966143441429,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2030,0.805880280609374,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2031,0.794578378105176,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2032,0.783554345396232,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2033,0.772798523289554,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2034,0.762301684934869,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2035,0.752055012196351,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2036,0.743910212413521,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2037,0.73595492214778,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2038,0.728182928398056,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2039,0.720588280382744,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2040,0.713165276017125,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2041,0.705966865341027,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2042,0.69893135254936,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2043,0.6920536375715,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2044,0.685328824714016,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2045,0.678752212669849,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2046,0.674673239015339,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2047,0.670669623856111,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2048,0.666739366293198,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2049,0.662880534484371,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2050,0.659091262715719,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2051,0.65730040788813,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2052,0.655546951330074,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2053,0.653829880494727,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2054,0.652148217046764,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2055,0.650501015468994,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2056,0.643859686918666,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2057,0.637330928348431,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2058,0.630911990612676,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2059,0.624600211908711,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2060,0.618393014365914,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2061,0.613349043259954,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2062,0.608392291309542,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2063,0.603520575939204,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2064,0.598731785870791,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2065,0.594023878253827,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2066,0.585966306763644,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2067,0.578039029573922,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2068,0.570238958032457,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2069,0.562563099706379,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2070,0.555008554675365,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2071,0.551665524104778,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2072,0.548372791692362,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2073,0.545129222836821,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2074,0.541933716901294,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2075,0.538785205950496,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2076,0.532827006083075,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2077,0.526961383285842,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2078,0.521186155507243,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2079,0.515499209120153,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2080,0.509898496256285,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2081,0.506653013998152,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2082,0.503453460300059,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2083,0.500298793868639,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2084,0.497188005189457,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2085,0.494120115319296,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2086,0.493329768143791,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2087,0.492552358258711,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2088,0.491787589861405,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2089,0.491035176016022,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2090,0.49029483832422,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2091,0.484381548696863,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2092,0.478598403744222,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2093,0.472942410442501,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2094,0.467410664426589,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2095,0.462000346739669,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2096,0.456747722031662,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2097,0.451606204514907,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2098,0.446573296521892,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2099,0.446573296521892,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2100,0.446573296521892,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2200,0.446573296521892,"forestryLoss_growthFactor_SSP2"
+"Wisconsin","WI",2300,0.446573296521892,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2000,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2001,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2002,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2003,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2004,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2005,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2006,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2007,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2008,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2009,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2010,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2011,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2012,NA,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2013,1.00916039263991,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2014,1.00449092379835,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2015,1,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2016,0.991068543683842,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2017,0.982484312366243,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2018,0.974229507228753,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2019,0.966287472500776,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2020,0.958642607040119,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2021,0.939549811538198,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2022,0.921059024789796,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2023,0.903143800699929,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2024,0.885779178847002,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2025,0.868941582998265,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2026,0.85428970618553,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2027,0.840023922883456,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2028,0.826129847134665,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2029,0.812593782485952,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2030,0.799402681687485,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2031,0.787596523956195,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2032,0.776089781196997,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2033,0.764871891625607,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2034,0.753932769788629,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2035,0.743262780424609,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2036,0.733661793576577,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2037,0.724285662002493,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2038,0.715126991844066,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2039,0.706178701764889,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2040,0.697434006821313,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2041,0.697082236864397,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2042,0.696760035382462,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2043,0.696466193900032,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2044,0.696199557638838,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2045,0.69595902276685,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2046,0.697337140853129,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2047,0.698696831916049,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2048,0.700038494675906,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2049,0.701362515693092,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2050,0.702669269847914,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2051,0.706897541641863,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2052,0.711066625653571,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2053,0.715177821536245,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2054,0.719232389830509,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2055,0.723231553457056,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2056,0.723129237438701,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2057,0.723037242454656,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2058,0.722955209939618,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2059,0.722882794531711,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2060,0.722819663517883,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2061,0.716877504095278,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2062,0.711037821292082,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2063,0.705298053909801,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2064,0.699655724365152,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2065,0.694108435325647,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2066,0.690439809362511,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2067,0.686832770433235,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2068,0.683285834976386,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2069,0.679797565979889,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2070,0.676366571181869,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2071,0.668719705315455,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2072,0.66118846933402,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2073,0.653770249717045,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2074,0.646462511241821,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2075,0.6392627940713,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2076,0.631095748008751,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2077,0.623056173465627,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2078,0.615141061852823,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2079,0.607347498961791,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2080,0.599672661287354,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2081,0.589722052294676,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2082,0.579921416942746,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2083,0.570267304107396,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2084,0.560756368338462,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2085,0.551385365840845,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2086,0.539516642640867,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2087,0.52782922623152,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2088,0.516319013272594,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2089,0.504982023228991,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2090,0.493814393811215,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2091,0.507049470125058,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2092,0.52013434065707,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2093,0.533072255057734,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2094,0.545866367281156,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2095,0.558519739091466,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2096,0.570932971425671,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2097,0.583203372139034,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2098,0.595334095150281,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2099,0.595334095150281,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2100,0.595334095150281,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2200,0.595334095150281,"forestryLoss_growthFactor_SSP2"
+"West Virginia","WV",2300,0.595334095150281,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2000,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2001,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2002,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2003,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2004,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2005,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2006,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2007,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2008,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2009,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2010,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2011,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2012,NA,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2013,1.00054427614511,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2014,1.00027134878646,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2015,1,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2016,0.995100346460276,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2017,0.990351578789362,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2018,0.985746741879247,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2019,0.981279304558794,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2020,0.976943127661563,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2021,0.966648188982135,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2022,0.956634267092213,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2023,0.9468898800255,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2024,0.93740416682933,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2025,0.928166845996736,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2026,0.921078267549684,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2027,0.914152875258545,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2028,0.907385026376656,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2029,0.900769337344771,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2030,0.894300669010614,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2031,0.890107651034125,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2032,0.886001723043174,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2033,0.881980126397956,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2034,0.878040219658004,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2035,0.874179472363585,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2036,0.865946054354708,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2037,0.857880320842882,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2038,0.849977134313267,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2039,0.842231566501942,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2040,0.83463888780818,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2041,0.842422721065298,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2042,0.850044749310851,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2043,0.857509850754451,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2044,0.864822711616484,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2045,0.871987835429728,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2046,0.87044991056955,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2047,0.86893548350434,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2048,0.867443993604326,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2049,0.865974898469815,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2050,0.864527673183164,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2051,0.868935074478525,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2052,0.8732644219468,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2053,0.877517683380991,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2054,0.881696762392968,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2055,0.885803500979242,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2056,0.88502924404827,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2057,0.884260043309396,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2058,0.883495875348206,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2059,0.882736715792281,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2060,0.881982539385241,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2061,0.88034714251275,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2062,0.878734346518235,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2063,0.877143651790627,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2064,0.875574573993526,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2065,0.874026643471343,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2066,0.875973890713274,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2067,0.877887303758695,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2068,0.879767709144422,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2069,0.881615907313759,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2070,0.883432673627824,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2071,0.877093784555505,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2072,0.870852195419116,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2073,0.864705694032247,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2074,0.858652134636573,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2075,0.852689435428911,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2076,0.831632920818913,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2077,0.810916062519956,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2078,0.79053076622234,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2079,0.770469192256488,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2080,0.750723745663594,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2081,0.749780585183423,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2082,0.748859274178225,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2083,0.747959269999568,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2084,0.747080046885053,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2085,0.746221095313841,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2086,0.741235169932764,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2087,0.736323686357794,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2088,0.731484965815011,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2089,0.726717379745073,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2090,0.722019347939009,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2091,0.717174759579073,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2092,0.712349206454269,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2093,0.707542377902388,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2094,0.702753972113413,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2095,0.697983695806224,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2096,0.693216024784685,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2097,0.688463455826491,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2098,0.683725690191818,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2099,0.683725690191818,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2100,0.683725690191818,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2200,0.683725690191818,"forestryLoss_growthFactor_SSP2"
+"Wyoming","WY",2300,0.683725690191818,"forestryLoss_growthFactor_SSP2"

--- a/inst/extdata/fredi/scalars/Scalar_damageAdj_forestryLoss_growthFactor_SSP5.csv
+++ b/inst/extdata/fredi/scalars/Scalar_damageAdj_forestryLoss_growthFactor_SSP5.csv
@@ -1,4901 +1,5048 @@
-state,postal,year,value,scalarName
-Alabama,AL,2000,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2001,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2002,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2003,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2004,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2005,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2006,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2007,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2008,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2009,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2010,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2011,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2012,NA,forestryLoss_growthFactor_SSP5
-Alabama,AL,2013,0.97301413,forestryLoss_growthFactor_SSP5
-Alabama,AL,2014,0.986631222,forestryLoss_growthFactor_SSP5
-Alabama,AL,2015,1,forestryLoss_growthFactor_SSP5
-Alabama,AL,2016,1.007311591,forestryLoss_growthFactor_SSP5
-Alabama,AL,2017,1.014429178,forestryLoss_growthFactor_SSP5
-Alabama,AL,2018,1.021360737,forestryLoss_growthFactor_SSP5
-Alabama,AL,2019,1.028113795,forestryLoss_growthFactor_SSP5
-Alabama,AL,2020,1.034695463,forestryLoss_growthFactor_SSP5
-Alabama,AL,2021,1.034386914,forestryLoss_growthFactor_SSP5
-Alabama,AL,2022,1.034130968,forestryLoss_growthFactor_SSP5
-Alabama,AL,2023,1.033923639,forestryLoss_growthFactor_SSP5
-Alabama,AL,2024,1.033761257,forestryLoss_growthFactor_SSP5
-Alabama,AL,2025,1.033640442,forestryLoss_growthFactor_SSP5
-Alabama,AL,2026,1.008756993,forestryLoss_growthFactor_SSP5
-Alabama,AL,2027,0.984731858,forestryLoss_growthFactor_SSP5
-Alabama,AL,2028,0.961522004,forestryLoss_growthFactor_SSP5
-Alabama,AL,2029,0.9390872,forestryLoss_growthFactor_SSP5
-Alabama,AL,2030,0.917389798,forestryLoss_growthFactor_SSP5
-Alabama,AL,2031,0.921598415,forestryLoss_growthFactor_SSP5
-Alabama,AL,2032,0.925687095,forestryLoss_growthFactor_SSP5
-Alabama,AL,2033,0.929661101,forestryLoss_growthFactor_SSP5
-Alabama,AL,2034,0.933525382,forestryLoss_growthFactor_SSP5
-Alabama,AL,2035,0.937284597,forestryLoss_growthFactor_SSP5
-Alabama,AL,2036,0.932506367,forestryLoss_growthFactor_SSP5
-Alabama,AL,2037,0.927909668,forestryLoss_growthFactor_SSP5
-Alabama,AL,2038,0.923484984,forestryLoss_growthFactor_SSP5
-Alabama,AL,2039,0.919223429,forestryLoss_growthFactor_SSP5
-Alabama,AL,2040,0.915116702,forestryLoss_growthFactor_SSP5
-Alabama,AL,2041,0.91852246,forestryLoss_growthFactor_SSP5
-Alabama,AL,2042,0.921848505,forestryLoss_growthFactor_SSP5
-Alabama,AL,2043,0.9250977,forestryLoss_growthFactor_SSP5
-Alabama,AL,2044,0.928272765,forestryLoss_growthFactor_SSP5
-Alabama,AL,2045,0.931376291,forestryLoss_growthFactor_SSP5
-Alabama,AL,2046,0.913608123,forestryLoss_growthFactor_SSP5
-Alabama,AL,2047,0.896365922,forestryLoss_growthFactor_SSP5
-Alabama,AL,2048,0.879626992,forestryLoss_growthFactor_SSP5
-Alabama,AL,2049,0.863369915,forestryLoss_growthFactor_SSP5
-Alabama,AL,2050,0.847574456,forestryLoss_growthFactor_SSP5
-Alabama,AL,2051,0.86234873,forestryLoss_growthFactor_SSP5
-Alabama,AL,2052,0.876744774,forestryLoss_growthFactor_SSP5
-Alabama,AL,2053,0.890777088,forestryLoss_growthFactor_SSP5
-Alabama,AL,2054,0.904459435,forestryLoss_growthFactor_SSP5
-Alabama,AL,2055,0.917804885,forestryLoss_growthFactor_SSP5
-Alabama,AL,2056,0.925186328,forestryLoss_growthFactor_SSP5
-Alabama,AL,2057,0.932393441,forestryLoss_growthFactor_SSP5
-Alabama,AL,2058,0.93943244,forestryLoss_growthFactor_SSP5
-Alabama,AL,2059,0.946309246,forestryLoss_growthFactor_SSP5
-Alabama,AL,2060,0.953029497,forestryLoss_growthFactor_SSP5
-Alabama,AL,2061,0.969165661,forestryLoss_growthFactor_SSP5
-Alabama,AL,2062,0.984863372,forestryLoss_growthFactor_SSP5
-Alabama,AL,2063,1.000140536,forestryLoss_growthFactor_SSP5
-Alabama,AL,2064,1.015014083,forestryLoss_growthFactor_SSP5
-Alabama,AL,2065,1.029500039,forestryLoss_growthFactor_SSP5
-Alabama,AL,2066,1.037474383,forestryLoss_growthFactor_SSP5
-Alabama,AL,2067,1.045251578,forestryLoss_growthFactor_SSP5
-Alabama,AL,2068,1.052839145,forestryLoss_growthFactor_SSP5
-Alabama,AL,2069,1.060244217,forestryLoss_growthFactor_SSP5
-Alabama,AL,2070,1.067473561,forestryLoss_growthFactor_SSP5
-Alabama,AL,2071,1.075643804,forestryLoss_growthFactor_SSP5
-Alabama,AL,2072,1.0835759,forestryLoss_growthFactor_SSP5
-Alabama,AL,2073,1.091280158,forestryLoss_growthFactor_SSP5
-Alabama,AL,2074,1.098766298,forestryLoss_growthFactor_SSP5
-Alabama,AL,2075,1.106043493,forestryLoss_growthFactor_SSP5
-Alabama,AL,2076,1.095003281,forestryLoss_growthFactor_SSP5
-Alabama,AL,2077,1.084299457,forestryLoss_growthFactor_SSP5
-Alabama,AL,2078,1.073916923,forestryLoss_growthFactor_SSP5
-Alabama,AL,2079,1.063841466,forestryLoss_growthFactor_SSP5
-Alabama,AL,2080,1.054059703,forestryLoss_growthFactor_SSP5
-Alabama,AL,2081,1.043461491,forestryLoss_growthFactor_SSP5
-Alabama,AL,2082,1.033188198,forestryLoss_growthFactor_SSP5
-Alabama,AL,2083,1.02322512,forestryLoss_growthFactor_SSP5
-Alabama,AL,2084,1.013558423,forestryLoss_growthFactor_SSP5
-Alabama,AL,2085,1.004175088,forestryLoss_growthFactor_SSP5
-Alabama,AL,2086,0.999147729,forestryLoss_growthFactor_SSP5
-Alabama,AL,2087,0.994277835,forestryLoss_growthFactor_SSP5
-Alabama,AL,2088,0.989558142,forestryLoss_growthFactor_SSP5
-Alabama,AL,2089,0.984981828,forestryLoss_growthFactor_SSP5
-Alabama,AL,2090,0.980542476,forestryLoss_growthFactor_SSP5
-Alabama,AL,2091,0.980288017,forestryLoss_growthFactor_SSP5
-Alabama,AL,2092,0.980060418,forestryLoss_growthFactor_SSP5
-Alabama,AL,2093,0.979858114,forestryLoss_growthFactor_SSP5
-Alabama,AL,2094,0.979679645,forestryLoss_growthFactor_SSP5
-Alabama,AL,2095,0.979523642,forestryLoss_growthFactor_SSP5
-Alabama,AL,2096,0.977790068,forestryLoss_growthFactor_SSP5
-Alabama,AL,2097,0.97612774,forestryLoss_growthFactor_SSP5
-Alabama,AL,2098,0.974533035,forestryLoss_growthFactor_SSP5
-Alabama,AL,2099,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2000,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2001,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2002,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2003,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2004,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2005,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2006,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2007,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2008,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2009,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2010,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2011,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2012,NA,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2013,0.96751228,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2014,0.983917644,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2015,1,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2016,1.00993815,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2017,1.019584571,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2018,1.028952277,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2019,1.038053504,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2020,1.046899767,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2021,1.048587284,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2022,1.050245341,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2023,1.051874487,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2024,1.053475274,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2025,1.055048257,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2026,1.030202994,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2027,1.006197517,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2028,0.982990276,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2029,0.960542404,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2030,0.938817504,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2031,0.945034389,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2032,0.951051664,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2033,0.956878943,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2034,0.962525228,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2035,0.967998953,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2036,0.964577366,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2037,0.961276672,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2038,0.958090777,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2039,0.955013979,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2040,0.952040944,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2041,0.95733982,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2042,0.962481445,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2043,0.967472813,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2044,0.972320507,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2045,0.977030723,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2046,0.959377133,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2047,0.942226923,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2048,0.925558934,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2049,0.90935317,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2050,0.893590724,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2051,0.910777809,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2052,0.927501711,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2053,0.943780939,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2054,0.959633028,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2055,0.975074604,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2056,0.984169015,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2057,0.993019345,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2058,1.001635332,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2059,1.010026201,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2060,1.018200698,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2061,1.036512468,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2062,1.054301379,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2063,1.07158956,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2064,1.088397906,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2065,1.104746166,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2066,1.114104517,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2067,1.123194715,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2068,1.132028181,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2069,1.140615696,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2070,1.148967442,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2071,1.1584024,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2072,1.167559313,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2073,1.176450295,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2074,1.185086767,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2075,1.193479505,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2076,1.182207511,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2077,1.171276685,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2078,1.160671767,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2079,1.150378393,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2080,1.140383032,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2081,1.129482535,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2082,1.11891571,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2083,1.108667467,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2084,1.098723611,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2085,1.089070779,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2086,1.084073985,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2087,1.079232831,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2088,1.074540154,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2089,1.069989225,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2090,1.065573716,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2091,1.065355467,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2092,1.065141564,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2093,1.064931848,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2094,1.064726165,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2095,1.064524371,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2096,1.062603037,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2097,1.060740559,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2098,1.058934159,forestryLoss_growthFactor_SSP5
-Arkansas,AR,2099,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2000,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2001,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2002,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2003,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2004,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2005,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2006,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2007,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2008,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2009,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2010,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2011,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2012,NA,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2013,1.006504264,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2014,1.003260753,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2015,1,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2016,0.991003968,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2017,0.982218062,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2018,0.973634683,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2019,0.965246613,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2020,0.957046988,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2021,0.947699521,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2022,0.938578005,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2023,0.929674239,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2024,0.920980416,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2025,0.912489106,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2026,0.903485871,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2027,0.894710981,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2028,0.886155636,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2029,0.87781149,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2030,0.86967063,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2031,0.862862406,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2032,0.856245485,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2033,0.849811576,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2034,0.843552878,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2035,0.837462041,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2036,0.829228508,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2037,0.82121613,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2038,0.813415751,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2039,0.805818731,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2040,0.79841691,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2041,0.791854563,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2042,0.7854534,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2043,0.779207327,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2044,0.773110563,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2045,0.767157623,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2046,0.75911913,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2047,0.751268381,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2048,0.743598737,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2049,0.736103875,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2050,0.728777769,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2051,0.724747271,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2052,0.720794313,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2053,0.716916755,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2054,0.71311253,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2055,0.709379642,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2056,0.699899774,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2057,0.690644148,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2058,0.681604754,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2059,0.672773967,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2060,0.664144521,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2061,0.65552848,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2062,0.647124489,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2063,0.638924568,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2064,0.630921143,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2065,0.62310702,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2066,0.611175238,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2067,0.599533208,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2068,0.588170044,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2069,0.577075418,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2070,0.566239522,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2071,0.562985957,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2072,0.559823777,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2073,0.556749117,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2074,0.55375833,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2075,0.550847971,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2076,0.540139,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2077,0.529751302,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2078,0.519670574,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2079,0.509883353,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2080,0.500376951,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2081,0.494497021,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2082,0.488796578,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2083,0.483267516,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2084,0.477902208,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2085,0.472693476,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2086,0.467699983,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2087,0.462861253,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2088,0.458170179,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2089,0.453620082,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2090,0.449204682,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2091,0.435432132,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2092,0.422078261,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2093,0.40912376,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2094,0.396550503,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2095,0.384341454,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2096,0.371852171,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2097,0.359754966,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2098,0.348031214,forestryLoss_growthFactor_SSP5
-Arizona,AZ,2099,NA,forestryLoss_growthFactor_SSP5
-California,CA,2000,NA,forestryLoss_growthFactor_SSP5
-California,CA,2001,NA,forestryLoss_growthFactor_SSP5
-California,CA,2002,NA,forestryLoss_growthFactor_SSP5
-California,CA,2003,NA,forestryLoss_growthFactor_SSP5
-California,CA,2004,NA,forestryLoss_growthFactor_SSP5
-California,CA,2005,NA,forestryLoss_growthFactor_SSP5
-California,CA,2006,NA,forestryLoss_growthFactor_SSP5
-California,CA,2007,NA,forestryLoss_growthFactor_SSP5
-California,CA,2008,NA,forestryLoss_growthFactor_SSP5
-California,CA,2009,NA,forestryLoss_growthFactor_SSP5
-California,CA,2010,NA,forestryLoss_growthFactor_SSP5
-California,CA,2011,NA,forestryLoss_growthFactor_SSP5
-California,CA,2012,NA,forestryLoss_growthFactor_SSP5
-California,CA,2013,1.009732686,forestryLoss_growthFactor_SSP5
-California,CA,2014,1.004825909,forestryLoss_growthFactor_SSP5
-California,CA,2015,1,forestryLoss_growthFactor_SSP5
-California,CA,2016,0.989540314,forestryLoss_growthFactor_SSP5
-California,CA,2017,0.979394397,forestryLoss_growthFactor_SSP5
-California,CA,2018,0.969548031,forestryLoss_growthFactor_SSP5
-California,CA,2019,0.959987857,forestryLoss_growthFactor_SSP5
-California,CA,2020,0.950701311,forestryLoss_growthFactor_SSP5
-California,CA,2021,0.937786684,forestryLoss_growthFactor_SSP5
-California,CA,2022,0.925279793,forestryLoss_growthFactor_SSP5
-California,CA,2023,0.913161438,forestryLoss_growthFactor_SSP5
-California,CA,2024,0.901413615,forestryLoss_growthFactor_SSP5
-California,CA,2025,0.890019422,forestryLoss_growthFactor_SSP5
-California,CA,2026,0.877902208,forestryLoss_growthFactor_SSP5
-California,CA,2027,0.866174245,forestryLoss_growthFactor_SSP5
-California,CA,2028,0.85481694,forestryLoss_growthFactor_SSP5
-California,CA,2029,0.843812873,forestryLoss_growthFactor_SSP5
-California,CA,2030,0.833145705,forestryLoss_growthFactor_SSP5
-California,CA,2031,0.824366646,forestryLoss_growthFactor_SSP5
-California,CA,2032,0.815880751,forestryLoss_growthFactor_SSP5
-California,CA,2033,0.807673517,forestryLoss_growthFactor_SSP5
-California,CA,2034,0.799731383,forestryLoss_growthFactor_SSP5
-California,CA,2035,0.792041656,forestryLoss_growthFactor_SSP5
-California,CA,2036,0.782267423,forestryLoss_growthFactor_SSP5
-California,CA,2037,0.772809642,forestryLoss_growthFactor_SSP5
-California,CA,2038,0.763653184,forestryLoss_growthFactor_SSP5
-California,CA,2039,0.75478387,forestryLoss_growthFactor_SSP5
-California,CA,2040,0.746188395,forestryLoss_growthFactor_SSP5
-California,CA,2041,0.735349274,forestryLoss_growthFactor_SSP5
-California,CA,2042,0.724851555,forestryLoss_growthFactor_SSP5
-California,CA,2043,0.71467942,forestryLoss_growthFactor_SSP5
-California,CA,2044,0.704818015,forestryLoss_growthFactor_SSP5
-California,CA,2045,0.695253369,forestryLoss_growthFactor_SSP5
-California,CA,2046,0.686849702,forestryLoss_growthFactor_SSP5
-California,CA,2047,0.678691364,forestryLoss_growthFactor_SSP5
-California,CA,2048,0.67076787,forestryLoss_growthFactor_SSP5
-California,CA,2049,0.663069319,forestryLoss_growthFactor_SSP5
-California,CA,2050,0.655586355,forestryLoss_growthFactor_SSP5
-California,CA,2051,0.647872836,forestryLoss_growthFactor_SSP5
-California,CA,2052,0.64038216,forestryLoss_growthFactor_SSP5
-California,CA,2053,0.633104961,forestryLoss_growthFactor_SSP5
-California,CA,2054,0.626032383,forestryLoss_growthFactor_SSP5
-California,CA,2055,0.61915605,forestryLoss_growthFactor_SSP5
-California,CA,2056,0.610446754,forestryLoss_growthFactor_SSP5
-California,CA,2057,0.601994986,forestryLoss_growthFactor_SSP5
-California,CA,2058,0.593789732,forestryLoss_growthFactor_SSP5
-California,CA,2059,0.585820589,forestryLoss_growthFactor_SSP5
-California,CA,2060,0.578077724,forestryLoss_growthFactor_SSP5
-California,CA,2061,0.567927955,forestryLoss_growthFactor_SSP5
-California,CA,2062,0.558091667,forestryLoss_growthFactor_SSP5
-California,CA,2063,0.548554899,forestryLoss_growthFactor_SSP5
-California,CA,2064,0.539304495,forestryLoss_growthFactor_SSP5
-California,CA,2065,0.530328047,forestryLoss_growthFactor_SSP5
-California,CA,2066,0.518700246,forestryLoss_growthFactor_SSP5
-California,CA,2067,0.507446184,forestryLoss_growthFactor_SSP5
-California,CA,2068,0.49654881,forestryLoss_growthFactor_SSP5
-California,CA,2069,0.485992073,forestryLoss_growthFactor_SSP5
-California,CA,2070,0.475760851,forestryLoss_growthFactor_SSP5
-California,CA,2071,0.469130355,forestryLoss_growthFactor_SSP5
-California,CA,2072,0.46269877,forestryLoss_growthFactor_SSP5
-California,CA,2073,0.456457338,forestryLoss_growthFactor_SSP5
-California,CA,2074,0.450397806,forestryLoss_growthFactor_SSP5
-California,CA,2075,0.444512389,forestryLoss_growthFactor_SSP5
-California,CA,2076,0.441392873,forestryLoss_growthFactor_SSP5
-California,CA,2077,0.438370968,forestryLoss_growthFactor_SSP5
-California,CA,2078,0.435442232,forestryLoss_growthFactor_SSP5
-California,CA,2079,0.432602488,forestryLoss_growthFactor_SSP5
-California,CA,2080,0.429847801,forestryLoss_growthFactor_SSP5
-California,CA,2081,0.420645745,forestryLoss_growthFactor_SSP5
-California,CA,2082,0.411726154,forestryLoss_growthFactor_SSP5
-California,CA,2083,0.403076237,forestryLoss_growthFactor_SSP5
-California,CA,2084,0.394683963,forestryLoss_growthFactor_SSP5
-California,CA,2085,0.386538005,forestryLoss_growthFactor_SSP5
-California,CA,2086,0.38396865,forestryLoss_growthFactor_SSP5
-California,CA,2087,0.381480728,forestryLoss_growthFactor_SSP5
-California,CA,2088,0.379070465,forestryLoss_growthFactor_SSP5
-California,CA,2089,0.376734317,forestryLoss_growthFactor_SSP5
-California,CA,2090,0.37446895,forestryLoss_growthFactor_SSP5
-California,CA,2091,0.36084807,forestryLoss_growthFactor_SSP5
-California,CA,2092,0.347695173,forestryLoss_growthFactor_SSP5
-California,CA,2093,0.334987756,forestryLoss_growthFactor_SSP5
-California,CA,2094,0.322704716,forestryLoss_growthFactor_SSP5
-California,CA,2095,0.310826237,forestryLoss_growthFactor_SSP5
-California,CA,2096,0.29878938,forestryLoss_growthFactor_SSP5
-California,CA,2097,0.287176615,forestryLoss_growthFactor_SSP5
-California,CA,2098,0.275967137,forestryLoss_growthFactor_SSP5
-California,CA,2099,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2000,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2001,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2002,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2003,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2004,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2005,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2006,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2007,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2008,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2009,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2010,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2011,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2012,NA,forestryLoss_growthFactor_SSP5
-Colorado,CO,2013,0.998307165,forestryLoss_growthFactor_SSP5
-Colorado,CO,2014,0.999236055,forestryLoss_growthFactor_SSP5
-Colorado,CO,2015,1,forestryLoss_growthFactor_SSP5
-Colorado,CO,2016,0.994865177,forestryLoss_growthFactor_SSP5
-Colorado,CO,2017,0.989763817,forestryLoss_growthFactor_SSP5
-Colorado,CO,2018,0.984698286,forestryLoss_growthFactor_SSP5
-Colorado,CO,2019,0.979670649,forestryLoss_growthFactor_SSP5
-Colorado,CO,2020,0.974682693,forestryLoss_growthFactor_SSP5
-Colorado,CO,2021,0.968477023,forestryLoss_growthFactor_SSP5
-Colorado,CO,2022,0.962334276,forestryLoss_growthFactor_SSP5
-Colorado,CO,2023,0.956256171,forestryLoss_growthFactor_SSP5
-Colorado,CO,2024,0.95024411,forestryLoss_growthFactor_SSP5
-Colorado,CO,2025,0.944299206,forestryLoss_growthFactor_SSP5
-Colorado,CO,2026,0.938557219,forestryLoss_growthFactor_SSP5
-Colorado,CO,2027,0.932877209,forestryLoss_growthFactor_SSP5
-Colorado,CO,2028,0.92726045,forestryLoss_growthFactor_SSP5
-Colorado,CO,2029,0.92170794,forestryLoss_growthFactor_SSP5
-Colorado,CO,2030,0.916220442,forestryLoss_growthFactor_SSP5
-Colorado,CO,2031,0.912438295,forestryLoss_growthFactor_SSP5
-Colorado,CO,2032,0.908709173,forestryLoss_growthFactor_SSP5
-Colorado,CO,2033,0.905032839,forestryLoss_growthFactor_SSP5
-Colorado,CO,2034,0.901408968,forestryLoss_growthFactor_SSP5
-Colorado,CO,2035,0.897837164,forestryLoss_growthFactor_SSP5
-Colorado,CO,2036,0.89189997,forestryLoss_growthFactor_SSP5
-Colorado,CO,2037,0.8860677,forestryLoss_growthFactor_SSP5
-Colorado,CO,2038,0.880338061,forestryLoss_growthFactor_SSP5
-Colorado,CO,2039,0.874708795,forestryLoss_growthFactor_SSP5
-Colorado,CO,2040,0.869177677,forestryLoss_growthFactor_SSP5
-Colorado,CO,2041,0.865943754,forestryLoss_growthFactor_SSP5
-Colorado,CO,2042,0.862725683,forestryLoss_growthFactor_SSP5
-Colorado,CO,2043,0.859525324,forestryLoss_growthFactor_SSP5
-Colorado,CO,2044,0.856344319,forestryLoss_growthFactor_SSP5
-Colorado,CO,2045,0.853184115,forestryLoss_growthFactor_SSP5
-Colorado,CO,2046,0.846448377,forestryLoss_growthFactor_SSP5
-Colorado,CO,2047,0.839820651,forestryLoss_growthFactor_SSP5
-Colorado,CO,2048,0.833298938,forestryLoss_growthFactor_SSP5
-Colorado,CO,2049,0.826881245,forestryLoss_growthFactor_SSP5
-Colorado,CO,2050,0.820565593,forestryLoss_growthFactor_SSP5
-Colorado,CO,2051,0.820868531,forestryLoss_growthFactor_SSP5
-Colorado,CO,2052,0.821089074,forestryLoss_growthFactor_SSP5
-Colorado,CO,2053,0.821232802,forestryLoss_growthFactor_SSP5
-Colorado,CO,2054,0.821304911,forestryLoss_growthFactor_SSP5
-Colorado,CO,2055,0.821310237,forestryLoss_growthFactor_SSP5
-Colorado,CO,2056,0.812564239,forestryLoss_growthFactor_SSP5
-Colorado,CO,2057,0.803976203,forestryLoss_growthFactor_SSP5
-Colorado,CO,2058,0.795542209,forestryLoss_growthFactor_SSP5
-Colorado,CO,2059,0.787258449,forestryLoss_growthFactor_SSP5
-Colorado,CO,2060,0.779121219,forestryLoss_growthFactor_SSP5
-Colorado,CO,2061,0.77204759,forestryLoss_growthFactor_SSP5
-Colorado,CO,2062,0.7651018,forestryLoss_growthFactor_SSP5
-Colorado,CO,2063,0.758280609,forestryLoss_growthFactor_SSP5
-Colorado,CO,2064,0.751580874,forestryLoss_growthFactor_SSP5
-Colorado,CO,2065,0.744999546,forestryLoss_growthFactor_SSP5
-Colorado,CO,2066,0.734455531,forestryLoss_growthFactor_SSP5
-Colorado,CO,2067,0.724117252,forestryLoss_growthFactor_SSP5
-Colorado,CO,2068,0.713978635,forestryLoss_growthFactor_SSP5
-Colorado,CO,2069,0.70403385,forestryLoss_growthFactor_SSP5
-Colorado,CO,2070,0.694277295,forestryLoss_growthFactor_SSP5
-Colorado,CO,2071,0.690932099,forestryLoss_growthFactor_SSP5
-Colorado,CO,2072,0.68767816,forestryLoss_growthFactor_SSP5
-Colorado,CO,2073,0.684511695,forestryLoss_growthFactor_SSP5
-Colorado,CO,2074,0.681429126,forestryLoss_growthFactor_SSP5
-Colorado,CO,2075,0.678427074,forestryLoss_growthFactor_SSP5
-Colorado,CO,2076,0.661835735,forestryLoss_growthFactor_SSP5
-Colorado,CO,2077,0.645741513,forestryLoss_growthFactor_SSP5
-Colorado,CO,2078,0.630122289,forestryLoss_growthFactor_SSP5
-Colorado,CO,2079,0.614957246,forestryLoss_growthFactor_SSP5
-Colorado,CO,2080,0.600226765,forestryLoss_growthFactor_SSP5
-Colorado,CO,2081,0.592387748,forestryLoss_growthFactor_SSP5
-Colorado,CO,2082,0.584787638,forestryLoss_growthFactor_SSP5
-Colorado,CO,2083,0.577415653,forestryLoss_growthFactor_SSP5
-Colorado,CO,2084,0.57026165,forestryLoss_growthFactor_SSP5
-Colorado,CO,2085,0.56331608,forestryLoss_growthFactor_SSP5
-Colorado,CO,2086,0.557336323,forestryLoss_growthFactor_SSP5
-Colorado,CO,2087,0.551541287,forestryLoss_growthFactor_SSP5
-Colorado,CO,2088,0.545922502,forestryLoss_growthFactor_SSP5
-Colorado,CO,2089,0.540472007,forestryLoss_growthFactor_SSP5
-Colorado,CO,2090,0.535182316,forestryLoss_growthFactor_SSP5
-Colorado,CO,2091,0.520250014,forestryLoss_growthFactor_SSP5
-Colorado,CO,2092,0.505755349,forestryLoss_growthFactor_SSP5
-Colorado,CO,2093,0.491678417,forestryLoss_growthFactor_SSP5
-Colorado,CO,2094,0.478000526,forestryLoss_growthFactor_SSP5
-Colorado,CO,2095,0.4647041,forestryLoss_growthFactor_SSP5
-Colorado,CO,2096,0.45099188,forestryLoss_growthFactor_SSP5
-Colorado,CO,2097,0.437697927,forestryLoss_growthFactor_SSP5
-Colorado,CO,2098,0.424802544,forestryLoss_growthFactor_SSP5
-Colorado,CO,2099,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2000,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2001,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2002,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2003,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2004,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2005,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2006,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2007,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2008,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2009,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2010,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2011,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2012,NA,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2013,1.032321696,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2014,1.015916676,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2015,1,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2016,0.978900492,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2017,0.958601967,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2018,0.939062716,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2019,0.920243777,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2020,0.902108714,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2021,0.882385598,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2022,0.863435251,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2023,0.845215999,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2024,0.827689004,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2025,0.810818033,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2026,0.793308799,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2027,0.776487174,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2028,0.76031599,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2029,0.744760617,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2030,0.729788756,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2031,0.715889843,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2032,0.702522617,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2033,0.689658573,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2034,0.677271154,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2035,0.665335592,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2036,0.652350782,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2037,0.639855274,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2038,0.627823526,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2039,0.616231685,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2040,0.605057457,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2041,0.59369421,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2042,0.5827489,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2043,0.572200355,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2044,0.562028761,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2045,0.552215554,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2046,0.543075254,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2047,0.534252518,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2048,0.525732276,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2049,0.517500357,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2050,0.509543424,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2051,0.501475344,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2052,0.493678437,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2053,0.486140212,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2054,0.478848898,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2055,0.471793403,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2056,0.462667157,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2057,0.453843656,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2058,0.445309025,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2059,0.437050195,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2060,0.429054845,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2061,0.421036146,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2062,0.413295296,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2063,0.405819102,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2064,0.398595164,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2065,0.391611815,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2066,0.380086084,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2067,0.368959407,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2068,0.35821287,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2069,0.347828687,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2070,0.337790128,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2071,0.333426594,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2072,0.329196256,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2073,0.325093191,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2074,0.321111819,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2075,0.31724688,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2076,0.313303413,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2077,0.309482831,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2078,0.305779555,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2079,0.302188335,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2080,0.298704228,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2081,0.294649467,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2082,0.290719662,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2083,0.286909143,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2084,0.283212579,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2085,0.279624951,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2086,0.276147163,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2087,0.272779123,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2088,0.269515754,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2089,0.266352286,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2090,0.263284235,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2091,0.254813787,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2092,0.246642534,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2093,0.238755965,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2094,0.231140475,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2095,0.223783291,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2096,0.216368814,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2097,0.209217987,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2098,0.202317845,forestryLoss_growthFactor_SSP5
-Connecticut,CT,2099,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2000,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2001,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2002,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2003,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2004,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2005,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2006,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2007,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2008,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2009,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2010,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2011,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2012,NA,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2013,0.990855483,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2014,0.995598224,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2015,1,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2016,0.998315592,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2017,0.99646844,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2018,0.994472786,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2019,0.992341728,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2020,0.99008732,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2021,0.98761812,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2022,0.985008422,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2023,0.982272536,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2024,0.979423528,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2025,0.976473336,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2026,0.973462218,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2027,0.970341178,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2028,0.96712261,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2029,0.9638178,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2030,0.960437037,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2031,0.959270337,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2032,0.958011351,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2033,0.956668921,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2034,0.955251128,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2035,0.953765366,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2036,0.950845358,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2037,0.947851417,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2038,0.944792337,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2039,0.941676142,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2040,0.938510158,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2041,0.935281047,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2042,0.931975035,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2043,0.928601069,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2044,0.925167339,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2045,0.921681344,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2046,0.918794799,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2047,0.915809858,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2048,0.912736117,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2049,0.909582429,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2050,0.906356956,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2051,0.902764767,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2052,0.899097986,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2053,0.895364877,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2054,0.891573056,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2055,0.887729542,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2056,0.880400995,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2057,0.873077969,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2058,0.86576618,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2059,0.858470799,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2060,0.851196503,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2061,0.840730754,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2062,0.830399426,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2063,0.820201643,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2064,0.810136395,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2065,0.80020255,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2066,0.7811796,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2067,0.762521298,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2068,0.744217144,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2069,0.726257047,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2070,0.7086313,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2071,0.706044857,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2072,0.703520612,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2073,0.701056219,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2074,0.698649453,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2075,0.696298205,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2076,0.693845346,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2077,0.691451843,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2078,0.689115392,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2079,0.686833816,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2080,0.684605051,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2081,0.68232202,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2082,0.68010526,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2083,0.677951848,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2084,0.675859037,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2085,0.673824234,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2086,0.669964264,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2087,0.666218844,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2088,0.662582811,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2089,0.65905131,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2090,0.655619774,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2091,0.634834885,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2092,0.614578783,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2093,0.59482884,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2094,0.575563775,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2095,0.556763548,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2096,0.537215686,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2097,0.518212119,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2098,0.499727974,forestryLoss_growthFactor_SSP5
-District of Columbia,DC,2099,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2000,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2001,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2002,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2003,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2004,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2005,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2006,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2007,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2008,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2009,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2010,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2011,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2012,NA,forestryLoss_growthFactor_SSP5
-Delaware,DE,2013,1.011476586,forestryLoss_growthFactor_SSP5
-Delaware,DE,2014,1.005691281,forestryLoss_growthFactor_SSP5
-Delaware,DE,2015,1,forestryLoss_growthFactor_SSP5
-Delaware,DE,2016,0.98869275,forestryLoss_growthFactor_SSP5
-Delaware,DE,2017,0.977721273,forestryLoss_growthFactor_SSP5
-Delaware,DE,2018,0.967070463,forestryLoss_growthFactor_SSP5
-Delaware,DE,2019,0.956726123,forestryLoss_growthFactor_SSP5
-Delaware,DE,2020,0.946674899,forestryLoss_growthFactor_SSP5
-Delaware,DE,2021,0.934070759,forestryLoss_growthFactor_SSP5
-Delaware,DE,2022,0.921864051,forestryLoss_growthFactor_SSP5
-Delaware,DE,2023,0.910036077,forestryLoss_growthFactor_SSP5
-Delaware,DE,2024,0.898569304,forestryLoss_growthFactor_SSP5
-Delaware,DE,2025,0.887447272,forestryLoss_growthFactor_SSP5
-Delaware,DE,2026,0.875588533,forestryLoss_growthFactor_SSP5
-Delaware,DE,2027,0.864112013,forestryLoss_growthFactor_SSP5
-Delaware,DE,2028,0.85299941,forestryLoss_growthFactor_SSP5
-Delaware,DE,2029,0.84223358,forestryLoss_growthFactor_SSP5
-Delaware,DE,2030,0.831798443,forestryLoss_growthFactor_SSP5
-Delaware,DE,2031,0.822083534,forestryLoss_growthFactor_SSP5
-Delaware,DE,2032,0.812694618,forestryLoss_growthFactor_SSP5
-Delaware,DE,2033,0.803615514,forestryLoss_growthFactor_SSP5
-Delaware,DE,2034,0.794831099,forestryLoss_growthFactor_SSP5
-Delaware,DE,2035,0.786327219,forestryLoss_growthFactor_SSP5
-Delaware,DE,2036,0.776379593,forestryLoss_growthFactor_SSP5
-Delaware,DE,2037,0.766756349,forestryLoss_growthFactor_SSP5
-Delaware,DE,2038,0.757441906,forestryLoss_growthFactor_SSP5
-Delaware,DE,2039,0.748421665,forestryLoss_growthFactor_SSP5
-Delaware,DE,2040,0.73968193,forestryLoss_growthFactor_SSP5
-Delaware,DE,2041,0.730798739,forestryLoss_growthFactor_SSP5
-Delaware,DE,2042,0.722196915,forestryLoss_growthFactor_SSP5
-Delaware,DE,2043,0.713863378,forestryLoss_growthFactor_SSP5
-Delaware,DE,2044,0.70578584,forestryLoss_growthFactor_SSP5
-Delaware,DE,2045,0.697952751,forestryLoss_growthFactor_SSP5
-Delaware,DE,2046,0.691207488,forestryLoss_growthFactor_SSP5
-Delaware,DE,2047,0.684659207,forestryLoss_growthFactor_SSP5
-Delaware,DE,2048,0.678299487,forestryLoss_growthFactor_SSP5
-Delaware,DE,2049,0.672120375,forestryLoss_growthFactor_SSP5
-Delaware,DE,2050,0.666114359,forestryLoss_growthFactor_SSP5
-Delaware,DE,2051,0.659596853,forestryLoss_growthFactor_SSP5
-Delaware,DE,2052,0.653264846,forestryLoss_growthFactor_SSP5
-Delaware,DE,2053,0.647110623,forestryLoss_growthFactor_SSP5
-Delaware,DE,2054,0.641126884,forestryLoss_growthFactor_SSP5
-Delaware,DE,2055,0.635306722,forestryLoss_growthFactor_SSP5
-Delaware,DE,2056,0.625997659,forestryLoss_growthFactor_SSP5
-Delaware,DE,2057,0.616951492,forestryLoss_growthFactor_SSP5
-Delaware,DE,2058,0.608157326,forestryLoss_growthFactor_SSP5
-Delaware,DE,2059,0.59960486,forestryLoss_growthFactor_SSP5
-Delaware,DE,2060,0.591284338,forestryLoss_growthFactor_SSP5
-Delaware,DE,2061,0.583499125,forestryLoss_growthFactor_SSP5
-Delaware,DE,2062,0.57594558,forestryLoss_growthFactor_SSP5
-Delaware,DE,2063,0.568613624,forestryLoss_growthFactor_SSP5
-Delaware,DE,2064,0.561493751,forestryLoss_growthFactor_SSP5
-Delaware,DE,2065,0.554576984,forestryLoss_growthFactor_SSP5
-Delaware,DE,2066,0.540759081,forestryLoss_growthFactor_SSP5
-Delaware,DE,2067,0.527350402,forestryLoss_growthFactor_SSP5
-Delaware,DE,2068,0.514333146,forestryLoss_growthFactor_SSP5
-Delaware,DE,2069,0.501690527,forestryLoss_growthFactor_SSP5
-Delaware,DE,2070,0.489406699,forestryLoss_growthFactor_SSP5
-Delaware,DE,2071,0.484107292,forestryLoss_growthFactor_SSP5
-Delaware,DE,2072,0.478964981,forestryLoss_growthFactor_SSP5
-Delaware,DE,2073,0.473972897,forestryLoss_growthFactor_SSP5
-Delaware,DE,2074,0.469124566,forestryLoss_growthFactor_SSP5
-Delaware,DE,2075,0.464413879,forestryLoss_growthFactor_SSP5
-Delaware,DE,2076,0.459814623,forestryLoss_growthFactor_SSP5
-Delaware,DE,2077,0.455355111,forestryLoss_growthFactor_SSP5
-Delaware,DE,2078,0.451029078,forestryLoss_growthFactor_SSP5
-Delaware,DE,2079,0.446830631,forestryLoss_growthFactor_SSP5
-Delaware,DE,2080,0.442754216,forestryLoss_growthFactor_SSP5
-Delaware,DE,2081,0.43753856,forestryLoss_growthFactor_SSP5
-Delaware,DE,2082,0.432482717,forestryLoss_growthFactor_SSP5
-Delaware,DE,2083,0.427579457,forestryLoss_growthFactor_SSP5
-Delaware,DE,2084,0.422821978,forestryLoss_growthFactor_SSP5
-Delaware,DE,2085,0.418203878,forestryLoss_growthFactor_SSP5
-Delaware,DE,2086,0.41398901,forestryLoss_growthFactor_SSP5
-Delaware,DE,2087,0.409905877,forestryLoss_growthFactor_SSP5
-Delaware,DE,2088,0.405948407,forestryLoss_growthFactor_SSP5
-Delaware,DE,2089,0.402110898,forestryLoss_growthFactor_SSP5
-Delaware,DE,2090,0.398387985,forestryLoss_growthFactor_SSP5
-Delaware,DE,2091,0.387088295,forestryLoss_growthFactor_SSP5
-Delaware,DE,2092,0.376158689,forestryLoss_growthFactor_SSP5
-Delaware,DE,2093,0.365581649,forestryLoss_growthFactor_SSP5
-Delaware,DE,2094,0.355340735,forestryLoss_growthFactor_SSP5
-Delaware,DE,2095,0.345420508,forestryLoss_growthFactor_SSP5
-Delaware,DE,2096,0.335207117,forestryLoss_growthFactor_SSP5
-Delaware,DE,2097,0.325338137,forestryLoss_growthFactor_SSP5
-Delaware,DE,2098,0.315796867,forestryLoss_growthFactor_SSP5
-Delaware,DE,2099,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2000,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2001,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2002,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2003,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2004,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2005,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2006,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2007,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2008,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2009,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2010,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2011,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2012,NA,forestryLoss_growthFactor_SSP5
-Florida,FL,2013,0.995410709,forestryLoss_growthFactor_SSP5
-Florida,FL,2014,0.997785047,forestryLoss_growthFactor_SSP5
-Florida,FL,2015,1,forestryLoss_growthFactor_SSP5
-Florida,FL,2016,0.996312082,forestryLoss_growthFactor_SSP5
-Florida,FL,2017,0.992644464,forestryLoss_growthFactor_SSP5
-Florida,FL,2018,0.988999135,forestryLoss_growthFactor_SSP5
-Florida,FL,2019,0.985377845,forestryLoss_growthFactor_SSP5
-Florida,FL,2020,0.981782124,forestryLoss_growthFactor_SSP5
-Florida,FL,2021,0.973514532,forestryLoss_growthFactor_SSP5
-Florida,FL,2022,0.965418073,forestryLoss_growthFactor_SSP5
-Florida,FL,2023,0.957487855,forestryLoss_growthFactor_SSP5
-Florida,FL,2024,0.949719145,forestryLoss_growthFactor_SSP5
-Florida,FL,2025,0.942107364,forestryLoss_growthFactor_SSP5
-Florida,FL,2026,0.93684093,forestryLoss_growthFactor_SSP5
-Florida,FL,2027,0.931660715,forestryLoss_growthFactor_SSP5
-Florida,FL,2028,0.926565468,forestryLoss_growthFactor_SSP5
-Florida,FL,2029,0.921553887,forestryLoss_growthFactor_SSP5
-Florida,FL,2030,0.91662463,forestryLoss_growthFactor_SSP5
-Florida,FL,2031,0.910553183,forestryLoss_growthFactor_SSP5
-Florida,FL,2032,0.904636616,forestryLoss_growthFactor_SSP5
-Florida,FL,2033,0.898868825,forestryLoss_growthFactor_SSP5
-Florida,FL,2034,0.893244036,forestryLoss_growthFactor_SSP5
-Florida,FL,2035,0.887756784,forestryLoss_growthFactor_SSP5
-Florida,FL,2036,0.879948637,forestryLoss_growthFactor_SSP5
-Florida,FL,2037,0.872335977,forestryLoss_growthFactor_SSP5
-Florida,FL,2038,0.864911248,forestryLoss_growthFactor_SSP5
-Florida,FL,2039,0.857667293,forestryLoss_growthFactor_SSP5
-Florida,FL,2040,0.850597329,forestryLoss_growthFactor_SSP5
-Florida,FL,2041,0.844066903,forestryLoss_growthFactor_SSP5
-Florida,FL,2042,0.837686806,forestryLoss_growthFactor_SSP5
-Florida,FL,2043,0.831451742,forestryLoss_growthFactor_SSP5
-Florida,FL,2044,0.825356673,forestryLoss_growthFactor_SSP5
-Florida,FL,2045,0.819396795,forestryLoss_growthFactor_SSP5
-Florida,FL,2046,0.81604704,forestryLoss_growthFactor_SSP5
-Florida,FL,2047,0.812745583,forestryLoss_growthFactor_SSP5
-Florida,FL,2048,0.809491823,forestryLoss_growthFactor_SSP5
-Florida,FL,2049,0.80628513,forestryLoss_growthFactor_SSP5
-Florida,FL,2050,0.80312486,forestryLoss_growthFactor_SSP5
-Florida,FL,2051,0.790908907,forestryLoss_growthFactor_SSP5
-Florida,FL,2052,0.778985115,forestryLoss_growthFactor_SSP5
-Florida,FL,2053,0.767342952,forestryLoss_growthFactor_SSP5
-Florida,FL,2054,0.755972392,forestryLoss_growthFactor_SSP5
-Florida,FL,2055,0.744863887,forestryLoss_growthFactor_SSP5
-Florida,FL,2056,0.737858586,forestryLoss_growthFactor_SSP5
-Florida,FL,2057,0.731001792,forestryLoss_growthFactor_SSP5
-Florida,FL,2058,0.724288807,forestryLoss_growthFactor_SSP5
-Florida,FL,2059,0.717715131,forestryLoss_growthFactor_SSP5
-Florida,FL,2060,0.711276449,forestryLoss_growthFactor_SSP5
-Florida,FL,2061,0.702281729,forestryLoss_growthFactor_SSP5
-Florida,FL,2062,0.693505571,forestryLoss_growthFactor_SSP5
-Florida,FL,2063,0.684939845,forestryLoss_growthFactor_SSP5
-Florida,FL,2064,0.676576831,forestryLoss_growthFactor_SSP5
-Florida,FL,2065,0.668409193,forestryLoss_growthFactor_SSP5
-Florida,FL,2066,0.65537144,forestryLoss_growthFactor_SSP5
-Florida,FL,2067,0.642657152,forestryLoss_growthFactor_SSP5
-Florida,FL,2068,0.630253951,forestryLoss_growthFactor_SSP5
-Florida,FL,2069,0.6181501,forestryLoss_growthFactor_SSP5
-Florida,FL,2070,0.606334467,forestryLoss_growthFactor_SSP5
-Florida,FL,2071,0.601445519,forestryLoss_growthFactor_SSP5
-Florida,FL,2072,0.596696963,forestryLoss_growthFactor_SSP5
-Florida,FL,2073,0.592082779,forestryLoss_growthFactor_SSP5
-Florida,FL,2074,0.587597285,forestryLoss_growthFactor_SSP5
-Florida,FL,2075,0.583235121,forestryLoss_growthFactor_SSP5
-Florida,FL,2076,0.577980929,forestryLoss_growthFactor_SSP5
-Florida,FL,2077,0.572883288,forestryLoss_growthFactor_SSP5
-Florida,FL,2078,0.567935253,forestryLoss_growthFactor_SSP5
-Florida,FL,2079,0.563130288,forestryLoss_growthFactor_SSP5
-Florida,FL,2080,0.558462232,forestryLoss_growthFactor_SSP5
-Florida,FL,2081,0.55381021,forestryLoss_growthFactor_SSP5
-Florida,FL,2082,0.549300172,forestryLoss_growthFactor_SSP5
-Florida,FL,2083,0.544925707,forestryLoss_growthFactor_SSP5
-Florida,FL,2084,0.540680782,forestryLoss_growthFactor_SSP5
-Florida,FL,2085,0.536559719,forestryLoss_growthFactor_SSP5
-Florida,FL,2086,0.531723401,forestryLoss_growthFactor_SSP5
-Florida,FL,2087,0.527037084,forestryLoss_growthFactor_SSP5
-Florida,FL,2088,0.522493879,forestryLoss_growthFactor_SSP5
-Florida,FL,2089,0.51808731,forestryLoss_growthFactor_SSP5
-Florida,FL,2090,0.513811288,forestryLoss_growthFactor_SSP5
-Florida,FL,2091,0.503949383,forestryLoss_growthFactor_SSP5
-Florida,FL,2092,0.494389466,forestryLoss_growthFactor_SSP5
-Florida,FL,2093,0.485117574,forestryLoss_growthFactor_SSP5
-Florida,FL,2094,0.476120597,forestryLoss_growthFactor_SSP5
-Florida,FL,2095,0.467386217,forestryLoss_growthFactor_SSP5
-Florida,FL,2096,0.457980178,forestryLoss_growthFactor_SSP5
-Florida,FL,2097,0.448880099,forestryLoss_growthFactor_SSP5
-Florida,FL,2098,0.440071291,forestryLoss_growthFactor_SSP5
-Florida,FL,2099,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2000,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2001,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2002,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2003,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2004,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2005,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2006,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2007,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2008,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2009,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2010,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2011,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2012,NA,forestryLoss_growthFactor_SSP5
-Georgia,GA,2013,0.976183779,forestryLoss_growthFactor_SSP5
-Georgia,GA,2014,0.988238617,forestryLoss_growthFactor_SSP5
-Georgia,GA,2015,1,forestryLoss_growthFactor_SSP5
-Georgia,GA,2016,1.005672393,forestryLoss_growthFactor_SSP5
-Georgia,GA,2017,1.011131871,forestryLoss_growthFactor_SSP5
-Georgia,GA,2018,1.016389459,forestryLoss_growthFactor_SSP5
-Georgia,GA,2019,1.02145546,forestryLoss_growthFactor_SSP5
-Georgia,GA,2020,1.026339507,forestryLoss_growthFactor_SSP5
-Georgia,GA,2021,1.015461856,forestryLoss_growthFactor_SSP5
-Georgia,GA,2022,1.004907415,forestryLoss_growthFactor_SSP5
-Georgia,GA,2023,0.994661677,forestryLoss_growthFactor_SSP5
-Georgia,GA,2024,0.984711004,forestryLoss_growthFactor_SSP5
-Georgia,GA,2025,0.975042564,forestryLoss_growthFactor_SSP5
-Georgia,GA,2026,0.97636833,forestryLoss_growthFactor_SSP5
-Georgia,GA,2027,0.977619067,forestryLoss_growthFactor_SSP5
-Georgia,GA,2028,0.978799481,forestryLoss_growthFactor_SSP5
-Georgia,GA,2029,0.97991393,forestryLoss_growthFactor_SSP5
-Georgia,GA,2030,0.980966454,forestryLoss_growthFactor_SSP5
-Georgia,GA,2031,0.974644605,forestryLoss_growthFactor_SSP5
-Georgia,GA,2032,0.968517963,forestryLoss_growthFactor_SSP5
-Georgia,GA,2033,0.962577389,forestryLoss_growthFactor_SSP5
-Georgia,GA,2034,0.956814316,forestryLoss_growthFactor_SSP5
-Georgia,GA,2035,0.951220704,forestryLoss_growthFactor_SSP5
-Georgia,GA,2036,0.943119615,forestryLoss_growthFactor_SSP5
-Georgia,GA,2037,0.935259305,forestryLoss_growthFactor_SSP5
-Georgia,GA,2038,0.927628935,forestryLoss_growthFactor_SSP5
-Georgia,GA,2039,0.920218316,forestryLoss_growthFactor_SSP5
-Georgia,GA,2040,0.913017865,forestryLoss_growthFactor_SSP5
-Georgia,GA,2041,0.910548559,forestryLoss_growthFactor_SSP5
-Georgia,GA,2042,0.908135532,forestryLoss_growthFactor_SSP5
-Georgia,GA,2043,0.905776823,forestryLoss_growthFactor_SSP5
-Georgia,GA,2044,0.903470568,forestryLoss_growthFactor_SSP5
-Georgia,GA,2045,0.901214987,forestryLoss_growthFactor_SSP5
-Georgia,GA,2046,0.909105782,forestryLoss_growthFactor_SSP5
-Georgia,GA,2047,0.916756535,forestryLoss_growthFactor_SSP5
-Georgia,GA,2048,0.92417779,forestryLoss_growthFactor_SSP5
-Georgia,GA,2049,0.931379495,forestryLoss_growthFactor_SSP5
-Georgia,GA,2050,0.938371036,forestryLoss_growthFactor_SSP5
-Georgia,GA,2051,0.914069451,forestryLoss_growthFactor_SSP5
-Georgia,GA,2052,0.89041416,forestryLoss_growthFactor_SSP5
-Georgia,GA,2053,0.8673796,forestryLoss_growthFactor_SSP5
-Georgia,GA,2054,0.844941546,forestryLoss_growthFactor_SSP5
-Georgia,GA,2055,0.82307702,forestryLoss_growthFactor_SSP5
-Georgia,GA,2056,0.823647549,forestryLoss_growthFactor_SSP5
-Georgia,GA,2057,0.824187494,forestryLoss_growthFactor_SSP5
-Georgia,GA,2058,0.824698551,forestryLoss_growthFactor_SSP5
-Georgia,GA,2059,0.825182306,forestryLoss_growthFactor_SSP5
-Georgia,GA,2060,0.825640242,forestryLoss_growthFactor_SSP5
-Georgia,GA,2061,0.822146225,forestryLoss_growthFactor_SSP5
-Georgia,GA,2062,0.818735965,forestryLoss_growthFactor_SSP5
-Georgia,GA,2063,0.815406387,forestryLoss_growthFactor_SSP5
-Georgia,GA,2064,0.812154568,forestryLoss_growthFactor_SSP5
-Georgia,GA,2065,0.808977728,forestryLoss_growthFactor_SSP5
-Georgia,GA,2066,0.804624685,forestryLoss_growthFactor_SSP5
-Georgia,GA,2067,0.800369847,forestryLoss_growthFactor_SSP5
-Georgia,GA,2068,0.796209773,forestryLoss_growthFactor_SSP5
-Georgia,GA,2069,0.792141185,forestryLoss_growthFactor_SSP5
-Georgia,GA,2070,0.788160963,forestryLoss_growthFactor_SSP5
-Georgia,GA,2071,0.779427006,forestryLoss_growthFactor_SSP5
-Georgia,GA,2072,0.77094837,forestryLoss_growthFactor_SSP5
-Georgia,GA,2073,0.762713983,forestryLoss_growthFactor_SSP5
-Georgia,GA,2074,0.754713407,forestryLoss_growthFactor_SSP5
-Georgia,GA,2075,0.746936792,forestryLoss_growthFactor_SSP5
-Georgia,GA,2076,0.738441644,forestryLoss_growthFactor_SSP5
-Georgia,GA,2077,0.730202203,forestryLoss_growthFactor_SSP5
-Georgia,GA,2078,0.722207065,forestryLoss_growthFactor_SSP5
-Georgia,GA,2079,0.714445494,forestryLoss_growthFactor_SSP5
-Georgia,GA,2080,0.706907377,forestryLoss_growthFactor_SSP5
-Georgia,GA,2081,0.70032227,forestryLoss_growthFactor_SSP5
-Georgia,GA,2082,0.693938499,forestryLoss_growthFactor_SSP5
-Georgia,GA,2083,0.687746962,forestryLoss_growthFactor_SSP5
-Georgia,GA,2084,0.681739102,forestryLoss_growthFactor_SSP5
-Georgia,GA,2085,0.675906857,forestryLoss_growthFactor_SSP5
-Georgia,GA,2086,0.670316416,forestryLoss_growthFactor_SSP5
-Georgia,GA,2087,0.664899793,forestryLoss_growthFactor_SSP5
-Georgia,GA,2088,0.659648996,forestryLoss_growthFactor_SSP5
-Georgia,GA,2089,0.654556513,forestryLoss_growthFactor_SSP5
-Georgia,GA,2090,0.649615284,forestryLoss_growthFactor_SSP5
-Georgia,GA,2091,0.656684786,forestryLoss_growthFactor_SSP5
-Georgia,GA,2092,0.663521098,forestryLoss_growthFactor_SSP5
-Georgia,GA,2093,0.670135284,forestryLoss_growthFactor_SSP5
-Georgia,GA,2094,0.676537727,forestryLoss_growthFactor_SSP5
-Georgia,GA,2095,0.682738178,forestryLoss_growthFactor_SSP5
-Georgia,GA,2096,0.687616668,forestryLoss_growthFactor_SSP5
-Georgia,GA,2097,0.692328799,forestryLoss_growthFactor_SSP5
-Georgia,GA,2098,0.696882661,forestryLoss_growthFactor_SSP5
-Georgia,GA,2099,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2000,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2001,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2002,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2003,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2004,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2005,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2006,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2007,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2008,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2009,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2010,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2011,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2012,NA,forestryLoss_growthFactor_SSP5
-Iowa,IA,2013,1.022443498,forestryLoss_growthFactor_SSP5
-Iowa,IA,2014,1.01107618,forestryLoss_growthFactor_SSP5
-Iowa,IA,2015,1,forestryLoss_growthFactor_SSP5
-Iowa,IA,2016,0.983526117,forestryLoss_growthFactor_SSP5
-Iowa,IA,2017,0.967623935,forestryLoss_growthFactor_SSP5
-Iowa,IA,2018,0.952265053,forestryLoss_growthFactor_SSP5
-Iowa,IA,2019,0.937422887,forestryLoss_growthFactor_SSP5
-Iowa,IA,2020,0.923072533,forestryLoss_growthFactor_SSP5
-Iowa,IA,2021,0.908062264,forestryLoss_growthFactor_SSP5
-Iowa,IA,2022,0.893576137,forestryLoss_growthFactor_SSP5
-Iowa,IA,2023,0.8795877,forestryLoss_growthFactor_SSP5
-Iowa,IA,2024,0.866072231,forestryLoss_growthFactor_SSP5
-Iowa,IA,2025,0.853006597,forestryLoss_growthFactor_SSP5
-Iowa,IA,2026,0.839886839,forestryLoss_growthFactor_SSP5
-Iowa,IA,2027,0.827221412,forestryLoss_growthFactor_SSP5
-Iowa,IA,2028,0.814987481,forestryLoss_growthFactor_SSP5
-Iowa,IA,2029,0.803163699,forestryLoss_growthFactor_SSP5
-Iowa,IA,2030,0.791730091,forestryLoss_growthFactor_SSP5
-Iowa,IA,2031,0.781649458,forestryLoss_growthFactor_SSP5
-Iowa,IA,2032,0.77191888,forestryLoss_growthFactor_SSP5
-Iowa,IA,2033,0.7625206,forestryLoss_growthFactor_SSP5
-Iowa,IA,2034,0.753438036,forestryLoss_growthFactor_SSP5
-Iowa,IA,2035,0.744655687,forestryLoss_growthFactor_SSP5
-Iowa,IA,2036,0.734368182,forestryLoss_growthFactor_SSP5
-Iowa,IA,2037,0.724418239,forestryLoss_growthFactor_SSP5
-Iowa,IA,2038,0.714789579,forestryLoss_growthFactor_SSP5
-Iowa,IA,2039,0.705466952,forestryLoss_growthFactor_SSP5
-Iowa,IA,2040,0.696436054,forestryLoss_growthFactor_SSP5
-Iowa,IA,2041,0.689200832,forestryLoss_growthFactor_SSP5
-Iowa,IA,2042,0.682188571,forestryLoss_growthFactor_SSP5
-Iowa,IA,2043,0.67538909,forestryLoss_growthFactor_SSP5
-Iowa,IA,2044,0.66879282,forestryLoss_growthFactor_SSP5
-Iowa,IA,2045,0.662390759,forestryLoss_growthFactor_SSP5
-Iowa,IA,2046,0.654684777,forestryLoss_growthFactor_SSP5
-Iowa,IA,2047,0.647186437,forestryLoss_growthFactor_SSP5
-Iowa,IA,2048,0.639887375,forestryLoss_growthFactor_SSP5
-Iowa,IA,2049,0.632779674,forestryLoss_growthFactor_SSP5
-Iowa,IA,2050,0.625855833,forestryLoss_growthFactor_SSP5
-Iowa,IA,2051,0.619886142,forestryLoss_growthFactor_SSP5
-Iowa,IA,2052,0.614062975,forestryLoss_growthFactor_SSP5
-Iowa,IA,2053,0.608380919,forestryLoss_growthFactor_SSP5
-Iowa,IA,2054,0.602834828,forestryLoss_growthFactor_SSP5
-Iowa,IA,2055,0.597419806,forestryLoss_growthFactor_SSP5
-Iowa,IA,2056,0.589529947,forestryLoss_growthFactor_SSP5
-Iowa,IA,2057,0.581831756,forestryLoss_growthFactor_SSP5
-Iowa,IA,2058,0.574318211,forestryLoss_growthFactor_SSP5
-Iowa,IA,2059,0.566982632,forestryLoss_growthFactor_SSP5
-Iowa,IA,2060,0.559818664,forestryLoss_growthFactor_SSP5
-Iowa,IA,2061,0.552538853,forestryLoss_growthFactor_SSP5
-Iowa,IA,2062,0.545443615,forestryLoss_growthFactor_SSP5
-Iowa,IA,2063,0.538525818,forestryLoss_growthFactor_SSP5
-Iowa,IA,2064,0.531778706,forestryLoss_growthFactor_SSP5
-Iowa,IA,2065,0.525195865,forestryLoss_growthFactor_SSP5
-Iowa,IA,2066,0.514411102,forestryLoss_growthFactor_SSP5
-Iowa,IA,2067,0.50390164,forestryLoss_growthFactor_SSP5
-Iowa,IA,2068,0.493656695,forestryLoss_growthFactor_SSP5
-Iowa,IA,2069,0.483666053,forestryLoss_growthFactor_SSP5
-Iowa,IA,2070,0.473920033,forestryLoss_growthFactor_SSP5
-Iowa,IA,2071,0.470038489,forestryLoss_growthFactor_SSP5
-Iowa,IA,2072,0.466267258,forestryLoss_growthFactor_SSP5
-Iowa,IA,2073,0.462601641,forestryLoss_growthFactor_SSP5
-Iowa,IA,2074,0.459037203,forestryLoss_growthFactor_SSP5
-Iowa,IA,2075,0.455569755,forestryLoss_growthFactor_SSP5
-Iowa,IA,2076,0.453664416,forestryLoss_growthFactor_SSP5
-Iowa,IA,2077,0.451812726,forestryLoss_growthFactor_SSP5
-Iowa,IA,2078,0.450012383,forestryLoss_growthFactor_SSP5
-Iowa,IA,2079,0.448261212,forestryLoss_growthFactor_SSP5
-Iowa,IA,2080,0.446557166,forestryLoss_growthFactor_SSP5
-Iowa,IA,2081,0.44289848,forestryLoss_growthFactor_SSP5
-Iowa,IA,2082,0.439350692,forestryLoss_growthFactor_SSP5
-Iowa,IA,2083,0.435908811,forestryLoss_growthFactor_SSP5
-Iowa,IA,2084,0.43256814,forestryLoss_growthFactor_SSP5
-Iowa,IA,2085,0.429324256,forestryLoss_growthFactor_SSP5
-Iowa,IA,2086,0.426759055,forestryLoss_growthFactor_SSP5
-Iowa,IA,2087,0.424271728,forestryLoss_growthFactor_SSP5
-Iowa,IA,2088,0.421858729,forestryLoss_growthFactor_SSP5
-Iowa,IA,2089,0.419516726,forestryLoss_growthFactor_SSP5
-Iowa,IA,2090,0.417242586,forestryLoss_growthFactor_SSP5
-Iowa,IA,2091,0.406787254,forestryLoss_growthFactor_SSP5
-Iowa,IA,2092,0.396606878,forestryLoss_growthFactor_SSP5
-Iowa,IA,2093,0.386689508,forestryLoss_growthFactor_SSP5
-Iowa,IA,2094,0.377023912,forestryLoss_growthFactor_SSP5
-Iowa,IA,2095,0.367599517,forestryLoss_growthFactor_SSP5
-Iowa,IA,2096,0.357977594,forestryLoss_growthFactor_SSP5
-Iowa,IA,2097,0.34861319,forestryLoss_growthFactor_SSP5
-Iowa,IA,2098,0.339494703,forestryLoss_growthFactor_SSP5
-Iowa,IA,2099,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2000,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2001,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2002,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2003,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2004,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2005,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2006,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2007,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2008,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2009,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2010,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2011,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2012,NA,forestryLoss_growthFactor_SSP5
-Idaho,ID,2013,0.981586441,forestryLoss_growthFactor_SSP5
-Idaho,ID,2014,0.990914453,forestryLoss_growthFactor_SSP5
-Idaho,ID,2015,1,forestryLoss_growthFactor_SSP5
-Idaho,ID,2016,1.003061229,forestryLoss_growthFactor_SSP5
-Idaho,ID,2017,1.005986433,forestryLoss_growthFactor_SSP5
-Idaho,ID,2018,1.008783201,forestryLoss_growthFactor_SSP5
-Idaho,ID,2019,1.0114586,forestryLoss_growthFactor_SSP5
-Idaho,ID,2020,1.014019227,forestryLoss_growthFactor_SSP5
-Idaho,ID,2021,1.005411152,forestryLoss_growthFactor_SSP5
-Idaho,ID,2022,0.997039777,forestryLoss_growthFactor_SSP5
-Idaho,ID,2023,0.988895189,forestryLoss_growthFactor_SSP5
-Idaho,ID,2024,0.980968039,forestryLoss_growthFactor_SSP5
-Idaho,ID,2025,0.973249497,forestryLoss_growthFactor_SSP5
-Idaho,ID,2026,0.972737494,forestryLoss_growthFactor_SSP5
-Idaho,ID,2027,0.97220163,forestryLoss_growthFactor_SSP5
-Idaho,ID,2028,0.971644439,forestryLoss_growthFactor_SSP5
-Idaho,ID,2029,0.97106823,forestryLoss_growthFactor_SSP5
-Idaho,ID,2030,0.970475113,forestryLoss_growthFactor_SSP5
-Idaho,ID,2031,0.974361715,forestryLoss_growthFactor_SSP5
-Idaho,ID,2032,0.978093538,forestryLoss_growthFactor_SSP5
-Idaho,ID,2033,0.981679056,forestryLoss_growthFactor_SSP5
-Idaho,ID,2034,0.985126152,forestryLoss_growthFactor_SSP5
-Idaho,ID,2035,0.988442175,forestryLoss_growthFactor_SSP5
-Idaho,ID,2036,0.987801628,forestryLoss_growthFactor_SSP5
-Idaho,ID,2037,0.987155653,forestryLoss_growthFactor_SSP5
-Idaho,ID,2038,0.986505324,forestryLoss_growthFactor_SSP5
-Idaho,ID,2039,0.985851618,forestryLoss_growthFactor_SSP5
-Idaho,ID,2040,0.985195418,forestryLoss_growthFactor_SSP5
-Idaho,ID,2041,1.01359396,forestryLoss_growthFactor_SSP5
-Idaho,ID,2042,1.041080883,forestryLoss_growthFactor_SSP5
-Idaho,ID,2043,1.067698935,forestryLoss_growthFactor_SSP5
-Idaho,ID,2044,1.093488253,forestryLoss_growthFactor_SSP5
-Idaho,ID,2045,1.118486551,forestryLoss_growthFactor_SSP5
-Idaho,ID,2046,1.108858288,forestryLoss_growthFactor_SSP5
-Idaho,ID,2047,1.099472319,forestryLoss_growthFactor_SSP5
-Idaho,ID,2048,1.090319432,forestryLoss_growthFactor_SSP5
-Idaho,ID,2049,1.081390887,forestryLoss_growthFactor_SSP5
-Idaho,ID,2050,1.072678379,forestryLoss_growthFactor_SSP5
-Idaho,ID,2051,1.132136979,forestryLoss_growthFactor_SSP5
-Idaho,ID,2052,1.189952413,forestryLoss_growthFactor_SSP5
-Idaho,ID,2053,1.246191605,forestryLoss_growthFactor_SSP5
-Idaho,ID,2054,1.300917901,forestryLoss_growthFactor_SSP5
-Idaho,ID,2055,1.35419131,forestryLoss_growthFactor_SSP5
-Idaho,ID,2056,1.350128353,forestryLoss_growthFactor_SSP5
-Idaho,ID,2057,1.346146964,forestryLoss_growthFactor_SSP5
-Idaho,ID,2058,1.342244743,forestryLoss_growthFactor_SSP5
-Idaho,ID,2059,1.338419378,forestryLoss_growthFactor_SSP5
-Idaho,ID,2060,1.334668649,forestryLoss_growthFactor_SSP5
-Idaho,ID,2061,1.359408066,forestryLoss_growthFactor_SSP5
-Idaho,ID,2062,1.383407022,forestryLoss_growthFactor_SSP5
-Idaho,ID,2063,1.406697853,forestryLoss_growthFactor_SSP5
-Idaho,ID,2064,1.429311056,forestryLoss_growthFactor_SSP5
-Idaho,ID,2065,1.451275414,forestryLoss_growthFactor_SSP5
-Idaho,ID,2066,1.493622355,forestryLoss_growthFactor_SSP5
-Idaho,ID,2067,1.534690526,forestryLoss_growthFactor_SSP5
-Idaho,ID,2068,1.574536218,forestryLoss_growthFactor_SSP5
-Idaho,ID,2069,1.613212493,forestryLoss_growthFactor_SSP5
-Idaho,ID,2070,1.650769409,forestryLoss_growthFactor_SSP5
-Idaho,ID,2071,1.644554408,forestryLoss_growthFactor_SSP5
-Idaho,ID,2072,1.638518468,forestryLoss_growthFactor_SSP5
-Idaho,ID,2073,1.632653893,forestryLoss_growthFactor_SSP5
-Idaho,ID,2074,1.626953425,forestryLoss_growthFactor_SSP5
-Idaho,ID,2075,1.621410211,forestryLoss_growthFactor_SSP5
-Idaho,ID,2076,1.496190079,forestryLoss_growthFactor_SSP5
-Idaho,ID,2077,1.374757528,forestryLoss_growthFactor_SSP5
-Idaho,ID,2078,1.256943201,forestryLoss_growthFactor_SSP5
-Idaho,ID,2079,1.142587693,forestryLoss_growthFactor_SSP5
-Idaho,ID,2080,1.031540827,forestryLoss_growthFactor_SSP5
-Idaho,ID,2081,0.988594119,forestryLoss_growthFactor_SSP5
-Idaho,ID,2082,0.946961369,forestryLoss_growthFactor_SSP5
-Idaho,ID,2083,0.906583166,forestryLoss_growthFactor_SSP5
-Idaho,ID,2084,0.867403629,forestryLoss_growthFactor_SSP5
-Idaho,ID,2085,0.829370145,forestryLoss_growthFactor_SSP5
-Idaho,ID,2086,0.811761878,forestryLoss_growthFactor_SSP5
-Idaho,ID,2087,0.794700849,forestryLoss_growthFactor_SSP5
-Idaho,ID,2088,0.778161898,forestryLoss_growthFactor_SSP5
-Idaho,ID,2089,0.762121386,forestryLoss_growthFactor_SSP5
-Idaho,ID,2090,0.746557081,forestryLoss_growthFactor_SSP5
-Idaho,ID,2091,0.753232541,forestryLoss_growthFactor_SSP5
-Idaho,ID,2092,0.759658482,forestryLoss_growthFactor_SSP5
-Idaho,ID,2093,0.765847206,forestryLoss_growthFactor_SSP5
-Idaho,ID,2094,0.771810245,forestryLoss_growthFactor_SSP5
-Idaho,ID,2095,0.777558419,forestryLoss_growthFactor_SSP5
-Idaho,ID,2096,0.781925951,forestryLoss_growthFactor_SSP5
-Idaho,ID,2097,0.786114102,forestryLoss_growthFactor_SSP5
-Idaho,ID,2098,0.790131995,forestryLoss_growthFactor_SSP5
-Idaho,ID,2099,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2000,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2001,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2002,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2003,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2004,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2005,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2006,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2007,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2008,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2009,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2010,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2011,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2012,NA,forestryLoss_growthFactor_SSP5
-Illinois,IL,2013,1.033518283,forestryLoss_growthFactor_SSP5
-Illinois,IL,2014,1.016508152,forestryLoss_growthFactor_SSP5
-Illinois,IL,2015,1,forestryLoss_growthFactor_SSP5
-Illinois,IL,2016,0.978325517,forestryLoss_growthFactor_SSP5
-Illinois,IL,2017,0.957471044,forestryLoss_growthFactor_SSP5
-Illinois,IL,2018,0.937393954,forestryLoss_growthFactor_SSP5
-Illinois,IL,2019,0.918054423,forestryLoss_growthFactor_SSP5
-Illinois,IL,2020,0.899415208,forestryLoss_growthFactor_SSP5
-Illinois,IL,2021,0.879225797,forestryLoss_growthFactor_SSP5
-Illinois,IL,2022,0.859832073,forestryLoss_growthFactor_SSP5
-Illinois,IL,2023,0.841190991,forestryLoss_growthFactor_SSP5
-Illinois,IL,2024,0.823262446,forestryLoss_growthFactor_SSP5
-Illinois,IL,2025,0.806009026,forestryLoss_growthFactor_SSP5
-Illinois,IL,2026,0.787787626,forestryLoss_growthFactor_SSP5
-Illinois,IL,2027,0.770289898,forestryLoss_growthFactor_SSP5
-Illinois,IL,2028,0.753476497,forestryLoss_growthFactor_SSP5
-Illinois,IL,2029,0.737310773,forestryLoss_growthFactor_SSP5
-Illinois,IL,2030,0.721758549,forestryLoss_growthFactor_SSP5
-Illinois,IL,2031,0.706993391,forestryLoss_growthFactor_SSP5
-Illinois,IL,2032,0.692801073,forestryLoss_growthFactor_SSP5
-Illinois,IL,2033,0.679150656,forestryLoss_growthFactor_SSP5
-Illinois,IL,2034,0.666013327,forestryLoss_growthFactor_SSP5
-Illinois,IL,2035,0.653362217,forestryLoss_growthFactor_SSP5
-Illinois,IL,2036,0.638939698,forestryLoss_growthFactor_SSP5
-Illinois,IL,2037,0.625072271,forestryLoss_growthFactor_SSP5
-Illinois,IL,2038,0.611730648,forestryLoss_growthFactor_SSP5
-Illinois,IL,2039,0.598887491,forestryLoss_growthFactor_SSP5
-Illinois,IL,2040,0.586517255,forestryLoss_growthFactor_SSP5
-Illinois,IL,2041,0.574266068,forestryLoss_growthFactor_SSP5
-Illinois,IL,2042,0.562482076,forestryLoss_growthFactor_SSP5
-Illinois,IL,2043,0.551141185,forestryLoss_growthFactor_SSP5
-Illinois,IL,2044,0.540220857,forestryLoss_growthFactor_SSP5
-Illinois,IL,2045,0.529699998,forestryLoss_growthFactor_SSP5
-Illinois,IL,2046,0.518418491,forestryLoss_growthFactor_SSP5
-Illinois,IL,2047,0.507538862,forestryLoss_growthFactor_SSP5
-Illinois,IL,2048,0.497041792,forestryLoss_growthFactor_SSP5
-Illinois,IL,2049,0.486909126,forestryLoss_growthFactor_SSP5
-Illinois,IL,2050,0.477123785,forestryLoss_growthFactor_SSP5
-Illinois,IL,2051,0.46734994,forestryLoss_growthFactor_SSP5
-Illinois,IL,2052,0.457921999,forestryLoss_growthFactor_SSP5
-Illinois,IL,2053,0.448823594,forestryLoss_growthFactor_SSP5
-Illinois,IL,2054,0.440039324,forestryLoss_growthFactor_SSP5
-Illinois,IL,2055,0.431554684,forestryLoss_growthFactor_SSP5
-Illinois,IL,2056,0.421164079,forestryLoss_growthFactor_SSP5
-Illinois,IL,2057,0.411153021,forestryLoss_growthFactor_SSP5
-Illinois,IL,2058,0.401503241,forestryLoss_growthFactor_SSP5
-Illinois,IL,2059,0.392197561,forestryLoss_growthFactor_SSP5
-Illinois,IL,2060,0.383219814,forestryLoss_growthFactor_SSP5
-Illinois,IL,2061,0.373720629,forestryLoss_growthFactor_SSP5
-Illinois,IL,2062,0.364586007,forestryLoss_growthFactor_SSP5
-Illinois,IL,2063,0.355797785,forestryLoss_growthFactor_SSP5
-Illinois,IL,2064,0.347338917,forestryLoss_growthFactor_SSP5
-Illinois,IL,2065,0.339193396,forestryLoss_growthFactor_SSP5
-Illinois,IL,2066,0.328123785,forestryLoss_growthFactor_SSP5
-Illinois,IL,2067,0.317502685,forestryLoss_growthFactor_SSP5
-Illinois,IL,2068,0.30730733,forestryLoss_growthFactor_SSP5
-Illinois,IL,2069,0.297516364,forestryLoss_growthFactor_SSP5
-Illinois,IL,2070,0.288109744,forestryLoss_growthFactor_SSP5
-Illinois,IL,2071,0.283195375,forestryLoss_growthFactor_SSP5
-Illinois,IL,2072,0.278435174,forestryLoss_growthFactor_SSP5
-Illinois,IL,2073,0.27382218,forestryLoss_growthFactor_SSP5
-Illinois,IL,2074,0.269349841,forestryLoss_growthFactor_SSP5
-Illinois,IL,2075,0.265011983,forestryLoss_growthFactor_SSP5
-Illinois,IL,2076,0.26111313,forestryLoss_growthFactor_SSP5
-Illinois,IL,2077,0.25733963,forestryLoss_growthFactor_SSP5
-Illinois,IL,2078,0.253685702,forestryLoss_growthFactor_SSP5
-Illinois,IL,2079,0.250145909,forestryLoss_growthFactor_SSP5
-Illinois,IL,2080,0.246715138,forestryLoss_growthFactor_SSP5
-Illinois,IL,2081,0.242432547,forestryLoss_growthFactor_SSP5
-Illinois,IL,2082,0.238282753,forestryLoss_growthFactor_SSP5
-Illinois,IL,2083,0.234259716,forestryLoss_growthFactor_SSP5
-Illinois,IL,2084,0.230357752,forestryLoss_growthFactor_SSP5
-Illinois,IL,2085,0.226571513,forestryLoss_growthFactor_SSP5
-Illinois,IL,2086,0.222920016,forestryLoss_growthFactor_SSP5
-Illinois,IL,2087,0.21938529,forestryLoss_growthFactor_SSP5
-Illinois,IL,2088,0.215961903,forestryLoss_growthFactor_SSP5
-Illinois,IL,2089,0.212644754,forestryLoss_growthFactor_SSP5
-Illinois,IL,2090,0.209429047,forestryLoss_growthFactor_SSP5
-Illinois,IL,2091,0.20187025,forestryLoss_growthFactor_SSP5
-Illinois,IL,2092,0.194622625,forestryLoss_growthFactor_SSP5
-Illinois,IL,2093,0.187670435,forestryLoss_growthFactor_SSP5
-Illinois,IL,2094,0.180998934,forestryLoss_growthFactor_SSP5
-Illinois,IL,2095,0.174594293,forestryLoss_growthFactor_SSP5
-Illinois,IL,2096,0.168204742,forestryLoss_growthFactor_SSP5
-Illinois,IL,2097,0.162080128,forestryLoss_growthFactor_SSP5
-Illinois,IL,2098,0.15620695,forestryLoss_growthFactor_SSP5
-Illinois,IL,2099,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2000,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2001,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2002,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2003,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2004,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2005,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2006,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2007,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2008,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2009,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2010,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2011,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2012,NA,forestryLoss_growthFactor_SSP5
-Indiana,IN,2013,1.024134176,forestryLoss_growthFactor_SSP5
-Indiana,IN,2014,1.011902548,forestryLoss_growthFactor_SSP5
-Indiana,IN,2015,1,forestryLoss_growthFactor_SSP5
-Indiana,IN,2016,0.982740419,forestryLoss_growthFactor_SSP5
-Indiana,IN,2017,0.966095356,forestryLoss_growthFactor_SSP5
-Indiana,IN,2018,0.950033848,forestryLoss_growthFactor_SSP5
-Indiana,IN,2019,0.934526933,forestryLoss_growthFactor_SSP5
-Indiana,IN,2020,0.919547493,forestryLoss_growthFactor_SSP5
-Indiana,IN,2021,0.903105562,forestryLoss_growthFactor_SSP5
-Indiana,IN,2022,0.887263085,forestryLoss_growthFactor_SSP5
-Indiana,IN,2023,0.871989002,forestryLoss_growthFactor_SSP5
-Indiana,IN,2024,0.85725432,forestryLoss_growthFactor_SSP5
-Indiana,IN,2025,0.843031941,forestryLoss_growthFactor_SSP5
-Indiana,IN,2026,0.828628072,forestryLoss_growthFactor_SSP5
-Indiana,IN,2027,0.814751615,forestryLoss_growthFactor_SSP5
-Indiana,IN,2028,0.801375142,forestryLoss_growthFactor_SSP5
-Indiana,IN,2029,0.788473057,forestryLoss_growthFactor_SSP5
-Indiana,IN,2030,0.776021442,forestryLoss_growthFactor_SSP5
-Indiana,IN,2031,0.764582411,forestryLoss_growthFactor_SSP5
-Indiana,IN,2032,0.753560925,forestryLoss_growthFactor_SSP5
-Indiana,IN,2033,0.742935169,forestryLoss_growthFactor_SSP5
-Indiana,IN,2034,0.732684794,forestryLoss_growthFactor_SSP5
-Indiana,IN,2035,0.722790805,forestryLoss_growthFactor_SSP5
-Indiana,IN,2036,0.7110149,forestryLoss_growthFactor_SSP5
-Indiana,IN,2037,0.699656467,forestryLoss_growthFactor_SSP5
-Indiana,IN,2038,0.688694418,forestryLoss_growthFactor_SSP5
-Indiana,IN,2039,0.678109033,forestryLoss_growthFactor_SSP5
-Indiana,IN,2040,0.667881856,forestryLoss_growthFactor_SSP5
-Indiana,IN,2041,0.660004803,forestryLoss_growthFactor_SSP5
-Indiana,IN,2042,0.652407692,forestryLoss_growthFactor_SSP5
-Indiana,IN,2043,0.645076596,forestryLoss_growthFactor_SSP5
-Indiana,IN,2044,0.637998468,forestryLoss_growthFactor_SSP5
-Indiana,IN,2045,0.631161079,forestryLoss_growthFactor_SSP5
-Indiana,IN,2046,0.621928088,forestryLoss_growthFactor_SSP5
-Indiana,IN,2047,0.612988066,forestryLoss_growthFactor_SSP5
-Indiana,IN,2048,0.604327798,forestryLoss_growthFactor_SSP5
-Indiana,IN,2049,0.595934834,forestryLoss_growthFactor_SSP5
-Indiana,IN,2050,0.587797439,forestryLoss_growthFactor_SSP5
-Indiana,IN,2051,0.580789175,forestryLoss_growthFactor_SSP5
-Indiana,IN,2052,0.574000598,forestryLoss_growthFactor_SSP5
-Indiana,IN,2053,0.567421977,forestryLoss_growthFactor_SSP5
-Indiana,IN,2054,0.561044136,forestryLoss_growthFactor_SSP5
-Indiana,IN,2055,0.554858407,forestryLoss_growthFactor_SSP5
-Indiana,IN,2056,0.545925524,forestryLoss_growthFactor_SSP5
-Indiana,IN,2057,0.537271003,forestryLoss_growthFactor_SSP5
-Indiana,IN,2058,0.528882539,forestryLoss_growthFactor_SSP5
-Indiana,IN,2059,0.520748524,forestryLoss_growthFactor_SSP5
-Indiana,IN,2060,0.512858,forestryLoss_growthFactor_SSP5
-Indiana,IN,2061,0.505575524,forestryLoss_growthFactor_SSP5
-Indiana,IN,2062,0.498534049,forestryLoss_growthFactor_SSP5
-Indiana,IN,2063,0.491722407,forestryLoss_growthFactor_SSP5
-Indiana,IN,2064,0.48513009,forestryLoss_growthFactor_SSP5
-Indiana,IN,2065,0.478747201,forestryLoss_growthFactor_SSP5
-Indiana,IN,2066,0.469037035,forestryLoss_growthFactor_SSP5
-Indiana,IN,2067,0.459651923,forestryLoss_growthFactor_SSP5
-Indiana,IN,2068,0.450576714,forestryLoss_growthFactor_SSP5
-Indiana,IN,2069,0.441797155,forestryLoss_growthFactor_SSP5
-Indiana,IN,2070,0.433299829,forestryLoss_growthFactor_SSP5
-Indiana,IN,2071,0.427665755,forestryLoss_growthFactor_SSP5
-Indiana,IN,2072,0.422200981,forestryLoss_growthFactor_SSP5
-Indiana,IN,2073,0.416898045,forestryLoss_growthFactor_SSP5
-Indiana,IN,2074,0.411749916,forestryLoss_growthFactor_SSP5
-Indiana,IN,2075,0.406749962,forestryLoss_growthFactor_SSP5
-Indiana,IN,2076,0.404043093,forestryLoss_growthFactor_SSP5
-Indiana,IN,2077,0.401420757,forestryLoss_growthFactor_SSP5
-Indiana,IN,2078,0.398879111,forestryLoss_growthFactor_SSP5
-Indiana,IN,2079,0.396414541,forestryLoss_growthFactor_SSP5
-Indiana,IN,2080,0.394023643,forestryLoss_growthFactor_SSP5
-Indiana,IN,2081,0.388687228,forestryLoss_growthFactor_SSP5
-Indiana,IN,2082,0.383514787,forestryLoss_growthFactor_SSP5
-Indiana,IN,2083,0.378498893,forestryLoss_growthFactor_SSP5
-Indiana,IN,2084,0.373632556,forestryLoss_growthFactor_SSP5
-Indiana,IN,2085,0.3689092,forestryLoss_growthFactor_SSP5
-Indiana,IN,2086,0.365582347,forestryLoss_growthFactor_SSP5
-Indiana,IN,2087,0.362360246,forestryLoss_growthFactor_SSP5
-Indiana,IN,2088,0.359238055,forestryLoss_growthFactor_SSP5
-Indiana,IN,2089,0.356211225,forestryLoss_growthFactor_SSP5
-Indiana,IN,2090,0.353275478,forestryLoss_growthFactor_SSP5
-Indiana,IN,2091,0.344851776,forestryLoss_growthFactor_SSP5
-Indiana,IN,2092,0.33672048,forestryLoss_growthFactor_SSP5
-Indiana,IN,2093,0.328867488,forestryLoss_growthFactor_SSP5
-Indiana,IN,2094,0.32127957,forestryLoss_growthFactor_SSP5
-Indiana,IN,2095,0.313944307,forestryLoss_growthFactor_SSP5
-Indiana,IN,2096,0.30637291,forestryLoss_growthFactor_SSP5
-Indiana,IN,2097,0.299067214,forestryLoss_growthFactor_SSP5
-Indiana,IN,2098,0.292014198,forestryLoss_growthFactor_SSP5
-Indiana,IN,2099,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2000,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2001,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2002,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2003,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2004,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2005,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2006,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2007,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2008,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2009,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2010,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2011,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2012,NA,forestryLoss_growthFactor_SSP5
-Kansas,KS,2013,1.025193111,forestryLoss_growthFactor_SSP5
-Kansas,KS,2014,1.012425068,forestryLoss_growthFactor_SSP5
-Kansas,KS,2015,1,forestryLoss_growthFactor_SSP5
-Kansas,KS,2016,0.982234202,forestryLoss_growthFactor_SSP5
-Kansas,KS,2017,0.965101322,forestryLoss_growthFactor_SSP5
-Kansas,KS,2018,0.948569459,forestryLoss_growthFactor_SSP5
-Kansas,KS,2019,0.932608776,forestryLoss_growthFactor_SSP5
-Kansas,KS,2020,0.917191333,forestryLoss_growthFactor_SSP5
-Kansas,KS,2021,0.901217561,forestryLoss_growthFactor_SSP5
-Kansas,KS,2022,0.885827328,forestryLoss_growthFactor_SSP5
-Kansas,KS,2023,0.870990365,forestryLoss_growthFactor_SSP5
-Kansas,KS,2024,0.856678416,forestryLoss_growthFactor_SSP5
-Kansas,KS,2025,0.842865076,forestryLoss_growthFactor_SSP5
-Kansas,KS,2026,0.827977355,forestryLoss_growthFactor_SSP5
-Kansas,KS,2027,0.813629246,forestryLoss_growthFactor_SSP5
-Kansas,KS,2028,0.799792853,forestryLoss_growthFactor_SSP5
-Kansas,KS,2029,0.786442137,forestryLoss_growthFactor_SSP5
-Kansas,KS,2030,0.773552761,forestryLoss_growthFactor_SSP5
-Kansas,KS,2031,0.762058013,forestryLoss_growthFactor_SSP5
-Kansas,KS,2032,0.75098024,forestryLoss_growthFactor_SSP5
-Kansas,KS,2033,0.740297731,forestryLoss_growthFactor_SSP5
-Kansas,KS,2034,0.729990238,forestryLoss_growthFactor_SSP5
-Kansas,KS,2035,0.720038851,forestryLoss_growthFactor_SSP5
-Kansas,KS,2036,0.708669865,forestryLoss_growthFactor_SSP5
-Kansas,KS,2037,0.697700325,forestryLoss_growthFactor_SSP5
-Kansas,KS,2038,0.687110155,forestryLoss_growthFactor_SSP5
-Kansas,KS,2039,0.67688058,forestryLoss_growthFactor_SSP5
-Kansas,KS,2040,0.666994022,forestryLoss_growthFactor_SSP5
-Kansas,KS,2041,0.656233893,forestryLoss_growthFactor_SSP5
-Kansas,KS,2042,0.645836433,forestryLoss_growthFactor_SSP5
-Kansas,KS,2043,0.635784125,forestryLoss_growthFactor_SSP5
-Kansas,KS,2044,0.626060542,forestryLoss_growthFactor_SSP5
-Kansas,KS,2045,0.616650267,forestryLoss_growthFactor_SSP5
-Kansas,KS,2046,0.606373593,forestryLoss_growthFactor_SSP5
-Kansas,KS,2047,0.596410195,forestryLoss_growthFactor_SSP5
-Kansas,KS,2048,0.586746291,forestryLoss_growthFactor_SSP5
-Kansas,KS,2049,0.577368884,forestryLoss_growthFactor_SSP5
-Kansas,KS,2050,0.568265708,forestryLoss_growthFactor_SSP5
-Kansas,KS,2051,0.560234996,forestryLoss_growthFactor_SSP5
-Kansas,KS,2052,0.552440946,forestryLoss_growthFactor_SSP5
-Kansas,KS,2053,0.544873476,forestryLoss_growthFactor_SSP5
-Kansas,KS,2054,0.537523062,forestryLoss_growthFactor_SSP5
-Kansas,KS,2055,0.530380696,forestryLoss_growthFactor_SSP5
-Kansas,KS,2056,0.522006454,forestryLoss_growthFactor_SSP5
-Kansas,KS,2057,0.513880977,forestryLoss_growthFactor_SSP5
-Kansas,KS,2058,0.505993594,forestryLoss_growthFactor_SSP5
-Kansas,KS,2059,0.498334228,forestryLoss_growthFactor_SSP5
-Kansas,KS,2060,0.490893353,forestryLoss_growthFactor_SSP5
-Kansas,KS,2061,0.483861821,forestryLoss_growthFactor_SSP5
-Kansas,KS,2062,0.477051706,forestryLoss_growthFactor_SSP5
-Kansas,KS,2063,0.470453032,forestryLoss_growthFactor_SSP5
-Kansas,KS,2064,0.464056402,forestryLoss_growthFactor_SSP5
-Kansas,KS,2065,0.457852958,forestryLoss_growthFactor_SSP5
-Kansas,KS,2066,0.443977464,forestryLoss_growthFactor_SSP5
-Kansas,KS,2067,0.430533274,forestryLoss_growthFactor_SSP5
-Kansas,KS,2068,0.417501077,forestryLoss_growthFactor_SSP5
-Kansas,KS,2069,0.404862681,forestryLoss_growthFactor_SSP5
-Kansas,KS,2070,0.392600935,forestryLoss_growthFactor_SSP5
-Kansas,KS,2071,0.391026082,forestryLoss_growthFactor_SSP5
-Kansas,KS,2072,0.389498856,forestryLoss_growthFactor_SSP5
-Kansas,KS,2073,0.388017148,forestryLoss_growthFactor_SSP5
-Kansas,KS,2074,0.386578974,forestryLoss_growthFactor_SSP5
-Kansas,KS,2075,0.385182462,forestryLoss_growthFactor_SSP5
-Kansas,KS,2076,0.377705931,forestryLoss_growthFactor_SSP5
-Kansas,KS,2077,0.370456686,forestryLoss_growthFactor_SSP5
-Kansas,KS,2078,0.363424536,forestryLoss_growthFactor_SSP5
-Kansas,KS,2079,0.356599893,forestryLoss_growthFactor_SSP5
-Kansas,KS,2080,0.349973721,forestryLoss_growthFactor_SSP5
-Kansas,KS,2081,0.346431803,forestryLoss_growthFactor_SSP5
-Kansas,KS,2082,0.342998518,forestryLoss_growthFactor_SSP5
-Kansas,KS,2083,0.339668948,forestryLoss_growthFactor_SSP5
-Kansas,KS,2084,0.336438468,forestryLoss_growthFactor_SSP5
-Kansas,KS,2085,0.333302724,forestryLoss_growthFactor_SSP5
-Kansas,KS,2086,0.329223705,forestryLoss_growthFactor_SSP5
-Kansas,KS,2087,0.325272138,forestryLoss_growthFactor_SSP5
-Kansas,KS,2088,0.32144215,forestryLoss_growthFactor_SSP5
-Kansas,KS,2089,0.317728224,forestryLoss_growthFactor_SSP5
-Kansas,KS,2090,0.314125171,forestryLoss_growthFactor_SSP5
-Kansas,KS,2091,0.303465317,forestryLoss_growthFactor_SSP5
-Kansas,KS,2092,0.293148463,forestryLoss_growthFactor_SSP5
-Kansas,KS,2093,0.283158468,forestryLoss_growthFactor_SSP5
-Kansas,KS,2094,0.273480185,forestryLoss_growthFactor_SSP5
-Kansas,KS,2095,0.264099387,forestryLoss_growthFactor_SSP5
-Kansas,KS,2096,0.254676976,forestryLoss_growthFactor_SSP5
-Kansas,KS,2097,0.24556013,forestryLoss_growthFactor_SSP5
-Kansas,KS,2098,0.236734193,forestryLoss_growthFactor_SSP5
-Kansas,KS,2099,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2000,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2001,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2002,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2003,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2004,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2005,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2006,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2007,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2008,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2009,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2010,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2011,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2012,NA,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2013,1.005067573,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2014,1.002476531,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2015,1,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2016,0.991906025,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2017,0.984125679,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2018,0.976642469,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2019,0.969440993,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2020,0.962506854,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2021,0.95226752,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2022,0.94242027,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2023,0.932944217,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2024,0.923819887,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2025,0.915029101,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2026,0.895917629,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2027,0.877485335,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2028,0.859697525,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2029,0.842521792,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2030,0.825927834,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2031,0.820289467,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2032,0.814870074,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2033,0.809657823,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2034,0.804641692,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2035,0.799811407,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2036,0.790582302,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2037,0.781684608,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2038,0.773101465,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2039,0.764817109,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2040,0.756816792,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2041,0.751428982,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2042,0.746239172,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2043,0.741237335,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2044,0.73641409,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2045,0.731760644,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2046,0.718857616,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2047,0.706346784,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2048,0.694210925,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2049,0.682433798,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2050,0.671000072,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2051,0.671574699,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2052,0.672158889,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2053,0.67275149,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2054,0.673351438,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2055,0.673957755,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2056,0.67107788,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2057,0.668304939,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2058,0.665633746,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2059,0.663059425,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2060,0.660577388,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2061,0.661093765,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2062,0.661619937,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2063,0.662154769,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2064,0.662697219,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2065,0.663246329,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2066,0.658767993,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2067,0.654449018,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2068,0.650281751,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2069,0.646258998,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2070,0.642373998,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2071,0.643603024,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2072,0.64479782,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2073,0.645959825,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2074,0.6470904,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2075,0.648190827,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2076,0.64167852,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2077,0.635364988,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2078,0.629241299,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2079,0.62329905,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2080,0.617530323,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2081,0.611401033,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2082,0.605459726,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2083,0.599697892,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2084,0.59410753,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2085,0.588681103,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2086,0.584573687,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2087,0.580594865,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2088,0.576738706,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2089,0.57299964,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2090,0.569372426,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2091,0.562774958,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2092,0.556398964,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2093,0.550233874,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2094,0.544269772,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2095,0.538497346,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2096,0.532075912,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2097,0.525871082,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2098,0.519872351,forestryLoss_growthFactor_SSP5
-Kentucky,KY,2099,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2000,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2001,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2002,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2003,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2004,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2005,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2006,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2007,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2008,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2009,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2010,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2011,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2012,NA,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2013,0.979231914,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2014,0.989720593,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2015,1,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2016,1.0042784,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2017,1.008434534,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2018,1.012473749,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2019,1.016401072,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2020,1.020221243,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2021,1.01849733,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2022,1.016843371,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2023,1.015255527,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2024,1.013730219,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2025,1.012264115,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2026,0.990600342,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2027,0.96966163,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2028,0.949412341,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2029,0.929819128,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2030,0.910850753,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2031,0.913140292,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2032,0.915359256,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2033,0.917510945,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2034,0.919598455,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2035,0.921624686,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2036,0.916326665,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2037,0.911208657,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2038,0.906261791,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2039,0.901477765,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2040,0.896848797,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2041,0.898236565,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2042,0.899588379,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2043,0.90090567,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2044,0.902189792,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2045,0.903442027,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2046,0.887860873,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2047,0.872723676,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2048,0.858011783,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2049,0.843707567,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2050,0.829794362,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2051,0.840719685,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2052,0.851350531,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2053,0.861698668,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2054,0.871775248,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2055,0.88159084,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2056,0.886104484,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2057,0.890496628,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2058,0.894772132,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2059,0.898935598,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2060,0.902991387,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2061,0.914220462,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2062,0.925130723,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2063,0.93573561,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2064,0.946047816,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2065,0.95607934,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2066,0.959512417,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2067,0.962855031,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2068,0.966110813,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2069,0.969283201,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2070,0.972375448,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2071,0.978522489,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2072,0.984488893,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2073,0.990282517,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2074,0.995910769,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2075,1.001380638,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2076,0.991870383,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2077,0.982648267,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2078,0.973701393,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2079,0.965017624,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2080,0.956585528,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2081,0.947491189,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2082,0.938675255,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2083,0.930125136,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2084,0.921828988,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2085,0.913775661,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2086,0.909070845,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2087,0.904512568,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2088,0.900094087,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2089,0.895809067,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2090,0.891651547,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2091,0.888404756,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2092,0.88525866,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2093,0.882208581,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2094,0.879250128,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2095,0.876379175,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2096,0.872177434,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2097,0.868109239,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2098,0.864168224,forestryLoss_growthFactor_SSP5
-Louisiana,LA,2099,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2000,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2001,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2002,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2003,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2004,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2005,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2006,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2007,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2008,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2009,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2010,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2011,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2012,NA,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2013,1.019357164,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2014,1.00956215,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2015,1,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2016,0.984976119,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2017,0.970455155,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2018,0.956412636,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2019,0.942825641,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2020,0.929672673,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2021,0.914870707,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2022,0.900580956,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2023,0.886777719,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2024,0.873436968,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2025,0.860536215,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2026,0.847018925,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2027,0.833969895,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2028,0.821365583,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2029,0.809183985,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2030,0.797404508,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2031,0.786639009,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2032,0.776250461,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2033,0.766219644,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2034,0.756528617,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2035,0.747160607,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2036,0.73628339,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2037,0.725774187,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2038,0.715614906,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2039,0.705788616,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2040,0.696279449,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2041,0.686380128,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2042,0.676804073,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2043,0.667535961,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2044,0.658561415,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2045,0.649866928,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2046,0.641693304,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2047,0.633765556,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2048,0.626072961,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2049,0.618605401,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2050,0.611353326,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2051,0.603753162,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2052,0.596373342,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2053,0.589204583,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2054,0.582238108,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2055,0.575465616,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2056,0.566170743,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2057,0.557141549,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2058,0.548366929,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2059,0.539836387,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2060,0.53153999,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2061,0.522753663,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2062,0.514230554,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2063,0.505959161,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2064,0.497928639,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2065,0.490128748,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2066,0.476628472,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2067,0.463541724,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2068,0.450850148,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2069,0.438536443,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2070,0.426584294,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2071,0.42210889,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2072,0.417767415,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2073,0.413553979,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2074,0.409463033,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2075,0.405489344,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2076,0.401426199,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2077,0.397486971,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2078,0.393666096,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2079,0.389958335,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2080,0.386358757,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2081,0.382139815,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2082,0.378050294,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2083,0.374084335,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2084,0.370236426,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2085,0.366501381,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2086,0.362528644,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2087,0.35868032,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2088,0.354950673,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2089,0.351334311,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2090,0.347826164,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2091,0.336607253,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2092,0.325757618,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2093,0.315259747,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2094,0.305097212,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2095,0.295254582,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2096,0.285236811,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2097,0.2755566,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2098,0.266197586,forestryLoss_growthFactor_SSP5
-Massachusetts,MA,2099,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2000,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2001,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2002,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2003,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2004,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2005,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2006,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2007,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2008,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2009,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2010,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2011,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2012,NA,forestryLoss_growthFactor_SSP5
-Maryland,MD,2013,1.015578053,forestryLoss_growthFactor_SSP5
-Maryland,MD,2014,1.007700982,forestryLoss_growthFactor_SSP5
-Maryland,MD,2015,1,forestryLoss_growthFactor_SSP5
-Maryland,MD,2016,0.986772435,forestryLoss_growthFactor_SSP5
-Maryland,MD,2017,0.973975997,forestryLoss_growthFactor_SSP5
-Maryland,MD,2018,0.961590044,forestryLoss_growthFactor_SSP5
-Maryland,MD,2019,0.949595229,forestryLoss_growthFactor_SSP5
-Maryland,MD,2020,0.937973396,forestryLoss_growthFactor_SSP5
-Maryland,MD,2021,0.924076505,forestryLoss_growthFactor_SSP5
-Maryland,MD,2022,0.910646108,forestryLoss_growthFactor_SSP5
-Maryland,MD,2023,0.897659262,forestryLoss_growthFactor_SSP5
-Maryland,MD,2024,0.885094496,forestryLoss_growthFactor_SSP5
-Maryland,MD,2025,0.872931696,forestryLoss_growthFactor_SSP5
-Maryland,MD,2026,0.86032596,forestryLoss_growthFactor_SSP5
-Maryland,MD,2027,0.848145454,forestryLoss_growthFactor_SSP5
-Maryland,MD,2028,0.836369169,forestryLoss_growthFactor_SSP5
-Maryland,MD,2029,0.824977448,forestryLoss_growthFactor_SSP5
-Maryland,MD,2030,0.813951884,forestryLoss_growthFactor_SSP5
-Maryland,MD,2031,0.803750111,forestryLoss_growthFactor_SSP5
-Maryland,MD,2032,0.793899716,forestryLoss_growthFactor_SSP5
-Maryland,MD,2033,0.784382964,forestryLoss_growthFactor_SSP5
-Maryland,MD,2034,0.775183293,forestryLoss_growthFactor_SSP5
-Maryland,MD,2035,0.766285212,forestryLoss_growthFactor_SSP5
-Maryland,MD,2036,0.756317401,forestryLoss_growthFactor_SSP5
-Maryland,MD,2037,0.74668043,forestryLoss_growthFactor_SSP5
-Maryland,MD,2038,0.737358229,forestryLoss_growthFactor_SSP5
-Maryland,MD,2039,0.728335746,forestryLoss_growthFactor_SSP5
-Maryland,MD,2040,0.71959887,forestryLoss_growthFactor_SSP5
-Maryland,MD,2041,0.710961164,forestryLoss_growthFactor_SSP5
-Maryland,MD,2042,0.702599568,forestryLoss_growthFactor_SSP5
-Maryland,MD,2043,0.694501171,forestryLoss_growthFactor_SSP5
-Maryland,MD,2044,0.686653846,forestryLoss_growthFactor_SSP5
-Maryland,MD,2045,0.679046198,forestryLoss_growthFactor_SSP5
-Maryland,MD,2046,0.672673877,forestryLoss_growthFactor_SSP5
-Maryland,MD,2047,0.666488572,forestryLoss_growthFactor_SSP5
-Maryland,MD,2048,0.660482261,forestryLoss_growthFactor_SSP5
-Maryland,MD,2049,0.65464737,forestryLoss_growthFactor_SSP5
-Maryland,MD,2050,0.648976744,forestryLoss_growthFactor_SSP5
-Maryland,MD,2051,0.642977006,forestryLoss_growthFactor_SSP5
-Maryland,MD,2052,0.637145785,forestryLoss_growthFactor_SSP5
-Maryland,MD,2053,0.631476138,forestryLoss_growthFactor_SSP5
-Maryland,MD,2054,0.625961493,forestryLoss_growthFactor_SSP5
-Maryland,MD,2055,0.620595629,forestryLoss_growthFactor_SSP5
-Maryland,MD,2056,0.611852962,forestryLoss_growthFactor_SSP5
-Maryland,MD,2057,0.60335137,forestryLoss_growthFactor_SSP5
-Maryland,MD,2058,0.595081037,forestryLoss_growthFactor_SSP5
-Maryland,MD,2059,0.587032668,forestryLoss_growthFactor_SSP5
-Maryland,MD,2060,0.579197462,forestryLoss_growthFactor_SSP5
-Maryland,MD,2061,0.572055428,forestryLoss_growthFactor_SSP5
-Maryland,MD,2062,0.565120123,forestryLoss_growthFactor_SSP5
-Maryland,MD,2063,0.558382714,forestryLoss_growthFactor_SSP5
-Maryland,MD,2064,0.551834867,forestryLoss_growthFactor_SSP5
-Maryland,MD,2065,0.545468705,forestryLoss_growthFactor_SSP5
-Maryland,MD,2066,0.53213464,forestryLoss_growthFactor_SSP5
-Maryland,MD,2067,0.519190705,forestryLoss_growthFactor_SSP5
-Maryland,MD,2068,0.506620059,forestryLoss_growthFactor_SSP5
-Maryland,MD,2069,0.494406815,forestryLoss_growthFactor_SSP5
-Maryland,MD,2070,0.482535972,forestryLoss_growthFactor_SSP5
-Maryland,MD,2071,0.477462599,forestryLoss_growthFactor_SSP5
-Maryland,MD,2072,0.472538709,forestryLoss_growthFactor_SSP5
-Maryland,MD,2073,0.467757791,forestryLoss_growthFactor_SSP5
-Maryland,MD,2074,0.463113704,forestryLoss_growthFactor_SSP5
-Maryland,MD,2075,0.458600657,forestryLoss_growthFactor_SSP5
-Maryland,MD,2076,0.454331231,forestryLoss_growthFactor_SSP5
-Maryland,MD,2077,0.450190489,forestryLoss_growthFactor_SSP5
-Maryland,MD,2078,0.446172689,forestryLoss_growthFactor_SSP5
-Maryland,MD,2079,0.442272422,forestryLoss_growthFactor_SSP5
-Maryland,MD,2080,0.438484598,forestryLoss_growthFactor_SSP5
-Maryland,MD,2081,0.433568198,forestryLoss_growthFactor_SSP5
-Maryland,MD,2082,0.428802145,forestryLoss_growthFactor_SSP5
-Maryland,MD,2083,0.424179641,forestryLoss_growthFactor_SSP5
-Maryland,MD,2084,0.419694294,forestryLoss_growthFactor_SSP5
-Maryland,MD,2085,0.415340086,forestryLoss_growthFactor_SSP5
-Maryland,MD,2086,0.411609364,forestryLoss_growthFactor_SSP5
-Maryland,MD,2087,0.407994477,forestryLoss_growthFactor_SSP5
-Maryland,MD,2088,0.404490103,forestryLoss_growthFactor_SSP5
-Maryland,MD,2089,0.401091239,forestryLoss_growthFactor_SSP5
-Maryland,MD,2090,0.397793181,forestryLoss_growthFactor_SSP5
-Maryland,MD,2091,0.387141337,forestryLoss_growthFactor_SSP5
-Maryland,MD,2092,0.376815119,forestryLoss_growthFactor_SSP5
-Maryland,MD,2093,0.366799478,forestryLoss_growthFactor_SSP5
-Maryland,MD,2094,0.35708029,forestryLoss_growthFactor_SSP5
-Maryland,MD,2095,0.347644277,forestryLoss_growthFactor_SSP5
-Maryland,MD,2096,0.337933182,forestryLoss_growthFactor_SSP5
-Maryland,MD,2097,0.328527274,forestryLoss_growthFactor_SSP5
-Maryland,MD,2098,0.319412051,forestryLoss_growthFactor_SSP5
-Maryland,MD,2099,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2000,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2001,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2002,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2003,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2004,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2005,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2006,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2007,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2008,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2009,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2010,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2011,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2012,NA,forestryLoss_growthFactor_SSP5
-Maine,ME,2013,0.95592434,forestryLoss_growthFactor_SSP5
-Maine,ME,2014,0.978168781,forestryLoss_growthFactor_SSP5
-Maine,ME,2015,1,forestryLoss_growthFactor_SSP5
-Maine,ME,2016,1.015566093,forestryLoss_growthFactor_SSP5
-Maine,ME,2017,1.030691873,forestryLoss_growthFactor_SSP5
-Maine,ME,2018,1.045396433,forestryLoss_growthFactor_SSP5
-Maine,ME,2019,1.059697749,forestryLoss_growthFactor_SSP5
-Maine,ME,2020,1.073612762,forestryLoss_growthFactor_SSP5
-Maine,ME,2021,1.060275252,forestryLoss_growthFactor_SSP5
-Maine,ME,2022,1.047440485,forestryLoss_growthFactor_SSP5
-Maine,ME,2023,1.035081908,forestryLoss_growthFactor_SSP5
-Maine,ME,2024,1.02317476,forestryLoss_growthFactor_SSP5
-Maine,ME,2025,1.011695913,forestryLoss_growthFactor_SSP5
-Maine,ME,2026,1.007316639,forestryLoss_growthFactor_SSP5
-Maine,ME,2027,1.003143804,forestryLoss_growthFactor_SSP5
-Maine,ME,2028,0.999165276,forestryLoss_growthFactor_SSP5
-Maine,ME,2029,0.995369789,forestryLoss_growthFactor_SSP5
-Maine,ME,2030,0.991746872,forestryLoss_growthFactor_SSP5
-Maine,ME,2031,0.984665964,forestryLoss_growthFactor_SSP5
-Maine,ME,2032,0.977862647,forestryLoss_growthFactor_SSP5
-Maine,ME,2033,0.971321848,forestryLoss_growthFactor_SSP5
-Maine,ME,2034,0.965029532,forestryLoss_growthFactor_SSP5
-Maine,ME,2035,0.958972616,forestryLoss_growthFactor_SSP5
-Maine,ME,2036,0.96720997,forestryLoss_growthFactor_SSP5
-Maine,ME,2037,0.975227527,forestryLoss_growthFactor_SSP5
-Maine,ME,2038,0.983034333,forestryLoss_growthFactor_SSP5
-Maine,ME,2039,0.990638923,forestryLoss_growthFactor_SSP5
-Maine,ME,2040,0.998049365,forestryLoss_growthFactor_SSP5
-Maine,ME,2041,1.021290036,forestryLoss_growthFactor_SSP5
-Maine,ME,2042,1.043853711,forestryLoss_growthFactor_SSP5
-Maine,ME,2043,1.065770093,forestryLoss_growthFactor_SSP5
-Maine,ME,2044,1.08706715,forestryLoss_growthFactor_SSP5
-Maine,ME,2045,1.107771242,forestryLoss_growthFactor_SSP5
-Maine,ME,2046,1.15256467,forestryLoss_growthFactor_SSP5
-Maine,ME,2047,1.196139316,forestryLoss_growthFactor_SSP5
-Maine,ME,2048,1.238544651,forestryLoss_growthFactor_SSP5
-Maine,ME,2049,1.279827486,forestryLoss_growthFactor_SSP5
-Maine,ME,2050,1.320032152,forestryLoss_growthFactor_SSP5
-Maine,ME,2051,1.359709954,forestryLoss_growthFactor_SSP5
-Maine,ME,2052,1.398347254,forestryLoss_growthFactor_SSP5
-Maine,ME,2053,1.435984744,forestryLoss_growthFactor_SSP5
-Maine,ME,2054,1.472661012,forestryLoss_growthFactor_SSP5
-Maine,ME,2055,1.508412673,forestryLoss_growthFactor_SSP5
-Maine,ME,2056,1.514737822,forestryLoss_growthFactor_SSP5
-Maine,ME,2057,1.520930449,forestryLoss_growthFactor_SSP5
-Maine,ME,2058,1.526994686,forestryLoss_growthFactor_SSP5
-Maine,ME,2059,1.532934494,forestryLoss_growthFactor_SSP5
-Maine,ME,2060,1.538753671,forestryLoss_growthFactor_SSP5
-Maine,ME,2061,1.586536039,forestryLoss_growthFactor_SSP5
-Maine,ME,2062,1.632979652,forestryLoss_growthFactor_SSP5
-Maine,ME,2063,1.678140421,forestryLoss_growthFactor_SSP5
-Maine,ME,2064,1.722071171,forestryLoss_growthFactor_SSP5
-Maine,ME,2065,1.764821849,forestryLoss_growthFactor_SSP5
-Maine,ME,2066,1.760787326,forestryLoss_growthFactor_SSP5
-Maine,ME,2067,1.756919988,forestryLoss_growthFactor_SSP5
-Maine,ME,2068,1.753211273,forestryLoss_growthFactor_SSP5
-Maine,ME,2069,1.749653157,forestryLoss_growthFactor_SSP5
-Maine,ME,2070,1.746238107,forestryLoss_growthFactor_SSP5
-Maine,ME,2071,1.709153645,forestryLoss_growthFactor_SSP5
-Maine,ME,2072,1.673166507,forestryLoss_growthFactor_SSP5
-Maine,ME,2073,1.638228765,forestryLoss_growthFactor_SSP5
-Maine,ME,2074,1.604295242,forestryLoss_growthFactor_SSP5
-Maine,ME,2075,1.571323314,forestryLoss_growthFactor_SSP5
-Maine,ME,2076,1.552210945,forestryLoss_growthFactor_SSP5
-Maine,ME,2077,1.533680112,forestryLoss_growthFactor_SSP5
-Maine,ME,2078,1.51570473,forestryLoss_growthFactor_SSP5
-Maine,ME,2079,1.498260251,forestryLoss_growthFactor_SSP5
-Maine,ME,2080,1.481323549,forestryLoss_growthFactor_SSP5
-Maine,ME,2081,1.443705513,forestryLoss_growthFactor_SSP5
-Maine,ME,2082,1.407239739,forestryLoss_growthFactor_SSP5
-Maine,ME,2083,1.371874097,forestryLoss_growthFactor_SSP5
-Maine,ME,2084,1.337559558,forestryLoss_growthFactor_SSP5
-Maine,ME,2085,1.304249961,forestryLoss_growthFactor_SSP5
-Maine,ME,2086,1.296716,forestryLoss_growthFactor_SSP5
-Maine,ME,2087,1.289417909,forestryLoss_growthFactor_SSP5
-Maine,ME,2088,1.282344811,forestryLoss_growthFactor_SSP5
-Maine,ME,2089,1.275486487,forestryLoss_growthFactor_SSP5
-Maine,ME,2090,1.268833326,forestryLoss_growthFactor_SSP5
-Maine,ME,2091,1.287745941,forestryLoss_growthFactor_SSP5
-Maine,ME,2092,1.306083211,forestryLoss_growthFactor_SSP5
-Maine,ME,2093,1.323871678,forestryLoss_growthFactor_SSP5
-Maine,ME,2094,1.341136256,forestryLoss_growthFactor_SSP5
-Maine,ME,2095,1.357900362,forestryLoss_growthFactor_SSP5
-Maine,ME,2096,1.371958021,forestryLoss_growthFactor_SSP5
-Maine,ME,2097,1.385576871,forestryLoss_growthFactor_SSP5
-Maine,ME,2098,1.398777722,forestryLoss_growthFactor_SSP5
-Maine,ME,2099,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2000,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2001,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2002,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2003,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2004,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2005,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2006,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2007,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2008,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2009,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2010,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2011,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2012,NA,forestryLoss_growthFactor_SSP5
-Michigan,MI,2013,1.020379053,forestryLoss_growthFactor_SSP5
-Michigan,MI,2014,1.010020903,forestryLoss_growthFactor_SSP5
-Michigan,MI,2015,1,forestryLoss_growthFactor_SSP5
-Michigan,MI,2016,0.984617637,forestryLoss_growthFactor_SSP5
-Michigan,MI,2017,0.969833547,forestryLoss_growthFactor_SSP5
-Michigan,MI,2018,0.955616213,forestryLoss_growthFactor_SSP5
-Michigan,MI,2019,0.941936205,forestryLoss_growthFactor_SSP5
-Michigan,MI,2020,0.928766016,forestryLoss_growthFactor_SSP5
-Michigan,MI,2021,0.910522451,forestryLoss_growthFactor_SSP5
-Michigan,MI,2022,0.892980096,forestryLoss_growthFactor_SSP5
-Michigan,MI,2023,0.87610152,forestryLoss_growthFactor_SSP5
-Michigan,MI,2024,0.859851825,forestryLoss_growthFactor_SSP5
-Michigan,MI,2025,0.844198442,forestryLoss_growthFactor_SSP5
-Michigan,MI,2026,0.830236091,forestryLoss_growthFactor_SSP5
-Michigan,MI,2027,0.816828019,forestryLoss_growthFactor_SSP5
-Michigan,MI,2028,0.803944097,forestryLoss_growthFactor_SSP5
-Michigan,MI,2029,0.791556261,forestryLoss_growthFactor_SSP5
-Michigan,MI,2030,0.779638338,forestryLoss_growthFactor_SSP5
-Michigan,MI,2031,0.769266734,forestryLoss_growthFactor_SSP5
-Michigan,MI,2032,0.759302533,forestryLoss_growthFactor_SSP5
-Michigan,MI,2033,0.74972359,forestryLoss_growthFactor_SSP5
-Michigan,MI,2034,0.740509288,forestryLoss_growthFactor_SSP5
-Michigan,MI,2035,0.731640406,forestryLoss_growthFactor_SSP5
-Michigan,MI,2036,0.718902575,forestryLoss_growthFactor_SSP5
-Michigan,MI,2037,0.706645597,forestryLoss_growthFactor_SSP5
-Michigan,MI,2038,0.694844347,forestryLoss_growthFactor_SSP5
-Michigan,MI,2039,0.683475365,forestryLoss_growthFactor_SSP5
-Michigan,MI,2040,0.672516721,forestryLoss_growthFactor_SSP5
-Michigan,MI,2041,0.662212354,forestryLoss_growthFactor_SSP5
-Michigan,MI,2042,0.652295387,forestryLoss_growthFactor_SSP5
-Michigan,MI,2043,0.64274598,forestryLoss_growthFactor_SSP5
-Michigan,MI,2044,0.63354557,forestryLoss_growthFactor_SSP5
-Michigan,MI,2045,0.624676774,forestryLoss_growthFactor_SSP5
-Michigan,MI,2046,0.622261407,forestryLoss_growthFactor_SSP5
-Michigan,MI,2047,0.619976825,forestryLoss_growthFactor_SSP5
-Michigan,MI,2048,0.617815658,forestryLoss_growthFactor_SSP5
-Michigan,MI,2049,0.615771018,forestryLoss_growthFactor_SSP5
-Michigan,MI,2050,0.613836463,forestryLoss_growthFactor_SSP5
-Michigan,MI,2051,0.607504708,forestryLoss_growthFactor_SSP5
-Michigan,MI,2052,0.601401444,forestryLoss_growthFactor_SSP5
-Michigan,MI,2053,0.595515754,forestryLoss_growthFactor_SSP5
-Michigan,MI,2054,0.589837373,forestryLoss_growthFactor_SSP5
-Michigan,MI,2055,0.584356634,forestryLoss_growthFactor_SSP5
-Michigan,MI,2056,0.578063319,forestryLoss_growthFactor_SSP5
-Michigan,MI,2057,0.572003489,forestryLoss_growthFactor_SSP5
-Michigan,MI,2058,0.566165821,forestryLoss_growthFactor_SSP5
-Michigan,MI,2059,0.560539674,forestryLoss_growthFactor_SSP5
-Michigan,MI,2060,0.555115036,forestryLoss_growthFactor_SSP5
-Michigan,MI,2061,0.550465029,forestryLoss_growthFactor_SSP5
-Michigan,MI,2062,0.546005237,forestryLoss_growthFactor_SSP5
-Michigan,MI,2063,0.541725929,forestryLoss_growthFactor_SSP5
-Michigan,MI,2064,0.537617978,forestryLoss_growthFactor_SSP5
-Michigan,MI,2065,0.533672823,forestryLoss_growthFactor_SSP5
-Michigan,MI,2066,0.527473694,forestryLoss_growthFactor_SSP5
-Michigan,MI,2067,0.521533949,forestryLoss_growthFactor_SSP5
-Michigan,MI,2068,0.51584026,forestryLoss_growthFactor_SSP5
-Michigan,MI,2069,0.51038013,forestryLoss_growthFactor_SSP5
-Michigan,MI,2070,0.505141834,forestryLoss_growthFactor_SSP5
-Michigan,MI,2071,0.500727147,forestryLoss_growthFactor_SSP5
-Michigan,MI,2072,0.496448886,forestryLoss_growthFactor_SSP5
-Michigan,MI,2073,0.492300943,forestryLoss_growthFactor_SSP5
-Michigan,MI,2074,0.488277563,forestryLoss_growthFactor_SSP5
-Michigan,MI,2075,0.484373325,forestryLoss_growthFactor_SSP5
-Michigan,MI,2076,0.484719836,forestryLoss_growthFactor_SSP5
-Michigan,MI,2077,0.485061123,forestryLoss_growthFactor_SSP5
-Michigan,MI,2078,0.485397294,forestryLoss_growthFactor_SSP5
-Michigan,MI,2079,0.485728457,forestryLoss_growthFactor_SSP5
-Michigan,MI,2080,0.486054714,forestryLoss_growthFactor_SSP5
-Michigan,MI,2081,0.47110721,forestryLoss_growthFactor_SSP5
-Michigan,MI,2082,0.45661848,forestryLoss_growthFactor_SSP5
-Michigan,MI,2083,0.442567751,forestryLoss_growthFactor_SSP5
-Michigan,MI,2084,0.428935481,forestryLoss_growthFactor_SSP5
-Michigan,MI,2085,0.415703277,forestryLoss_growthFactor_SSP5
-Michigan,MI,2086,0.408572542,forestryLoss_growthFactor_SSP5
-Michigan,MI,2087,0.401666,forestryLoss_growthFactor_SSP5
-Michigan,MI,2088,0.394973296,forestryLoss_growthFactor_SSP5
-Michigan,MI,2089,0.388484701,forestryLoss_growthFactor_SSP5
-Michigan,MI,2090,0.382191063,forestryLoss_growthFactor_SSP5
-Michigan,MI,2091,0.375532134,forestryLoss_growthFactor_SSP5
-Michigan,MI,2092,0.369129516,forestryLoss_growthFactor_SSP5
-Michigan,MI,2093,0.362970471,forestryLoss_growthFactor_SSP5
-Michigan,MI,2094,0.357043059,forestryLoss_growthFactor_SSP5
-Michigan,MI,2095,0.351336078,forestryLoss_growthFactor_SSP5
-Michigan,MI,2096,0.345289999,forestryLoss_growthFactor_SSP5
-Michigan,MI,2097,0.339476869,forestryLoss_growthFactor_SSP5
-Michigan,MI,2098,0.333885008,forestryLoss_growthFactor_SSP5
-Michigan,MI,2099,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2000,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2001,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2002,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2003,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2004,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2005,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2006,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2007,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2008,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2009,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2010,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2011,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2012,NA,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2013,1.004269575,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2014,1.002104067,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2015,1,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2016,0.992226619,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2017,0.984716664,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2018,0.977457225,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2019,0.970436211,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2020,0.963642291,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2021,0.950048911,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2022,0.936914177,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2023,0.924215452,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2024,0.911931557,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2025,0.900042657,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2026,0.8911975,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2027,0.882654739,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2028,0.874399298,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2029,0.866417083,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2030,0.858694897,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2031,0.853003102,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2032,0.847511161,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2033,0.842208866,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2034,0.83708669,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2035,0.832135726,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2036,0.82232073,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2037,0.812833531,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2038,0.803658145,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2039,0.794779604,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2040,0.786183877,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2041,0.778821246,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2042,0.771697274,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2043,0.7648007,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2044,0.758120955,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2045,0.75164811,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2046,0.754305312,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2047,0.756895289,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2048,0.75942061,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2049,0.761883711,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2050,0.764286906,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2051,0.760557149,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2052,0.75693223,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2053,0.753407824,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2054,0.749979842,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2055,0.746644413,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2056,0.742433543,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2057,0.738337225,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2058,0.73435084,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2059,0.730470017,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2060,0.72669061,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2061,0.724016918,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2062,0.72142069,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2063,0.718898613,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2064,0.716447563,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2065,0.714064587,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2066,0.708842021,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2067,0.703773184,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2068,0.698851413,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2069,0.694070427,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2070,0.689424293,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2071,0.685596164,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2072,0.681880296,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2073,0.678271811,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2074,0.674766111,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2075,0.671358858,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2076,0.674176379,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2077,0.676907808,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2078,0.679557016,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2079,0.682127644,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2080,0.684623123,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2081,0.665479554,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2082,0.64692179,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2083,0.628923341,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2084,0.611459291,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2085,0.594506183,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2086,0.586114494,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2087,0.577983852,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2088,0.570102251,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2089,0.562458411,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2090,0.555041721,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2091,0.546662212,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2092,0.538534312,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2093,0.530646471,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2094,0.522987845,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2095,0.515548239,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2096,0.507539366,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2097,0.499776213,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2098,0.492247188,forestryLoss_growthFactor_SSP5
-Minnesota,MN,2099,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2000,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2001,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2002,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2003,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2004,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2005,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2006,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2007,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2008,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2009,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2010,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2011,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2012,NA,forestryLoss_growthFactor_SSP5
-Missouri,MO,2013,1.022587222,forestryLoss_growthFactor_SSP5
-Missouri,MO,2014,1.01113097,forestryLoss_growthFactor_SSP5
-Missouri,MO,2015,1,forestryLoss_growthFactor_SSP5
-Missouri,MO,2016,0.983503518,forestryLoss_growthFactor_SSP5
-Missouri,MO,2017,0.967608753,forestryLoss_growthFactor_SSP5
-Missouri,MO,2018,0.952284997,forestryLoss_growthFactor_SSP5
-Missouri,MO,2019,0.937503541,forestryLoss_growthFactor_SSP5
-Missouri,MO,2020,0.923237517,forestryLoss_growthFactor_SSP5
-Missouri,MO,2021,0.906236896,forestryLoss_growthFactor_SSP5
-Missouri,MO,2022,0.889867739,forestryLoss_growthFactor_SSP5
-Missouri,MO,2023,0.874096974,forestryLoss_growthFactor_SSP5
-Missouri,MO,2024,0.858893742,forestryLoss_growthFactor_SSP5
-Missouri,MO,2025,0.844229216,forestryLoss_growthFactor_SSP5
-Missouri,MO,2026,0.830345591,forestryLoss_growthFactor_SSP5
-Missouri,MO,2027,0.816986217,forestryLoss_growthFactor_SSP5
-Missouri,MO,2028,0.80412335,forestryLoss_growthFactor_SSP5
-Missouri,MO,2029,0.791731115,forestryLoss_growthFactor_SSP5
-Missouri,MO,2030,0.779785357,forestryLoss_growthFactor_SSP5
-Missouri,MO,2031,0.768688831,forestryLoss_growthFactor_SSP5
-Missouri,MO,2032,0.758007755,forestryLoss_growthFactor_SSP5
-Missouri,MO,2033,0.747720113,forestryLoss_growthFactor_SSP5
-Missouri,MO,2034,0.737805384,forestryLoss_growthFactor_SSP5
-Missouri,MO,2035,0.728244419,forestryLoss_growthFactor_SSP5
-Missouri,MO,2036,0.716568053,forestryLoss_growthFactor_SSP5
-Missouri,MO,2037,0.705318305,forestryLoss_growthFactor_SSP5
-Missouri,MO,2038,0.694473265,forestryLoss_growthFactor_SSP5
-Missouri,MO,2039,0.684012455,forestryLoss_growthFactor_SSP5
-Missouri,MO,2040,0.673916726,forestryLoss_growthFactor_SSP5
-Missouri,MO,2041,0.671249136,forestryLoss_growthFactor_SSP5
-Missouri,MO,2042,0.668712133,forestryLoss_growthFactor_SSP5
-Missouri,MO,2043,0.666298264,forestryLoss_growthFactor_SSP5
-Missouri,MO,2044,0.664000583,forestryLoss_growthFactor_SSP5
-Missouri,MO,2045,0.661812612,forestryLoss_growthFactor_SSP5
-Missouri,MO,2046,0.653152729,forestryLoss_growthFactor_SSP5
-Missouri,MO,2047,0.644781893,forestryLoss_growthFactor_SSP5
-Missouri,MO,2048,0.636686678,forestryLoss_growthFactor_SSP5
-Missouri,MO,2049,0.628854454,forestryLoss_growthFactor_SSP5
-Missouri,MO,2050,0.62127332,forestryLoss_growthFactor_SSP5
-Missouri,MO,2051,0.617217454,forestryLoss_growthFactor_SSP5
-Missouri,MO,2052,0.613311586,forestryLoss_growthFactor_SSP5
-Missouri,MO,2053,0.609548467,forestryLoss_growthFactor_SSP5
-Missouri,MO,2054,0.605921282,forestryLoss_growthFactor_SSP5
-Missouri,MO,2055,0.602423616,forestryLoss_growthFactor_SSP5
-Missouri,MO,2056,0.594925883,forestryLoss_growthFactor_SSP5
-Missouri,MO,2057,0.587679243,forestryLoss_growthFactor_SSP5
-Missouri,MO,2058,0.580672131,forestryLoss_growthFactor_SSP5
-Missouri,MO,2059,0.573893652,forestryLoss_growthFactor_SSP5
-Missouri,MO,2060,0.567333539,forestryLoss_growthFactor_SSP5
-Missouri,MO,2061,0.564552687,forestryLoss_growthFactor_SSP5
-Missouri,MO,2062,0.561897063,forestryLoss_growthFactor_SSP5
-Missouri,MO,2063,0.559360025,forestryLoss_growthFactor_SSP5
-Missouri,MO,2064,0.556935352,forestryLoss_growthFactor_SSP5
-Missouri,MO,2065,0.554617217,forestryLoss_growthFactor_SSP5
-Missouri,MO,2066,0.550514598,forestryLoss_growthFactor_SSP5
-Missouri,MO,2067,0.546596808,forestryLoss_growthFactor_SSP5
-Missouri,MO,2068,0.542854097,forestryLoss_growthFactor_SSP5
-Missouri,MO,2069,0.539277331,forestryLoss_growthFactor_SSP5
-Missouri,MO,2070,0.53585795,forestryLoss_growthFactor_SSP5
-Missouri,MO,2071,0.526818118,forestryLoss_growthFactor_SSP5
-Missouri,MO,2072,0.518049682,forestryLoss_growthFactor_SSP5
-Missouri,MO,2073,0.509540686,forestryLoss_growthFactor_SSP5
-Missouri,MO,2074,0.501279865,forestryLoss_growthFactor_SSP5
-Missouri,MO,2075,0.493256594,forestryLoss_growthFactor_SSP5
-Missouri,MO,2076,0.492265057,forestryLoss_growthFactor_SSP5
-Missouri,MO,2077,0.491307444,forestryLoss_growthFactor_SSP5
-Missouri,MO,2078,0.490382144,forestryLoss_growthFactor_SSP5
-Missouri,MO,2079,0.489487646,forestryLoss_growthFactor_SSP5
-Missouri,MO,2080,0.488622527,forestryLoss_growthFactor_SSP5
-Missouri,MO,2081,0.480144937,forestryLoss_growthFactor_SSP5
-Missouri,MO,2082,0.471927749,forestryLoss_growthFactor_SSP5
-Missouri,MO,2083,0.463959167,forestryLoss_growthFactor_SSP5
-Missouri,MO,2084,0.456228096,forestryLoss_growthFactor_SSP5
-Missouri,MO,2085,0.448724092,forestryLoss_growthFactor_SSP5
-Missouri,MO,2086,0.446073225,forestryLoss_growthFactor_SSP5
-Missouri,MO,2087,0.443506543,forestryLoss_growthFactor_SSP5
-Missouri,MO,2088,0.441020142,forestryLoss_growthFactor_SSP5
-Missouri,MO,2089,0.438610353,forestryLoss_growthFactor_SSP5
-Missouri,MO,2090,0.436273728,forestryLoss_growthFactor_SSP5
-Missouri,MO,2091,0.432374216,forestryLoss_growthFactor_SSP5
-Missouri,MO,2092,0.428636317,forestryLoss_growthFactor_SSP5
-Missouri,MO,2093,0.425051845,forestryLoss_growthFactor_SSP5
-Missouri,MO,2094,0.421613128,forestryLoss_growthFactor_SSP5
-Missouri,MO,2095,0.418312973,forestryLoss_growthFactor_SSP5
-Missouri,MO,2096,0.414482727,forestryLoss_growthFactor_SSP5
-Missouri,MO,2097,0.410807344,forestryLoss_growthFactor_SSP5
-Missouri,MO,2098,0.407278974,forestryLoss_growthFactor_SSP5
-Missouri,MO,2099,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2000,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2001,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2002,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2003,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2004,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2005,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2006,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2007,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2008,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2009,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2010,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2011,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2012,NA,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2013,0.963091926,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2014,0.981722743,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2015,1,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2016,1.012090513,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2017,1.023835912,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2018,1.035251268,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2019,1.046350768,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2020,1.057147773,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2021,1.059943909,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2022,1.062691001,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2023,1.065389976,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2024,1.068041769,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2025,1.070647313,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2026,1.043711961,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2027,1.017701678,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2028,0.992570213,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2029,0.968274324,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2030,0.944773536,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2031,0.95223067,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2032,0.959457269,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2033,0.966464139,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2034,0.973261405,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2035,0.979858568,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2036,0.976593891,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2037,0.973460326,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2038,0.970450812,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2039,0.967558763,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2040,0.964778032,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2041,0.971234329,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2042,0.977513821,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2043,0.9836239,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2044,0.989571539,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2045,0.995363324,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2046,0.976092951,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2047,0.957388036,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2048,0.939224325,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2049,0.921578922,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2050,0.904430193,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2051,0.924123026,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2052,0.943301043,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2053,0.961984328,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2054,0.980191925,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2055,0.997941911,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2056,1.008924198,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2057,1.019630254,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2058,1.030070525,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2059,1.040254931,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2060,1.050192897,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2061,1.071706142,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2062,1.09262354,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2063,1.112969771,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2064,1.132768158,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2065,1.152040763,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2066,1.164343935,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2067,1.176319903,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2068,1.187981899,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2069,1.199342434,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2070,1.210413352,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2071,1.221086157,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2072,1.231446545,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2073,1.241508074,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2074,1.251283525,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2075,1.260784963,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2076,1.248361923,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2077,1.236316762,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2078,1.224632535,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2079,1.213293291,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2080,1.202284006,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2081,1.190293861,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2082,1.17867117,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2083,1.167399307,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2084,1.156462632,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2085,1.145846421,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2086,1.140583158,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2087,1.135484605,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2088,1.130543167,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2089,1.125751709,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2090,1.121103522,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2091,1.122981037,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2092,1.124815633,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2093,1.126609048,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2094,1.128362917,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2095,1.130078786,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2096,1.129933333,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2097,1.129804356,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2098,1.129690905,forestryLoss_growthFactor_SSP5
-Mississippi,MS,2099,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2000,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2001,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2002,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2003,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2004,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2005,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2006,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2007,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2008,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2009,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2010,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2011,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2012,NA,forestryLoss_growthFactor_SSP5
-Montana,MT,2013,0.984495016,forestryLoss_growthFactor_SSP5
-Montana,MT,2014,0.992336238,forestryLoss_growthFactor_SSP5
-Montana,MT,2015,1,forestryLoss_growthFactor_SSP5
-Montana,MT,2016,1.001709158,forestryLoss_growthFactor_SSP5
-Montana,MT,2017,1.003355721,forestryLoss_growthFactor_SSP5
-Montana,MT,2018,1.004942889,forestryLoss_growthFactor_SSP5
-Montana,MT,2019,1.006473656,forestryLoss_growthFactor_SSP5
-Montana,MT,2020,1.007950821,forestryLoss_growthFactor_SSP5
-Montana,MT,2021,0.997759542,forestryLoss_growthFactor_SSP5
-Montana,MT,2022,0.987889893,forestryLoss_growthFactor_SSP5
-Montana,MT,2023,0.978326734,forestryLoss_growthFactor_SSP5
-Montana,MT,2024,0.969055866,forestryLoss_growthFactor_SSP5
-Montana,MT,2025,0.96006396,forestryLoss_growthFactor_SSP5
-Montana,MT,2026,0.958584818,forestryLoss_growthFactor_SSP5
-Montana,MT,2027,0.957141175,forestryLoss_growthFactor_SSP5
-Montana,MT,2028,0.955731752,forestryLoss_growthFactor_SSP5
-Montana,MT,2029,0.954355329,forestryLoss_growthFactor_SSP5
-Montana,MT,2030,0.953010747,forestryLoss_growthFactor_SSP5
-Montana,MT,2031,0.956277159,forestryLoss_growthFactor_SSP5
-Montana,MT,2032,0.95942482,forestryLoss_growthFactor_SSP5
-Montana,MT,2033,0.962459919,forestryLoss_growthFactor_SSP5
-Montana,MT,2034,0.965388232,forestryLoss_growthFactor_SSP5
-Montana,MT,2035,0.968215149,forestryLoss_growthFactor_SSP5
-Montana,MT,2036,0.967248831,forestryLoss_growthFactor_SSP5
-Montana,MT,2037,0.966302703,forestryLoss_growthFactor_SSP5
-Montana,MT,2038,0.965376148,forestryLoss_growthFactor_SSP5
-Montana,MT,2039,0.96446857,forestryLoss_growthFactor_SSP5
-Montana,MT,2040,0.963579398,forestryLoss_growthFactor_SSP5
-Montana,MT,2041,0.992655418,forestryLoss_growthFactor_SSP5
-Montana,MT,2042,1.020812237,forestryLoss_growthFactor_SSP5
-Montana,MT,2043,1.048092541,forestryLoss_growthFactor_SSP5
-Montana,MT,2044,1.074536421,forestryLoss_growthFactor_SSP5
-Montana,MT,2045,1.100181571,forestryLoss_growthFactor_SSP5
-Montana,MT,2046,1.0905162,forestryLoss_growthFactor_SSP5
-Montana,MT,2047,1.081101572,forestryLoss_growthFactor_SSP5
-Montana,MT,2048,1.071927897,forestryLoss_growthFactor_SSP5
-Montana,MT,2049,1.062985895,forestryLoss_growthFactor_SSP5
-Montana,MT,2050,1.054266763,forestryLoss_growthFactor_SSP5
-Montana,MT,2051,1.116003953,forestryLoss_growthFactor_SSP5
-Montana,MT,2052,1.176035996,forestryLoss_growthFactor_SSP5
-Montana,MT,2053,1.23443231,forestryLoss_growthFactor_SSP5
-Montana,MT,2054,1.291258606,forestryLoss_growthFactor_SSP5
-Montana,MT,2055,1.346577129,forestryLoss_growthFactor_SSP5
-Montana,MT,2056,1.343356289,forestryLoss_growthFactor_SSP5
-Montana,MT,2057,1.340187999,forestryLoss_growthFactor_SSP5
-Montana,MT,2058,1.337071213,forestryLoss_growthFactor_SSP5
-Montana,MT,2059,1.334004901,forestryLoss_growthFactor_SSP5
-Montana,MT,2060,1.330988043,forestryLoss_growthFactor_SSP5
-Montana,MT,2061,1.357371614,forestryLoss_growthFactor_SSP5
-Montana,MT,2062,1.382961811,forestryLoss_growthFactor_SSP5
-Montana,MT,2063,1.407793383,forestryLoss_growthFactor_SSP5
-Montana,MT,2064,1.4318991,forestryLoss_growthFactor_SSP5
-Montana,MT,2065,1.455309888,forestryLoss_growthFactor_SSP5
-Montana,MT,2066,1.499948247,forestryLoss_growthFactor_SSP5
-Montana,MT,2067,1.543237301,forestryLoss_growthFactor_SSP5
-Montana,MT,2068,1.58523648,forestryLoss_growthFactor_SSP5
-Montana,MT,2069,1.626001805,forestryLoss_growthFactor_SSP5
-Montana,MT,2070,1.665586126,forestryLoss_growthFactor_SSP5
-Montana,MT,2071,1.659541211,forestryLoss_growthFactor_SSP5
-Montana,MT,2072,1.653669863,forestryLoss_growthFactor_SSP5
-Montana,MT,2073,1.647964638,forestryLoss_growthFactor_SSP5
-Montana,MT,2074,1.642418513,forestryLoss_growthFactor_SSP5
-Montana,MT,2075,1.637024861,forestryLoss_growthFactor_SSP5
-Montana,MT,2076,1.508647049,forestryLoss_growthFactor_SSP5
-Montana,MT,2077,1.384152061,forestryLoss_growthFactor_SSP5
-Montana,MT,2078,1.263366288,forestryLoss_growthFactor_SSP5
-Montana,MT,2079,1.146126322,forestryLoss_growthFactor_SSP5
-Montana,MT,2080,1.032278215,forestryLoss_growthFactor_SSP5
-Montana,MT,2081,0.98863193,forestryLoss_growthFactor_SSP5
-Montana,MT,2082,0.946320754,forestryLoss_growthFactor_SSP5
-Montana,MT,2083,0.905284325,forestryLoss_growthFactor_SSP5
-Montana,MT,2084,0.865465867,forestryLoss_growthFactor_SSP5
-Montana,MT,2085,0.826811926,forestryLoss_growthFactor_SSP5
-Montana,MT,2086,0.809225893,forestryLoss_growthFactor_SSP5
-Montana,MT,2087,0.792185905,forestryLoss_growthFactor_SSP5
-Montana,MT,2088,0.775666865,forestryLoss_growthFactor_SSP5
-Montana,MT,2089,0.759645195,forestryLoss_growthFactor_SSP5
-Montana,MT,2090,0.74409872,forestryLoss_growthFactor_SSP5
-Montana,MT,2091,0.752033507,forestryLoss_growthFactor_SSP5
-Montana,MT,2092,0.759665568,forestryLoss_growthFactor_SSP5
-Montana,MT,2093,0.76700991,forestryLoss_growthFactor_SSP5
-Montana,MT,2094,0.774080604,forestryLoss_growthFactor_SSP5
-Montana,MT,2095,0.780890848,forestryLoss_growthFactor_SSP5
-Montana,MT,2096,0.786253457,forestryLoss_growthFactor_SSP5
-Montana,MT,2097,0.791394209,forestryLoss_growthFactor_SSP5
-Montana,MT,2098,0.796324407,forestryLoss_growthFactor_SSP5
-Montana,MT,2099,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2000,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2001,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2002,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2003,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2004,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2005,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2006,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2007,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2008,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2009,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2010,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2011,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2012,NA,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2013,0.987955432,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2014,0.994058879,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2015,1,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2016,1.000011657,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2017,0.99999502,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2018,0.99995227,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2019,0.999885421,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2020,0.999796331,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2021,0.988349307,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2022,0.977249629,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2023,0.966481435,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2024,0.956029829,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2025,0.945880807,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2026,0.943171171,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2027,0.940525291,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2028,0.937940926,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2029,0.935415941,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2030,0.932948299,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2031,0.925655251,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2032,0.918593591,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2033,0.911752269,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2034,0.905120934,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2035,0.898689883,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2036,0.889902432,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2037,0.881382297,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2038,0.873117232,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2039,0.865095741,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2040,0.857307017,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2041,0.852684265,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2042,0.848187466,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2043,0.843811375,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2044,0.839551046,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2045,0.835401803,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2046,0.838407391,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2047,0.841312108,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2048,0.844120652,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2049,0.846837445,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2050,0.849466651,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2051,0.829973854,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2052,0.810998256,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2053,0.792519437,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2054,0.774518046,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2055,0.756975724,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2056,0.754483135,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2057,0.752045621,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2058,0.749661352,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2059,0.74732858,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2060,0.745045633,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2061,0.73957962,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2062,0.734254577,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2063,0.729064979,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2064,0.724005594,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2065,0.719071458,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2066,0.711876799,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2067,0.704860982,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2068,0.69801715,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2069,0.691338805,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2070,0.684819784,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2071,0.677840593,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2072,0.671064611,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2073,0.664483048,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2074,0.658087615,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2075,0.65187049,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2076,0.645025278,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2077,0.638385163,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2078,0.63194102,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2079,0.62568426,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2080,0.619606788,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2081,0.614174881,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2082,0.608908815,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2083,0.603801096,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2084,0.598844681,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2085,0.594032933,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2086,0.589107451,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2087,0.58433475,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2088,0.579707809,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2089,0.575220035,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2090,0.570865226,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2091,0.571950845,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2092,0.572984268,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2093,0.573968231,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2094,0.574905293,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2095,0.575797853,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2096,0.575741706,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2097,0.575670411,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2098,0.575584926,forestryLoss_growthFactor_SSP5
-North Carolina,NC,2099,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2000,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2001,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2002,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2003,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2004,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2005,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2006,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2007,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2008,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2009,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2010,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2011,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2012,NA,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2013,0.985588871,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2014,0.99301317,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2015,1,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2016,1.000794113,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2017,1.001310606,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2018,1.001570234,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2019,1.001592157,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2020,1.00139408,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2021,1.003517981,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2022,1.005269943,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2023,1.006678219,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2024,1.00776881,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2025,1.008565666,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2026,1.010426278,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2027,1.011918683,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2028,1.013071126,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2029,1.013909593,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2030,1.014458007,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2031,1.01849429,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2032,1.022194296,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2033,1.025581224,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2034,1.028676483,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2035,1.031499849,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2036,1.033948067,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2037,1.036052,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2038,1.037836378,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2039,1.039324042,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2040,1.0405361,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2041,1.042109899,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2042,1.043352499,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2043,1.044287735,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2044,1.044937656,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2045,1.045322676,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2046,1.046764834,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2047,1.047862644,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2048,1.048639746,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2049,1.049118113,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2050,1.049318174,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2051,1.051597098,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2052,1.053494375,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2053,1.05503513,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2054,1.056242761,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2055,1.057139078,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2056,1.055850742,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2057,1.054195856,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2058,1.052201498,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2059,1.049892812,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2060,1.047293159,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2061,1.043659531,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2062,1.039727367,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2063,1.035521082,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2064,1.031063277,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2065,1.026374882,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2066,1.00926646,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2067,0.992069561,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2068,0.974804099,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2069,0.957488276,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2070,0.94013873,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2071,0.945149603,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2072,0.949964275,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2073,0.954592556,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2074,0.959043651,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2075,0.963326202,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2076,0.96282704,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2077,0.962300885,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2078,0.961749941,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2079,0.961176252,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2080,0.960581712,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2081,0.963335716,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2082,0.965994415,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2083,0.968562352,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2084,0.971043795,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2085,0.973442754,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2086,0.974512532,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2087,0.975527758,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2088,0.976491346,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2089,0.977406022,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2090,0.978274341,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2091,0.954934639,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2092,0.931776903,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2093,0.908801741,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2094,0.886009526,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2095,0.863400421,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2096,0.840427522,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2097,0.817695156,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2098,0.795198731,forestryLoss_growthFactor_SSP5
-North Dakota,ND,2099,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2000,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2001,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2002,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2003,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2004,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2005,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2006,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2007,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2008,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2009,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2010,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2011,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2012,NA,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2013,1.01756516,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2014,1.008685697,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2015,1,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2016,0.985810505,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2017,0.9720795,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2018,0.958785149,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2019,0.945906984,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2020,0.933425794,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2021,0.920968149,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2022,0.908909669,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2023,0.897231352,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2024,0.885915388,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2025,0.874945066,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2026,0.863136137,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2027,0.851699699,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2028,0.840618199,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2029,0.829875176,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2030,0.819455183,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2031,0.810803519,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2032,0.802431271,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2033,0.794324924,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2034,0.786471829,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2035,0.778860136,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2036,0.770055517,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2037,0.761513312,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2038,0.753221685,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2039,0.745169508,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2040,0.737346318,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2041,0.72885406,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2042,0.720597178,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2043,0.712565737,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2044,0.704750363,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2045,0.697142209,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2046,0.688852075,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2047,0.680760138,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2048,0.672859219,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2049,0.665142492,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2050,0.657603455,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2051,0.651400331,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2052,0.64532445,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2053,0.639371957,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2054,0.633539151,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2055,0.627822477,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2056,0.620679494,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2057,0.613679515,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2058,0.606818345,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2059,0.600091951,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2060,0.593496451,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2061,0.58723501,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2062,0.58110122,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2063,0.575091176,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2064,0.569201132,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2065,0.563427495,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2066,0.548708352,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2067,0.53434194,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2068,0.520315163,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2069,0.506615586,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2070,0.4932314,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2071,0.493003596,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2072,0.492774987,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2073,0.492545804,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2074,0.492316257,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2075,0.492086539,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2076,0.485420532,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2077,0.478949465,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2078,0.472664781,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2079,0.46655842,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2080,0.460622782,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2081,0.458172123,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2082,0.455794681,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2083,0.453487182,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2084,0.451246547,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2085,0.449069875,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2086,0.445707288,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2087,0.442446227,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2088,0.439282081,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2089,0.436210516,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2090,0.433227455,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2091,0.420188668,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2092,0.407476419,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2093,0.395076842,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2094,0.38297689,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2095,0.371164279,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2096,0.359219224,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2097,0.347580928,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2098,0.336235787,forestryLoss_growthFactor_SSP5
-Nebraska,NE,2099,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2000,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2001,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2002,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2003,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2004,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2005,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2006,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2007,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2008,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2009,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2010,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2011,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2012,NA,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2013,1.002505503,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2014,1.001193429,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2015,1,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2016,0.99318477,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2017,0.986670858,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2018,0.980441489,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2019,0.974481033,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2020,0.96877491,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2021,0.951839497,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2022,0.935553238,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2023,0.919881532,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2024,0.904792118,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2025,0.890254884,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2026,0.877480503,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2027,0.865218296,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2028,0.853440282,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2029,0.842120402,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2030,0.831234361,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2031,0.819330119,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2032,0.807886238,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2033,0.796877896,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2034,0.786281973,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2035,0.776076911,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2036,0.769927517,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2037,0.764050287,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2038,0.758429928,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2039,0.753052201,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2040,0.747903836,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2041,0.747994571,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2042,0.748157861,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2043,0.74838807,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2044,0.748679998,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2045,0.749028837,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2046,0.758303274,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2047,0.767390781,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2048,0.776296874,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2049,0.785026857,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2050,0.793585835,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2051,0.801804657,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2052,0.809867682,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2053,0.817779111,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2054,0.825543006,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2055,0.833163294,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2056,0.828946557,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2057,0.82491636,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2058,0.821062985,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2059,0.817377314,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2060,0.813850795,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2061,0.825567995,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2062,0.837010523,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2063,0.848188251,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2064,0.859110567,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2065,0.869786408,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2066,0.860840354,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2067,0.85224175,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2068,0.843973255,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2069,0.836018595,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2070,0.828362486,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2071,0.81172548,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2072,0.795585974,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2073,0.779922104,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2074,0.764713265,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2075,0.749940021,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2076,0.740065381,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2077,0.730495393,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2078,0.721216294,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2079,0.712215133,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2080,0.703479713,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2081,0.686916519,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2082,0.670861716,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2083,0.655292285,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2084,0.64018657,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2085,0.625524187,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2086,0.620239877,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2087,0.615122597,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2088,0.610164613,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2089,0.605358662,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2090,0.600697913,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2091,0.602496994,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2092,0.604292595,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2093,0.606084003,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2094,0.607870568,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2095,0.609651697,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2096,0.610449981,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2097,0.611265082,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2098,0.612095608,forestryLoss_growthFactor_SSP5
-New Hampshire,NH,2099,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2000,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2001,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2002,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2003,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2004,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2005,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2006,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2007,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2008,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2009,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2010,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2011,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2012,NA,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2013,1.026946207,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2014,1.013286016,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2015,1,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2016,0.981407857,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2017,0.963486081,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2018,0.946200668,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2019,0.929519819,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2020,0.913413767,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2021,0.896133704,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2022,0.879496277,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2023,0.863467807,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2024,0.848016865,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2025,0.833114099,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2026,0.817471592,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2027,0.802410968,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2028,0.787901691,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2029,0.773915274,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2030,0.76042511,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2031,0.747987962,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2032,0.736009087,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2033,0.724464414,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2034,0.713331497,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2035,0.702589384,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2036,0.690350142,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2037,0.678550064,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2038,0.667166814,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2039,0.656179516,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2040,0.645568632,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2041,0.634442519,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2042,0.623702989,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2043,0.613331043,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2044,0.603308879,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2045,0.593619799,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2046,0.584206254,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2047,0.575096335,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2048,0.566276214,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2049,0.557732868,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2050,0.549454023,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2051,0.540919579,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2052,0.532651088,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2053,0.524636814,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2054,0.516865682,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2055,0.509327238,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2056,0.499715983,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2057,0.490405101,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2058,0.481381291,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2059,0.472632008,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2060,0.464145406,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2061,0.454792888,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2062,0.445744356,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2063,0.436985863,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2064,0.42850428,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2065,0.420287239,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2066,0.40762731,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2067,0.395382734,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2068,0.383534352,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2069,0.372064137,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2070,0.360955108,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2071,0.356989683,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2072,0.353144479,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2073,0.349414172,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2074,0.345793744,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2075,0.342278462,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2076,0.338405635,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2077,0.334652624,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2078,0.331014007,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2079,0.327484685,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2080,0.324059854,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2081,0.320349813,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2082,0.316753947,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2083,0.313267079,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2084,0.30988434,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2085,0.306601146,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2086,0.302987605,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2087,0.299487612,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2088,0.296095921,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2089,0.292807606,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2090,0.289618034,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2091,0.279475752,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2092,0.269677403,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2093,0.260206521,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2094,0.251047656,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2095,0.242186304,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2096,0.233218211,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2097,0.224560601,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2098,0.216198311,forestryLoss_growthFactor_SSP5
-New Jersey,NJ,2099,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2000,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2001,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2002,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2003,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2004,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2005,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2006,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2007,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2008,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2009,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2010,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2011,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2012,NA,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2013,1.024777952,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2014,1.012201245,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2015,1,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2016,0.982486884,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2017,0.965631829,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2018,0.949400743,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2019,0.933761769,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2020,0.918685113,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2021,0.900536056,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2022,0.883083934,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2023,0.866291563,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2024,0.850124275,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2025,0.834549713,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2026,0.819491382,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2027,0.805019951,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2028,0.791103823,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2029,0.777713553,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2030,0.76482167,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2031,0.753469813,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2032,0.742555063,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2033,0.732053903,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2034,0.721944431,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2035,0.71220622,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2036,0.700465512,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2037,0.689166957,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2038,0.67828748,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2039,0.667805534,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2040,0.657700977,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2041,0.652336542,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2042,0.647195579,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2043,0.642266093,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2044,0.637536881,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2045,0.632997472,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2046,0.622460988,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2047,0.612272764,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2048,0.602416714,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2049,0.592877698,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2050,0.583641452,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2051,0.58642384,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2052,0.589175043,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2053,0.591894957,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2054,0.594583537,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2055,0.597240794,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2056,0.588456496,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2057,0.579962316,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2058,0.57174499,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2059,0.563792024,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2060,0.556091637,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2061,0.552568603,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2062,0.549193285,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2063,0.545958051,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2064,0.542855747,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2065,0.539879663,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2066,0.537718877,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2067,0.535684244,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2068,0.533768598,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2069,0.531965243,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2070,0.530267914,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2071,0.525954809,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2072,0.521773473,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2073,0.517718044,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2074,0.513783,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2075,0.509963133,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2076,0.484472684,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2077,0.459757977,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2078,0.435784213,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2079,0.412518641,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2080,0.389930413,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2081,0.37938008,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2082,0.369153654,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2083,0.359236466,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2084,0.349614717,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2085,0.34027542,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2086,0.334130343,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2087,0.328178398,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2088,0.322410662,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2089,0.316818757,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2090,0.311394802,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2091,0.305276873,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2092,0.299392997,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2093,0.293731561,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2094,0.28828168,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2095,0.28303314,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2096,0.277574641,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2097,0.272323857,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2098,0.267270405,forestryLoss_growthFactor_SSP5
-New Mexico,NM,2099,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2000,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2001,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2002,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2003,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2004,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2005,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2006,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2007,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2008,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2009,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2010,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2011,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2012,NA,forestryLoss_growthFactor_SSP5
-Nevada,NV,2013,1.004119156,forestryLoss_growthFactor_SSP5
-Nevada,NV,2014,1.002090447,forestryLoss_growthFactor_SSP5
-Nevada,NV,2015,1,forestryLoss_growthFactor_SSP5
-Nevada,NV,2016,0.992125293,forestryLoss_growthFactor_SSP5
-Nevada,NV,2017,0.984408013,forestryLoss_growthFactor_SSP5
-Nevada,NV,2018,0.976843564,forestryLoss_growthFactor_SSP5
-Nevada,NV,2019,0.969427522,forestryLoss_growthFactor_SSP5
-Nevada,NV,2020,0.962155628,forestryLoss_growthFactor_SSP5
-Nevada,NV,2021,0.954159119,forestryLoss_growthFactor_SSP5
-Nevada,NV,2022,0.946318308,forestryLoss_growthFactor_SSP5
-Nevada,NV,2023,0.938629273,forestryLoss_growthFactor_SSP5
-Nevada,NV,2024,0.931088178,forestryLoss_growthFactor_SSP5
-Nevada,NV,2025,0.923691276,forestryLoss_growthFactor_SSP5
-Nevada,NV,2026,0.915902633,forestryLoss_growthFactor_SSP5
-Nevada,NV,2027,0.908278562,forestryLoss_growthFactor_SSP5
-Nevada,NV,2028,0.900814162,forestryLoss_growthFactor_SSP5
-Nevada,NV,2029,0.893504706,forestryLoss_growthFactor_SSP5
-Nevada,NV,2030,0.886345637,forestryLoss_growthFactor_SSP5
-Nevada,NV,2031,0.880613523,forestryLoss_growthFactor_SSP5
-Nevada,NV,2032,0.87502206,forestryLoss_growthFactor_SSP5
-Nevada,NV,2033,0.869565943,forestryLoss_growthFactor_SSP5
-Nevada,NV,2034,0.864240142,forestryLoss_growthFactor_SSP5
-Nevada,NV,2035,0.859039881,forestryLoss_growthFactor_SSP5
-Nevada,NV,2036,0.851582876,forestryLoss_growthFactor_SSP5
-Nevada,NV,2037,0.844306025,forestryLoss_growthFactor_SSP5
-Nevada,NV,2038,0.837202629,forestryLoss_growthFactor_SSP5
-Nevada,NV,2039,0.830266327,forestryLoss_growthFactor_SSP5
-Nevada,NV,2040,0.823491082,forestryLoss_growthFactor_SSP5
-Nevada,NV,2041,0.817825678,forestryLoss_growthFactor_SSP5
-Nevada,NV,2042,0.812277668,forestryLoss_growthFactor_SSP5
-Nevada,NV,2043,0.806843453,forestryLoss_growthFactor_SSP5
-Nevada,NV,2044,0.801519581,forestryLoss_growthFactor_SSP5
-Nevada,NV,2045,0.796302736,forestryLoss_growthFactor_SSP5
-Nevada,NV,2046,0.788681929,forestryLoss_growthFactor_SSP5
-Nevada,NV,2047,0.781222405,forestryLoss_growthFactor_SSP5
-Nevada,NV,2048,0.773919078,forestryLoss_growthFactor_SSP5
-Nevada,NV,2049,0.766767074,forestryLoss_growthFactor_SSP5
-Nevada,NV,2050,0.759761719,forestryLoss_growthFactor_SSP5
-Nevada,NV,2051,0.756577617,forestryLoss_growthFactor_SSP5
-Nevada,NV,2052,0.753435073,forestryLoss_growthFactor_SSP5
-Nevada,NV,2053,0.750333789,forestryLoss_growthFactor_SSP5
-Nevada,NV,2054,0.74727343,forestryLoss_growthFactor_SSP5
-Nevada,NV,2055,0.744253626,forestryLoss_growthFactor_SSP5
-Nevada,NV,2056,0.734903968,forestryLoss_growthFactor_SSP5
-Nevada,NV,2057,0.725760264,forestryLoss_growthFactor_SSP5
-Nevada,NV,2058,0.716815692,forestryLoss_growthFactor_SSP5
-Nevada,NV,2059,0.708063735,forestryLoss_growthFactor_SSP5
-Nevada,NV,2060,0.699498159,forestryLoss_growthFactor_SSP5
-Nevada,NV,2061,0.691091198,forestryLoss_growthFactor_SSP5
-Nevada,NV,2062,0.682876871,forestryLoss_growthFactor_SSP5
-Nevada,NV,2063,0.674848413,forestryLoss_growthFactor_SSP5
-Nevada,NV,2064,0.666999383,forestryLoss_growthFactor_SSP5
-Nevada,NV,2065,0.659323644,forestryLoss_growthFactor_SSP5
-Nevada,NV,2066,0.647463251,forestryLoss_growthFactor_SSP5
-Nevada,NV,2067,0.635871329,forestryLoss_growthFactor_SSP5
-Nevada,NV,2068,0.624538434,forestryLoss_growthFactor_SSP5
-Nevada,NV,2069,0.613455579,forestryLoss_growthFactor_SSP5
-Nevada,NV,2070,0.602614208,forestryLoss_growthFactor_SSP5
-Nevada,NV,2071,0.599416661,forestryLoss_growthFactor_SSP5
-Nevada,NV,2072,0.59630755,forestryLoss_growthFactor_SSP5
-Nevada,NV,2073,0.593283173,forestryLoss_growthFactor_SSP5
-Nevada,NV,2074,0.590340035,forestryLoss_growthFactor_SSP5
-Nevada,NV,2075,0.587474832,forestryLoss_growthFactor_SSP5
-Nevada,NV,2076,0.57585646,forestryLoss_growthFactor_SSP5
-Nevada,NV,2077,0.564585504,forestryLoss_growthFactor_SSP5
-Nevada,NV,2078,0.553646522,forestryLoss_growthFactor_SSP5
-Nevada,NV,2079,0.54302498,forestryLoss_growthFactor_SSP5
-Nevada,NV,2080,0.532707183,forestryLoss_growthFactor_SSP5
-Nevada,NV,2081,0.526657986,forestryLoss_growthFactor_SSP5
-Nevada,NV,2082,0.520793064,forestryLoss_growthFactor_SSP5
-Nevada,NV,2083,0.515104102,forestryLoss_growthFactor_SSP5
-Nevada,NV,2084,0.509583278,forestryLoss_growthFactor_SSP5
-Nevada,NV,2085,0.504223227,forestryLoss_growthFactor_SSP5
-Nevada,NV,2086,0.499282721,forestryLoss_growthFactor_SSP5
-Nevada,NV,2087,0.494494473,forestryLoss_growthFactor_SSP5
-Nevada,NV,2088,0.489851506,forestryLoss_growthFactor_SSP5
-Nevada,NV,2089,0.485347265,forestryLoss_growthFactor_SSP5
-Nevada,NV,2090,0.480975586,forestryLoss_growthFactor_SSP5
-Nevada,NV,2091,0.466737537,forestryLoss_growthFactor_SSP5
-Nevada,NV,2092,0.452913146,forestryLoss_growthFactor_SSP5
-Nevada,NV,2093,0.439483663,forestryLoss_growthFactor_SSP5
-Nevada,NV,2094,0.426431479,forestryLoss_growthFactor_SSP5
-Nevada,NV,2095,0.413740036,forestryLoss_growthFactor_SSP5
-Nevada,NV,2096,0.400711946,forestryLoss_growthFactor_SSP5
-Nevada,NV,2097,0.388077392,forestryLoss_growthFactor_SSP5
-Nevada,NV,2098,0.375817899,forestryLoss_growthFactor_SSP5
-Nevada,NV,2099,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2000,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2001,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2002,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2003,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2004,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2005,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2006,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2007,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2008,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2009,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2010,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2011,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2012,NA,forestryLoss_growthFactor_SSP5
-New York,NY,2013,1.023156566,forestryLoss_growthFactor_SSP5
-New York,NY,2014,1.011416262,forestryLoss_growthFactor_SSP5
-New York,NY,2015,1,forestryLoss_growthFactor_SSP5
-New York,NY,2016,0.983218896,forestryLoss_growthFactor_SSP5
-New York,NY,2017,0.967041969,forestryLoss_growthFactor_SSP5
-New York,NY,2018,0.951438597,forestryLoss_growthFactor_SSP5
-New York,NY,2019,0.936380142,forestryLoss_growthFactor_SSP5
-New York,NY,2020,0.921839795,forestryLoss_growthFactor_SSP5
-New York,NY,2021,0.904869119,forestryLoss_growthFactor_SSP5
-New York,NY,2022,0.888527142,forestryLoss_growthFactor_SSP5
-New York,NY,2023,0.872780987,forestryLoss_growthFactor_SSP5
-New York,NY,2024,0.857599974,forestryLoss_growthFactor_SSP5
-New York,NY,2025,0.842955441,forestryLoss_growthFactor_SSP5
-New York,NY,2026,0.827744364,forestryLoss_growthFactor_SSP5
-New York,NY,2027,0.813100406,forestryLoss_growthFactor_SSP5
-New York,NY,2028,0.798993769,forestryLoss_growthFactor_SSP5
-New York,NY,2029,0.785396654,forestryLoss_growthFactor_SSP5
-New York,NY,2030,0.772283098,forestryLoss_growthFactor_SSP5
-New York,NY,2031,0.759959834,forestryLoss_growthFactor_SSP5
-New York,NY,2032,0.748091844,forestryLoss_growthFactor_SSP5
-New York,NY,2033,0.73665518,forestryLoss_growthFactor_SSP5
-New York,NY,2034,0.725627511,forestryLoss_growthFactor_SSP5
-New York,NY,2035,0.714987993,forestryLoss_growthFactor_SSP5
-New York,NY,2036,0.703389149,forestryLoss_growthFactor_SSP5
-New York,NY,2037,0.692211306,forestryLoss_growthFactor_SSP5
-New York,NY,2038,0.681432918,forestryLoss_growthFactor_SSP5
-New York,NY,2039,0.671033847,forestryLoss_growthFactor_SSP5
-New York,NY,2040,0.660995257,forestryLoss_growthFactor_SSP5
-New York,NY,2041,0.651077335,forestryLoss_growthFactor_SSP5
-New York,NY,2042,0.641511222,forestryLoss_growthFactor_SSP5
-New York,NY,2043,0.632279432,forestryLoss_growthFactor_SSP5
-New York,NY,2044,0.623365586,forestryLoss_growthFactor_SSP5
-New York,NY,2045,0.614754328,forestryLoss_growthFactor_SSP5
-New York,NY,2046,0.607326832,forestryLoss_growthFactor_SSP5
-New York,NY,2047,0.600150519,forestryLoss_growthFactor_SSP5
-New York,NY,2048,0.593213639,forestryLoss_growthFactor_SSP5
-New York,NY,2049,0.586505138,forestryLoss_growthFactor_SSP5
-New York,NY,2050,0.580014606,forestryLoss_growthFactor_SSP5
-New York,NY,2051,0.573150092,forestryLoss_growthFactor_SSP5
-New York,NY,2052,0.566511554,forestryLoss_growthFactor_SSP5
-New York,NY,2053,0.560088698,forestryLoss_growthFactor_SSP5
-New York,NY,2054,0.553871823,forestryLoss_growthFactor_SSP5
-New York,NY,2055,0.547851782,forestryLoss_growthFactor_SSP5
-New York,NY,2056,0.538638935,forestryLoss_growthFactor_SSP5
-New York,NY,2057,0.529722559,forestryLoss_growthFactor_SSP5
-New York,NY,2058,0.521089299,forestryLoss_growthFactor_SSP5
-New York,NY,2059,0.512726562,forestryLoss_growthFactor_SSP5
-New York,NY,2060,0.504622473,forestryLoss_growthFactor_SSP5
-New York,NY,2061,0.497229566,forestryLoss_growthFactor_SSP5
-New York,NY,2062,0.49009503,forestryLoss_growthFactor_SSP5
-New York,NY,2063,0.483206547,forestryLoss_growthFactor_SSP5
-New York,NY,2064,0.476552536,forestryLoss_growthFactor_SSP5
-New York,NY,2065,0.470122105,forestryLoss_growthFactor_SSP5
-New York,NY,2066,0.45743919,forestryLoss_growthFactor_SSP5
-New York,NY,2067,0.445194959,forestryLoss_growthFactor_SSP5
-New York,NY,2068,0.433368625,forestryLoss_growthFactor_SSP5
-New York,NY,2069,0.42194065,forestryLoss_growthFactor_SSP5
-New York,NY,2070,0.410892647,forestryLoss_growthFactor_SSP5
-New York,NY,2071,0.405093497,forestryLoss_growthFactor_SSP5
-New York,NY,2072,0.399471037,forestryLoss_growthFactor_SSP5
-New York,NY,2073,0.394017416,forestryLoss_growthFactor_SSP5
-New York,NY,2074,0.38872524,forestryLoss_growthFactor_SSP5
-New York,NY,2075,0.383587538,forestryLoss_growthFactor_SSP5
-New York,NY,2076,0.378763297,forestryLoss_growthFactor_SSP5
-New York,NY,2077,0.374089246,forestryLoss_growthFactor_SSP5
-New York,NY,2078,0.369558569,forestryLoss_growthFactor_SSP5
-New York,NY,2079,0.365164853,forestryLoss_growthFactor_SSP5
-New York,NY,2080,0.36090206,forestryLoss_growthFactor_SSP5
-New York,NY,2081,0.355591685,forestryLoss_growthFactor_SSP5
-New York,NY,2082,0.350444793,forestryLoss_growthFactor_SSP5
-New York,NY,2083,0.345453971,forestryLoss_growthFactor_SSP5
-New York,NY,2084,0.340612245,forestryLoss_growthFactor_SSP5
-New York,NY,2085,0.335913053,forestryLoss_growthFactor_SSP5
-New York,NY,2086,0.331880451,forestryLoss_growthFactor_SSP5
-New York,NY,2087,0.327975149,forestryLoss_growthFactor_SSP5
-New York,NY,2088,0.324191256,forestryLoss_growthFactor_SSP5
-New York,NY,2089,0.320523238,forestryLoss_growthFactor_SSP5
-New York,NY,2090,0.316965893,forestryLoss_growthFactor_SSP5
-New York,NY,2091,0.308051698,forestryLoss_growthFactor_SSP5
-New York,NY,2092,0.29946059,forestryLoss_growthFactor_SSP5
-New York,NY,2093,0.291176783,forestryLoss_growthFactor_SSP5
-New York,NY,2094,0.283185472,forestryLoss_growthFactor_SSP5
-New York,NY,2095,0.275472765,forestryLoss_growthFactor_SSP5
-New York,NY,2096,0.267508552,forestryLoss_growthFactor_SSP5
-New York,NY,2097,0.259840872,forestryLoss_growthFactor_SSP5
-New York,NY,2098,0.252454975,forestryLoss_growthFactor_SSP5
-New York,NY,2099,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2000,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2001,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2002,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2003,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2004,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2005,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2006,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2007,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2008,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2009,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2010,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2011,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2012,NA,forestryLoss_growthFactor_SSP5
-Ohio,OH,2013,1.029512743,forestryLoss_growthFactor_SSP5
-Ohio,OH,2014,1.014538881,forestryLoss_growthFactor_SSP5
-Ohio,OH,2015,1,forestryLoss_growthFactor_SSP5
-Ohio,OH,2016,0.980219709,forestryLoss_growthFactor_SSP5
-Ohio,OH,2017,0.961177519,forestryLoss_growthFactor_SSP5
-Ohio,OH,2018,0.942835321,forestryLoss_growthFactor_SSP5
-Ohio,OH,2019,0.925157505,forestryLoss_growthFactor_SSP5
-Ohio,OH,2020,0.908110758,forestryLoss_growthFactor_SSP5
-Ohio,OH,2021,0.889477216,forestryLoss_growthFactor_SSP5
-Ohio,OH,2022,0.871558916,forestryLoss_growthFactor_SSP5
-Ohio,OH,2023,0.854317705,forestryLoss_growthFactor_SSP5
-Ohio,OH,2024,0.837718013,forestryLoss_growthFactor_SSP5
-Ohio,OH,2025,0.821726639,forestryLoss_growthFactor_SSP5
-Ohio,OH,2026,0.805388675,forestryLoss_growthFactor_SSP5
-Ohio,OH,2027,0.789683681,forestryLoss_growthFactor_SSP5
-Ohio,OH,2028,0.774577689,forestryLoss_growthFactor_SSP5
-Ohio,OH,2029,0.760039038,forestryLoss_growthFactor_SSP5
-Ohio,OH,2030,0.746038188,forestryLoss_growthFactor_SSP5
-Ohio,OH,2031,0.732883648,forestryLoss_growthFactor_SSP5
-Ohio,OH,2032,0.720230345,forestryLoss_growthFactor_SSP5
-Ohio,OH,2033,0.70805146,forestryLoss_growthFactor_SSP5
-Ohio,OH,2034,0.696322011,forestryLoss_growthFactor_SSP5
-Ohio,OH,2035,0.685018691,forestryLoss_growthFactor_SSP5
-Ohio,OH,2036,0.671755555,forestryLoss_growthFactor_SSP5
-Ohio,OH,2037,0.65899076,forestryLoss_growthFactor_SSP5
-Ohio,OH,2038,0.646698331,forestryLoss_growthFactor_SSP5
-Ohio,OH,2039,0.634854009,forestryLoss_growthFactor_SSP5
-Ohio,OH,2040,0.623435118,forestryLoss_growthFactor_SSP5
-Ohio,OH,2041,0.61440974,forestryLoss_growthFactor_SSP5
-Ohio,OH,2042,0.605731983,forestryLoss_growthFactor_SSP5
-Ohio,OH,2043,0.597383833,forestryLoss_growthFactor_SSP5
-Ohio,OH,2044,0.589348445,forestryLoss_growthFactor_SSP5
-Ohio,OH,2045,0.581610052,forestryLoss_growthFactor_SSP5
-Ohio,OH,2046,0.571513138,forestryLoss_growthFactor_SSP5
-Ohio,OH,2047,0.561762709,forestryLoss_growthFactor_SSP5
-Ohio,OH,2048,0.552342431,forestryLoss_growthFactor_SSP5
-Ohio,OH,2049,0.543236937,forestryLoss_growthFactor_SSP5
-Ohio,OH,2050,0.534431765,forestryLoss_growthFactor_SSP5
-Ohio,OH,2051,0.526852855,forestryLoss_growthFactor_SSP5
-Ohio,OH,2052,0.519535508,forestryLoss_growthFactor_SSP5
-Ohio,OH,2053,0.512467504,forestryLoss_growthFactor_SSP5
-Ohio,OH,2054,0.505637338,forestryLoss_growthFactor_SSP5
-Ohio,OH,2055,0.499034171,forestryLoss_growthFactor_SSP5
-Ohio,OH,2056,0.489976667,forestryLoss_growthFactor_SSP5
-Ohio,OH,2057,0.481228999,forestryLoss_growthFactor_SSP5
-Ohio,OH,2058,0.472776733,forestryLoss_growthFactor_SSP5
-Ohio,OH,2059,0.46460628,forestryLoss_growthFactor_SSP5
-Ohio,OH,2060,0.456704836,forestryLoss_growthFactor_SSP5
-Ohio,OH,2061,0.449623633,forestryLoss_growthFactor_SSP5
-Ohio,OH,2062,0.442803934,forestryLoss_growthFactor_SSP5
-Ohio,OH,2063,0.436232936,forestryLoss_growthFactor_SSP5
-Ohio,OH,2064,0.429898614,forestryLoss_growthFactor_SSP5
-Ohio,OH,2065,0.423789668,forestryLoss_growthFactor_SSP5
-Ohio,OH,2066,0.414886915,forestryLoss_growthFactor_SSP5
-Ohio,OH,2067,0.406324955,forestryLoss_growthFactor_SSP5
-Ohio,OH,2068,0.398086882,forestryLoss_growthFactor_SSP5
-Ohio,OH,2069,0.390156828,forestryLoss_growthFactor_SSP5
-Ohio,OH,2070,0.382519884,forestryLoss_growthFactor_SSP5
-Ohio,OH,2071,0.37647331,forestryLoss_growthFactor_SSP5
-Ohio,OH,2072,0.370611699,forestryLoss_growthFactor_SSP5
-Ohio,OH,2073,0.364926817,forestryLoss_growthFactor_SSP5
-Ohio,OH,2074,0.359410906,forestryLoss_growthFactor_SSP5
-Ohio,OH,2075,0.354056653,forestryLoss_growthFactor_SSP5
-Ohio,OH,2076,0.351167616,forestryLoss_growthFactor_SSP5
-Ohio,OH,2077,0.34837122,forestryLoss_growthFactor_SSP5
-Ohio,OH,2078,0.345663199,forestryLoss_growthFactor_SSP5
-Ohio,OH,2079,0.34303954,forestryLoss_growthFactor_SSP5
-Ohio,OH,2080,0.340496468,forestryLoss_growthFactor_SSP5
-Ohio,OH,2081,0.335083304,forestryLoss_growthFactor_SSP5
-Ohio,OH,2082,0.329836978,forestryLoss_growthFactor_SSP5
-Ohio,OH,2083,0.324749922,forestryLoss_growthFactor_SSP5
-Ohio,OH,2084,0.319815015,forestryLoss_growthFactor_SSP5
-Ohio,OH,2085,0.315025556,forestryLoss_growthFactor_SSP5
-Ohio,OH,2086,0.311812566,forestryLoss_growthFactor_SSP5
-Ohio,OH,2087,0.308701623,forestryLoss_growthFactor_SSP5
-Ohio,OH,2088,0.305687994,forestryLoss_growthFactor_SSP5
-Ohio,OH,2089,0.302767233,forestryLoss_growthFactor_SSP5
-Ohio,OH,2090,0.299935158,forestryLoss_growthFactor_SSP5
-Ohio,OH,2091,0.293101383,forestryLoss_growthFactor_SSP5
-Ohio,OH,2092,0.286528276,forestryLoss_growthFactor_SSP5
-Ohio,OH,2093,0.280202911,forestryLoss_growthFactor_SSP5
-Ohio,OH,2094,0.274113176,forestryLoss_growthFactor_SSP5
-Ohio,OH,2095,0.268247705,forestryLoss_growthFactor_SSP5
-Ohio,OH,2096,0.26218863,forestryLoss_growthFactor_SSP5
-Ohio,OH,2097,0.256361685,forestryLoss_growthFactor_SSP5
-Ohio,OH,2098,0.250755245,forestryLoss_growthFactor_SSP5
-Ohio,OH,2099,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2000,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2001,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2002,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2003,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2004,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2005,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2006,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2007,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2008,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2009,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2010,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2011,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2012,NA,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2013,1.014001824,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2014,1.006931696,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2015,1,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2016,0.987501682,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2017,0.975392625,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2018,0.96365473,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2019,0.952271007,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2020,0.941225498,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2021,0.928905467,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2022,0.916961705,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2023,0.90537694,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2024,0.894134957,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2025,0.883220514,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2026,0.872283383,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2027,0.861672424,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2028,0.851372929,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2029,0.841371076,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2030,0.831653864,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2031,0.823503129,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2032,0.815603023,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2033,0.80794185,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2034,0.800508642,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2035,0.793293107,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2036,0.840255989,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2037,0.885659616,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2038,0.929579746,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2039,0.972087331,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2040,1.01324889,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2041,0.988543427,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2042,0.964563093,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2043,0.941275894,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2044,0.918651712,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2045,0.896662172,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2046,0.900286619,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2047,0.903758594,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2048,0.907085991,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2049,0.91027621,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2050,0.913336193,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2051,0.918066832,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2052,0.922612932,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2053,0.926983624,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2054,0.931187492,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2055,0.935232603,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2056,0.935564091,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2057,0.9358173,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2058,0.935997508,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2059,0.936109626,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2060,0.936158227,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2061,0.937797342,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2062,0.939319785,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2063,0.940732541,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2064,0.942042124,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2065,0.943254619,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2066,0.937863471,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2067,0.932529057,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2068,0.927251688,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2069,0.922031557,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2070,0.916868753,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2071,0.912437017,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2072,0.908127195,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2073,0.9039342,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2074,0.89985323,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2075,0.895879746,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2076,0.892388755,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2077,0.888995611,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2078,0.885696123,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2079,0.88248634,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2080,0.879362534,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2081,0.877158274,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2082,0.875019457,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2083,0.872943166,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2084,0.870926655,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2085,0.868967341,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2086,0.875940119,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2087,0.882691722,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2088,0.889232401,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2089,0.89557179,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2090,0.901718945,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2091,0.881494966,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2092,0.861809411,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2093,0.842638753,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2094,0.823960876,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2095,0.805754967,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2096,0.786894252,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2097,0.76855169,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2098,0.750703716,forestryLoss_growthFactor_SSP5
-Oklahoma,OK,2099,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2000,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2001,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2002,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2003,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2004,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2005,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2006,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2007,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2008,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2009,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2010,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2011,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2012,NA,forestryLoss_growthFactor_SSP5
-Oregon,OR,2013,0.983824573,forestryLoss_growthFactor_SSP5
-Oregon,OR,2014,0.992012183,forestryLoss_growthFactor_SSP5
-Oregon,OR,2015,1,forestryLoss_growthFactor_SSP5
-Oregon,OR,2016,1.002010315,forestryLoss_growthFactor_SSP5
-Oregon,OR,2017,1.00393484,forestryLoss_growthFactor_SSP5
-Oregon,OR,2018,1.005778284,forestryLoss_growthFactor_SSP5
-Oregon,OR,2019,1.007545035,forestryLoss_growthFactor_SSP5
-Oregon,OR,2020,1.009239192,forestryLoss_growthFactor_SSP5
-Oregon,OR,2021,0.998357144,forestryLoss_growthFactor_SSP5
-Oregon,OR,2022,0.987808672,forestryLoss_growthFactor_SSP5
-Oregon,OR,2023,0.97757842,forestryLoss_growthFactor_SSP5
-Oregon,OR,2024,0.967651971,forestryLoss_growthFactor_SSP5
-Oregon,OR,2025,0.958015778,forestryLoss_growthFactor_SSP5
-Oregon,OR,2026,0.957555056,forestryLoss_growthFactor_SSP5
-Oregon,OR,2027,0.957090457,forestryLoss_growthFactor_SSP5
-Oregon,OR,2028,0.956622811,forestryLoss_growthFactor_SSP5
-Oregon,OR,2029,0.956152868,forestryLoss_growthFactor_SSP5
-Oregon,OR,2030,0.955681302,forestryLoss_growthFactor_SSP5
-Oregon,OR,2031,0.962630617,forestryLoss_growthFactor_SSP5
-Oregon,OR,2032,0.96933482,forestryLoss_growthFactor_SSP5
-Oregon,OR,2033,0.975806463,forestryLoss_growthFactor_SSP5
-Oregon,OR,2034,0.982057263,forestryLoss_growthFactor_SSP5
-Oregon,OR,2035,0.98809817,forestryLoss_growthFactor_SSP5
-Oregon,OR,2036,0.992240157,forestryLoss_growthFactor_SSP5
-Oregon,OR,2037,0.99623731,forestryLoss_growthFactor_SSP5
-Oregon,OR,2038,1.000096888,forestryLoss_growthFactor_SSP5
-Oregon,OR,2039,1.003825682,forestryLoss_growthFactor_SSP5
-Oregon,OR,2040,1.007430048,forestryLoss_growthFactor_SSP5
-Oregon,OR,2041,1.023450031,forestryLoss_growthFactor_SSP5
-Oregon,OR,2042,1.038960445,forestryLoss_growthFactor_SSP5
-Oregon,OR,2043,1.053985047,forestryLoss_growthFactor_SSP5
-Oregon,OR,2044,1.068546146,forestryLoss_growthFactor_SSP5
-Oregon,OR,2045,1.082664712,forestryLoss_growthFactor_SSP5
-Oregon,OR,2046,1.09785597,forestryLoss_growthFactor_SSP5
-Oregon,OR,2047,1.1126079,forestryLoss_growthFactor_SSP5
-Oregon,OR,2048,1.126939157,forestryLoss_growthFactor_SSP5
-Oregon,OR,2049,1.14086736,forestryLoss_growthFactor_SSP5
-Oregon,OR,2050,1.154409161,forestryLoss_growthFactor_SSP5
-Oregon,OR,2051,1.17670535,forestryLoss_growthFactor_SSP5
-Oregon,OR,2052,1.19838674,forestryLoss_growthFactor_SSP5
-Oregon,OR,2053,1.219478331,forestryLoss_growthFactor_SSP5
-Oregon,OR,2054,1.240003787,forestryLoss_growthFactor_SSP5
-Oregon,OR,2055,1.259985526,forestryLoss_growthFactor_SSP5
-Oregon,OR,2056,1.313336646,forestryLoss_growthFactor_SSP5
-Oregon,OR,2057,1.365220079,forestryLoss_growthFactor_SSP5
-Oregon,OR,2058,1.415695493,forestryLoss_growthFactor_SSP5
-Oregon,OR,2059,1.464819369,forestryLoss_growthFactor_SSP5
-Oregon,OR,2060,1.512645208,forestryLoss_growthFactor_SSP5
-Oregon,OR,2061,1.465217095,forestryLoss_growthFactor_SSP5
-Oregon,OR,2062,1.419148854,forestryLoss_growthFactor_SSP5
-Oregon,OR,2063,1.374382766,forestryLoss_growthFactor_SSP5
-Oregon,OR,2064,1.330864335,forestryLoss_growthFactor_SSP5
-Oregon,OR,2065,1.288542064,forestryLoss_growthFactor_SSP5
-Oregon,OR,2066,1.352758391,forestryLoss_growthFactor_SSP5
-Oregon,OR,2067,1.415099614,forestryLoss_growthFactor_SSP5
-Oregon,OR,2068,1.475646578,forestryLoss_growthFactor_SSP5
-Oregon,OR,2069,1.53447555,forestryLoss_growthFactor_SSP5
-Oregon,OR,2070,1.591658539,forestryLoss_growthFactor_SSP5
-Oregon,OR,2071,1.485040539,forestryLoss_growthFactor_SSP5
-Oregon,OR,2072,1.381565507,forestryLoss_growthFactor_SSP5
-Oregon,OR,2073,1.281096477,forestryLoss_growthFactor_SSP5
-Oregon,OR,2074,1.183504325,forestryLoss_growthFactor_SSP5
-Oregon,OR,2075,1.088667222,forestryLoss_growthFactor_SSP5
-Oregon,OR,2076,1.074825464,forestryLoss_growthFactor_SSP5
-Oregon,OR,2077,1.061402582,forestryLoss_growthFactor_SSP5
-Oregon,OR,2078,1.048379842,forestryLoss_growthFactor_SSP5
-Oregon,OR,2079,1.03573961,forestryLoss_growthFactor_SSP5
-Oregon,OR,2080,1.023465273,forestryLoss_growthFactor_SSP5
-Oregon,OR,2081,1.027356773,forestryLoss_growthFactor_SSP5
-Oregon,OR,2082,1.03112912,forestryLoss_growthFactor_SSP5
-Oregon,OR,2083,1.034787704,forestryLoss_growthFactor_SSP5
-Oregon,OR,2084,1.038337594,forestryLoss_growthFactor_SSP5
-Oregon,OR,2085,1.041783562,forestryLoss_growthFactor_SSP5
-Oregon,OR,2086,1.0228369,forestryLoss_growthFactor_SSP5
-Oregon,OR,2087,1.004480623,forestryLoss_growthFactor_SSP5
-Oregon,OR,2088,0.986687559,forestryLoss_growthFactor_SSP5
-Oregon,OR,2089,0.969432178,forestryLoss_growthFactor_SSP5
-Oregon,OR,2090,0.95269047,forestryLoss_growthFactor_SSP5
-Oregon,OR,2091,0.976388974,forestryLoss_growthFactor_SSP5
-Oregon,OR,2092,0.999336757,forestryLoss_growthFactor_SSP5
-Oregon,OR,2093,1.021568957,forestryLoss_growthFactor_SSP5
-Oregon,OR,2094,1.04311855,forestryLoss_growthFactor_SSP5
-Oregon,OR,2095,1.064016518,forestryLoss_growthFactor_SSP5
-Oregon,OR,2096,1.082494087,forestryLoss_growthFactor_SSP5
-Oregon,OR,2097,1.100372049,forestryLoss_growthFactor_SSP5
-Oregon,OR,2098,1.117679167,forestryLoss_growthFactor_SSP5
-Oregon,OR,2099,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2000,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2001,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2002,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2003,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2004,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2005,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2006,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2007,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2008,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2009,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2010,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2011,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2012,NA,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2013,1.023038958,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2014,1.011337639,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2015,1,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2016,0.983333976,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2017,0.967305215,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2018,0.951880417,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2019,0.937028478,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2020,0.922720317,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2021,0.904302627,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2022,0.8865951,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2023,0.869559762,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2024,0.853161213,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2025,0.837366413,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2026,0.821689317,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2027,0.806622303,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2028,0.792132553,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2029,0.778189482,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2030,0.764764556,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2031,0.751845537,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2032,0.739417359,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2033,0.727453804,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2034,0.715930439,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2035,0.704824476,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2036,0.693820888,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2037,0.683238816,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2038,0.673056069,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2039,0.663251936,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2040,0.653807062,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2041,0.64564709,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2042,0.63780317,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2043,0.630258881,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2044,0.622998868,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2045,0.616008762,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2046,0.612014562,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2047,0.608189609,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2048,0.604525116,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2049,0.601012845,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2050,0.597645071,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2051,0.594089257,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2052,0.59067964,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2053,0.587408824,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2054,0.584269866,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2055,0.581256245,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2056,0.573453664,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2057,0.565916503,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2058,0.558632433,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2059,0.551589846,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2060,0.544777803,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2061,0.541916347,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2062,0.539184632,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2063,0.536575758,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2064,0.534083268,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2065,0.531701107,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2066,0.520534848,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2067,0.509762194,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2068,0.499364326,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2069,0.489323557,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2070,0.47962325,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2071,0.471789805,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2072,0.464192952,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2073,0.456822232,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2074,0.449667792,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2075,0.44272034,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2076,0.437198211,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2077,0.431846986,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2078,0.42665893,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2079,0.421626768,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2080,0.416743647,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2081,0.409497005,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2082,0.402472942,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2083,0.395661375,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2084,0.38905282,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2085,0.382638352,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2086,0.378753781,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2087,0.374991554,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2088,0.371346016,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2089,0.367811855,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2090,0.364384074,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2091,0.358427818,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2092,0.352688963,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2093,0.347156863,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2094,0.341821537,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2095,0.336673618,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2096,0.331191212,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2097,0.325908982,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2098,0.320817018,forestryLoss_growthFactor_SSP5
-Pennsylvania,PA,2099,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2000,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2001,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2002,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2003,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2004,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2005,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2006,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2007,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2008,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2009,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2010,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2011,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2012,NA,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2013,1.032674919,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2014,1.016092752,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2015,1,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2016,0.978726543,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2017,0.958257165,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2018,0.938550088,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2019,0.919566277,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2020,0.90126923,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2021,0.881826906,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2022,0.863142122,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2023,0.845174141,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2024,0.827884999,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2025,0.811239274,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2026,0.793694043,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2027,0.776835718,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2028,0.76062723,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2029,0.745034038,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2030,0.730023921,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2031,0.715991433,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2032,0.702495772,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2033,0.689508156,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2034,0.677001773,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2035,0.664951613,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2036,0.651514048,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2037,0.638584061,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2038,0.626135123,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2039,0.61414246,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2040,0.60258292,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2041,0.590666035,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2042,0.579187908,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2043,0.568126302,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2044,0.557460403,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2045,0.547170716,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2046,0.537447088,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2047,0.528058576,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2048,0.51898934,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2049,0.51022449,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2050,0.501750007,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2051,0.49318754,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2052,0.484910325,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2053,0.476905284,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2054,0.469160094,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2055,0.461663136,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2056,0.452442106,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2057,0.443525058,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2058,0.434898109,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2059,0.426548179,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2060,0.418462937,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2061,0.4099639,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2062,0.401754613,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2063,0.393821432,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2064,0.38615153,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2065,0.378732834,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2066,0.367149647,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2067,0.355965826,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2068,0.345162481,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2069,0.334721848,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2070,0.324627215,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2071,0.32050278,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2072,0.316504824,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2073,0.312627707,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2074,0.308866119,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2075,0.30521505,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2076,0.301590687,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2077,0.298078904,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2078,0.294674598,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2079,0.291372966,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2080,0.288169487,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2081,0.284777864,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2082,0.281490567,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2083,0.278302866,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2084,0.275210314,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2085,0.272208724,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2086,0.268969862,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2087,0.265832888,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2088,0.262793094,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2089,0.259846057,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2090,0.256987617,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2091,0.248394269,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2092,0.240090346,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2093,0.232062021,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2094,0.224296322,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2095,0.216781068,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2096,0.209212938,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2097,0.201902147,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2098,0.194836189,forestryLoss_growthFactor_SSP5
-Rhode Island,RI,2099,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2000,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2001,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2002,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2003,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2004,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2005,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2006,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2007,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2008,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2009,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2010,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2011,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2012,NA,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2013,0.972016066,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2014,0.986180153,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2015,1,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2016,1.007670325,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2017,1.015058652,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2018,1.022179432,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2019,1.02904617,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2020,1.035671508,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2021,1.025003635,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2022,1.014649488,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2023,1.004595108,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2024,0.994827365,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2025,0.985333901,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2026,0.987844247,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2027,0.990239664,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2028,0.992526825,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2029,0.99471193,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2030,0.996800746,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2031,0.990681831,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2032,0.984751291,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2033,0.979000328,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2034,0.973420691,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2035,0.968004638,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2036,0.95996237,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2037,0.952160027,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2038,0.944586778,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2039,0.937232443,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2040,0.930087448,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2041,0.928172423,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2042,0.92629766,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2043,0.924461897,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2044,0.922663927,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2045,0.92090259,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2046,0.930254291,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2047,0.939325565,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2048,0.948128617,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2049,0.956674964,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2050,0.964975477,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2051,0.939129491,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2052,0.913972567,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2053,0.889477401,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2054,0.865618112,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2055,0.842370161,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2056,0.843823863,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2057,0.845224555,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2058,0.846574787,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2059,0.847876955,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2060,0.849133317,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2061,0.84616156,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2062,0.843261806,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2063,0.840431382,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2064,0.837667753,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2065,0.834968508,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2066,0.831467695,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2067,0.828044936,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2068,0.824697528,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2069,0.821422895,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2070,0.818218585,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2071,0.808894607,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2072,0.799843727,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2073,0.791054091,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2074,0.782514519,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2075,0.774214463,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2076,0.765300804,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2077,0.756655451,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2078,0.748266438,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2079,0.740122502,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2080,0.732213029,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2081,0.725381779,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2082,0.718759367,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2083,0.712336355,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2084,0.706103864,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2085,0.700053534,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2086,0.694316648,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2087,0.688758154,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2088,0.683369851,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2089,0.678144029,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2090,0.67307344,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2091,0.682034849,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2092,0.690705885,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2093,0.699100245,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2094,0.707230781,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2095,0.715109567,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2096,0.721546122,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2097,0.727768862,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2098,0.733788111,forestryLoss_growthFactor_SSP5
-South Carolina,SC,2099,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2000,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2001,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2002,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2003,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2004,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2005,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2006,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2007,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2008,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2009,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2010,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2011,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2012,NA,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2013,1.004178126,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2014,1.002090744,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2015,1,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2016,0.99217943,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2017,0.984566443,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2018,0.977152505,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2019,0.969929559,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2020,0.962889992,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2021,0.956437362,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2022,0.950140172,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2023,0.943992803,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2024,0.937989909,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2025,0.932126397,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2026,0.922570879,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2027,0.913268485,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2028,0.904208985,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2029,0.89538271,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2030,0.886780513,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2031,0.882583476,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2032,0.878487141,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2033,0.874487809,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2034,0.870581969,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2035,0.866766283,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2036,0.863440995,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2037,0.860166461,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2038,0.856942031,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2039,0.853767022,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2040,0.850640725,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2041,0.845154631,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2042,0.839772369,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2043,0.834491207,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2044,0.829308498,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2045,0.824221673,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2046,0.811306148,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2047,0.798673864,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2048,0.786315482,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2049,0.77422208,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2050,0.76238512,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2051,0.761370747,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2052,0.760289322,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2053,0.759146435,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2054,0.757947263,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2055,0.756696602,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2056,0.759136512,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2057,0.761381628,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2058,0.763443735,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2059,0.765333836,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2060,0.767062207,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2061,0.782352352,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2062,0.797064899,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2063,0.811228424,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2064,0.82486975,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2065,0.838014077,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2066,0.817866327,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2067,0.79808285,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2068,0.778654074,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2069,0.759570745,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2070,0.74082392,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2071,0.755733895,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2072,0.770183475,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2073,0.784193266,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2074,0.797782674,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2075,0.810969993,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2076,0.778260126,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2077,0.74652067,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2078,0.715708685,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2079,0.685783738,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2080,0.656707724,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2081,0.654658278,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2082,0.652666037,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2083,0.650728529,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2084,0.648843429,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2085,0.647008542,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2086,0.642743153,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2087,0.638599283,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2088,0.634571553,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2089,0.630654907,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2090,0.626844584,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2091,0.616120576,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2092,0.605414264,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2093,0.594730091,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2094,0.584072114,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2095,0.573444034,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2096,0.562897536,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2097,0.552375265,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2098,0.541880431,forestryLoss_growthFactor_SSP5
-South Dakota,SD,2099,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2000,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2001,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2002,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2003,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2004,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2005,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2006,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2007,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2008,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2009,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2010,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2011,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2012,NA,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2013,0.999527312,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2014,0.999765523,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2015,1,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2016,0.994489421,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2017,0.98915736,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2018,0.983995301,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2019,0.978995263,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2020,0.974149754,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2021,0.966368849,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2022,0.958843818,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2023,0.951562251,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2024,0.944512529,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2025,0.937683759,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2026,0.921111122,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2027,0.905083791,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2028,0.889575273,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2029,0.874560765,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2030,0.860017022,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2031,0.856026251,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2032,0.852168864,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2033,0.84843826,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2034,0.844828264,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2035,0.8413331,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2036,0.833526059,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2037,0.825968578,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2038,0.818648827,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2039,0.811555713,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2040,0.804678825,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2041,0.800214084,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2042,0.795883926,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2043,0.791682299,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2044,0.787603511,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2045,0.783642201,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2046,0.771878096,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2047,0.760440921,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2048,0.749317191,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2049,0.738494153,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2050,0.727959738,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2051,0.728691046,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2052,0.729397639,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2053,0.730080658,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2054,0.730741179,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2055,0.731380216,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2056,0.728353036,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2057,0.725402596,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2058,0.722525973,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2059,0.719720393,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2060,0.716983222,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2061,0.716847854,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2062,0.716707461,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2063,0.716562516,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2064,0.716413455,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2065,0.716260682,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2066,0.710451431,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2067,0.704793129,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2068,0.699279779,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2069,0.693905705,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2070,0.688665531,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2071,0.689946725,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2072,0.691188683,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2073,0.692393154,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2074,0.693561785,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2075,0.694696127,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2076,0.688502039,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2077,0.682494304,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2078,0.676664614,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2079,0.671005148,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2080,0.665508535,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2081,0.659676757,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2082,0.654023177,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2083,0.648539741,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2084,0.643218877,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2085,0.638053453,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2086,0.634012395,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2087,0.630096572,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2088,0.626300232,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2089,0.622617971,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2090,0.619044707,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2091,0.610566552,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2092,0.602337638,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2093,0.594346617,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2094,0.586582829,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2095,0.579036256,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2096,0.570812812,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2097,0.562837607,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2098,0.555098987,forestryLoss_growthFactor_SSP5
-Tennessee,TN,2099,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2000,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2001,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2002,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2003,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2004,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2005,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2006,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2007,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2008,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2009,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2010,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2011,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2012,NA,forestryLoss_growthFactor_SSP5
-Texas,TX,2013,0.992198107,forestryLoss_growthFactor_SSP5
-Texas,TX,2014,0.996224445,forestryLoss_growthFactor_SSP5
-Texas,TX,2015,1,forestryLoss_growthFactor_SSP5
-Texas,TX,2016,0.997777472,forestryLoss_growthFactor_SSP5
-Texas,TX,2017,0.995477423,forestryLoss_growthFactor_SSP5
-Texas,TX,2018,0.993108011,forestryLoss_growthFactor_SSP5
-Texas,TX,2019,0.990676708,forestryLoss_growthFactor_SSP5
-Texas,TX,2020,0.988190359,forestryLoss_growthFactor_SSP5
-Texas,TX,2021,0.984934735,forestryLoss_growthFactor_SSP5
-Texas,TX,2022,0.981622917,forestryLoss_growthFactor_SSP5
-Texas,TX,2023,0.978263153,forestryLoss_growthFactor_SSP5
-Texas,TX,2024,0.974862916,forestryLoss_growthFactor_SSP5
-Texas,TX,2025,0.971428985,forestryLoss_growthFactor_SSP5
-Texas,TX,2026,0.964318512,forestryLoss_growthFactor_SSP5
-Texas,TX,2027,0.957291175,forestryLoss_growthFactor_SSP5
-Texas,TX,2028,0.950348025,forestryLoss_growthFactor_SSP5
-Texas,TX,2029,0.943489819,forestryLoss_growthFactor_SSP5
-Texas,TX,2030,0.936717054,forestryLoss_growthFactor_SSP5
-Texas,TX,2031,0.935014471,forestryLoss_growthFactor_SSP5
-Texas,TX,2032,0.933277534,forestryLoss_growthFactor_SSP5
-Texas,TX,2033,0.931510914,forestryLoss_growthFactor_SSP5
-Texas,TX,2034,0.929718848,forestryLoss_growthFactor_SSP5
-Texas,TX,2035,0.927905187,forestryLoss_growthFactor_SSP5
-Texas,TX,2036,0.929168678,forestryLoss_growthFactor_SSP5
-Texas,TX,2037,0.930278361,forestryLoss_growthFactor_SSP5
-Texas,TX,2038,0.931245114,forestryLoss_growthFactor_SSP5
-Texas,TX,2039,0.932078985,forestryLoss_growthFactor_SSP5
-Texas,TX,2040,0.93278927,forestryLoss_growthFactor_SSP5
-Texas,TX,2041,0.927071017,forestryLoss_growthFactor_SSP5
-Texas,TX,2042,0.921418026,forestryLoss_growthFactor_SSP5
-Texas,TX,2043,0.915830738,forestryLoss_growthFactor_SSP5
-Texas,TX,2044,0.910309426,forestryLoss_growthFactor_SSP5
-Texas,TX,2045,0.904854219,forestryLoss_growthFactor_SSP5
-Texas,TX,2046,0.899358474,forestryLoss_growthFactor_SSP5
-Texas,TX,2047,0.893907274,forestryLoss_growthFactor_SSP5
-Texas,TX,2048,0.888502134,forestryLoss_growthFactor_SSP5
-Texas,TX,2049,0.883144354,forestryLoss_growthFactor_SSP5
-Texas,TX,2050,0.877835034,forestryLoss_growthFactor_SSP5
-Texas,TX,2051,0.876467186,forestryLoss_growthFactor_SSP5
-Texas,TX,2052,0.875033061,forestryLoss_growthFactor_SSP5
-Texas,TX,2053,0.873538487,forestryLoss_growthFactor_SSP5
-Texas,TX,2054,0.871988856,forestryLoss_growthFactor_SSP5
-Texas,TX,2055,0.870389158,forestryLoss_growthFactor_SSP5
-Texas,TX,2056,0.865020204,forestryLoss_growthFactor_SSP5
-Texas,TX,2057,0.859681684,forestryLoss_growthFactor_SSP5
-Texas,TX,2058,0.854375912,forestryLoss_growthFactor_SSP5
-Texas,TX,2059,0.849104936,forestryLoss_growthFactor_SSP5
-Texas,TX,2060,0.843870564,forestryLoss_growthFactor_SSP5
-Texas,TX,2061,0.838280597,forestryLoss_growthFactor_SSP5
-Texas,TX,2062,0.83274041,forestryLoss_growthFactor_SSP5
-Texas,TX,2063,0.827251112,forestryLoss_growthFactor_SSP5
-Texas,TX,2064,0.821813626,forestryLoss_growthFactor_SSP5
-Texas,TX,2065,0.816428709,forestryLoss_growthFactor_SSP5
-Texas,TX,2066,0.803589553,forestryLoss_growthFactor_SSP5
-Texas,TX,2067,0.79096903,forestryLoss_growthFactor_SSP5
-Texas,TX,2068,0.778561993,forestryLoss_growthFactor_SSP5
-Texas,TX,2069,0.766363428,forestryLoss_growthFactor_SSP5
-Texas,TX,2070,0.754368459,forestryLoss_growthFactor_SSP5
-Texas,TX,2071,0.753489604,forestryLoss_growthFactor_SSP5
-Texas,TX,2072,0.752624608,forestryLoss_growthFactor_SSP5
-Texas,TX,2073,0.75177318,forestryLoss_growthFactor_SSP5
-Texas,TX,2074,0.750935034,forestryLoss_growthFactor_SSP5
-Texas,TX,2075,0.750109891,forestryLoss_growthFactor_SSP5
-Texas,TX,2076,0.745931563,forestryLoss_growthFactor_SSP5
-Texas,TX,2077,0.741870374,forestryLoss_growthFactor_SSP5
-Texas,TX,2078,0.737921303,forestryLoss_growthFactor_SSP5
-Texas,TX,2079,0.734079622,forestryLoss_growthFactor_SSP5
-Texas,TX,2080,0.730340866,forestryLoss_growthFactor_SSP5
-Texas,TX,2081,0.726342219,forestryLoss_growthFactor_SSP5
-Texas,TX,2082,0.72246387,forestryLoss_growthFactor_SSP5
-Texas,TX,2083,0.718700422,forestryLoss_growthFactor_SSP5
-Texas,TX,2084,0.715046798,forestryLoss_growthFactor_SSP5
-Texas,TX,2085,0.711498218,forestryLoss_growthFactor_SSP5
-Texas,TX,2086,0.708423798,forestryLoss_growthFactor_SSP5
-Texas,TX,2087,0.705441456,forestryLoss_growthFactor_SSP5
-Texas,TX,2088,0.702547026,forestryLoss_growthFactor_SSP5
-Texas,TX,2089,0.69973659,forestryLoss_growthFactor_SSP5
-Texas,TX,2090,0.697006463,forestryLoss_growthFactor_SSP5
-Texas,TX,2091,0.679814411,forestryLoss_growthFactor_SSP5
-Texas,TX,2092,0.663078474,forestryLoss_growthFactor_SSP5
-Texas,TX,2093,0.646778753,forestryLoss_growthFactor_SSP5
-Texas,TX,2094,0.63089654,forestryLoss_growthFactor_SSP5
-Texas,TX,2095,0.615414231,forestryLoss_growthFactor_SSP5
-Texas,TX,2096,0.599290734,forestryLoss_growthFactor_SSP5
-Texas,TX,2097,0.583619872,forestryLoss_growthFactor_SSP5
-Texas,TX,2098,0.568380902,forestryLoss_growthFactor_SSP5
-Texas,TX,2099,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2000,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2001,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2002,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2003,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2004,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2005,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2006,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2007,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2008,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2009,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2010,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2011,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2012,NA,forestryLoss_growthFactor_SSP5
-Utah,UT,2013,0.998031656,forestryLoss_growthFactor_SSP5
-Utah,UT,2014,0.999101014,forestryLoss_growthFactor_SSP5
-Utah,UT,2015,1,forestryLoss_growthFactor_SSP5
-Utah,UT,2016,0.994994293,forestryLoss_growthFactor_SSP5
-Utah,UT,2017,0.990015716,forestryLoss_growthFactor_SSP5
-Utah,UT,2018,0.985067002,forestryLoss_growthFactor_SSP5
-Utah,UT,2019,0.980150554,forestryLoss_growthFactor_SSP5
-Utah,UT,2020,0.975268481,forestryLoss_growthFactor_SSP5
-Utah,UT,2021,0.969539944,forestryLoss_growthFactor_SSP5
-Utah,UT,2022,0.963849639,forestryLoss_growthFactor_SSP5
-Utah,UT,2023,0.958200789,forestryLoss_growthFactor_SSP5
-Utah,UT,2024,0.952596187,forestryLoss_growthFactor_SSP5
-Utah,UT,2025,0.947038238,forestryLoss_growthFactor_SSP5
-Utah,UT,2026,0.941882254,forestryLoss_growthFactor_SSP5
-Utah,UT,2027,0.936757317,forestryLoss_growthFactor_SSP5
-Utah,UT,2028,0.931666596,forestryLoss_growthFactor_SSP5
-Utah,UT,2029,0.926612848,forestryLoss_growthFactor_SSP5
-Utah,UT,2030,0.921598467,forestryLoss_growthFactor_SSP5
-Utah,UT,2031,0.918495056,forestryLoss_growthFactor_SSP5
-Utah,UT,2032,0.915412578,forestryLoss_growthFactor_SSP5
-Utah,UT,2033,0.912352692,forestryLoss_growthFactor_SSP5
-Utah,UT,2034,0.909316831,forestryLoss_growthFactor_SSP5
-Utah,UT,2035,0.906306231,forestryLoss_growthFactor_SSP5
-Utah,UT,2036,0.901360205,forestryLoss_growthFactor_SSP5
-Utah,UT,2037,0.896469053,forestryLoss_growthFactor_SSP5
-Utah,UT,2038,0.891633438,forestryLoss_growthFactor_SSP5
-Utah,UT,2039,0.886853843,forestryLoss_growthFactor_SSP5
-Utah,UT,2040,0.882130599,forestryLoss_growthFactor_SSP5
-Utah,UT,2041,0.880002189,forestryLoss_growthFactor_SSP5
-Utah,UT,2042,0.877832645,forestryLoss_growthFactor_SSP5
-Utah,UT,2043,0.875627133,forestryLoss_growthFactor_SSP5
-Utah,UT,2044,0.873390378,forestryLoss_growthFactor_SSP5
-Utah,UT,2045,0.871126698,forestryLoss_growthFactor_SSP5
-Utah,UT,2046,0.865508708,forestryLoss_growthFactor_SSP5
-Utah,UT,2047,0.859941525,forestryLoss_growthFactor_SSP5
-Utah,UT,2048,0.85442632,forestryLoss_growthFactor_SSP5
-Utah,UT,2049,0.848964066,forestryLoss_growthFactor_SSP5
-Utah,UT,2050,0.843555559,forestryLoss_growthFactor_SSP5
-Utah,UT,2051,0.844803108,forestryLoss_growthFactor_SSP5
-Utah,UT,2052,0.845917452,forestryLoss_growthFactor_SSP5
-Utah,UT,2053,0.846906985,forestryLoss_growthFactor_SSP5
-Utah,UT,2054,0.847779534,forestryLoss_growthFactor_SSP5
-Utah,UT,2055,0.848542401,forestryLoss_growthFactor_SSP5
-Utah,UT,2056,0.840297574,forestryLoss_growthFactor_SSP5
-Utah,UT,2057,0.832172056,forestryLoss_growthFactor_SSP5
-Utah,UT,2058,0.824164253,forestryLoss_growthFactor_SSP5
-Utah,UT,2059,0.816272527,forestryLoss_growthFactor_SSP5
-Utah,UT,2060,0.808495201,forestryLoss_growthFactor_SSP5
-Utah,UT,2061,0.801447637,forestryLoss_growthFactor_SSP5
-Utah,UT,2062,0.794510265,forestryLoss_growthFactor_SSP5
-Utah,UT,2063,0.787681089,forestryLoss_growthFactor_SSP5
-Utah,UT,2064,0.780958118,forestryLoss_growthFactor_SSP5
-Utah,UT,2065,0.774339376,forestryLoss_growthFactor_SSP5
-Utah,UT,2066,0.763757427,forestryLoss_growthFactor_SSP5
-Utah,UT,2067,0.75334438,forestryLoss_growthFactor_SSP5
-Utah,UT,2068,0.74309679,forestryLoss_growthFactor_SSP5
-Utah,UT,2069,0.733011265,forestryLoss_growthFactor_SSP5
-Utah,UT,2070,0.723084472,forestryLoss_growthFactor_SSP5
-Utah,UT,2071,0.720727006,forestryLoss_growthFactor_SSP5
-Utah,UT,2072,0.718426416,forestryLoss_growthFactor_SSP5
-Utah,UT,2073,0.716180549,forestryLoss_growthFactor_SSP5
-Utah,UT,2074,0.713987367,forestryLoss_growthFactor_SSP5
-Utah,UT,2075,0.711844937,forestryLoss_growthFactor_SSP5
-Utah,UT,2076,0.696212938,forestryLoss_growthFactor_SSP5
-Utah,UT,2077,0.681044264,forestryLoss_growthFactor_SSP5
-Utah,UT,2078,0.666318423,forestryLoss_growthFactor_SSP5
-Utah,UT,2079,0.652016119,forestryLoss_growthFactor_SSP5
-Utah,UT,2080,0.638119169,forestryLoss_growthFactor_SSP5
-Utah,UT,2081,0.631258494,forestryLoss_growthFactor_SSP5
-Utah,UT,2082,0.624605513,forestryLoss_growthFactor_SSP5
-Utah,UT,2083,0.618150883,forestryLoss_growthFactor_SSP5
-Utah,UT,2084,0.611885813,forestryLoss_growthFactor_SSP5
-Utah,UT,2085,0.605802025,forestryLoss_growthFactor_SSP5
-Utah,UT,2086,0.60066018,forestryLoss_growthFactor_SSP5
-Utah,UT,2087,0.595674584,forestryLoss_growthFactor_SSP5
-Utah,UT,2088,0.590838123,forestryLoss_growthFactor_SSP5
-Utah,UT,2089,0.586144107,forestryLoss_growthFactor_SSP5
-Utah,UT,2090,0.581586246,forestryLoss_growthFactor_SSP5
-Utah,UT,2091,0.566199928,forestryLoss_growthFactor_SSP5
-Utah,UT,2092,0.551204898,forestryLoss_growthFactor_SSP5
-Utah,UT,2093,0.536584416,forestryLoss_growthFactor_SSP5
-Utah,UT,2094,0.522322736,forestryLoss_growthFactor_SSP5
-Utah,UT,2095,0.508405034,forestryLoss_growthFactor_SSP5
-Utah,UT,2096,0.494200693,forestryLoss_growthFactor_SSP5
-Utah,UT,2097,0.48036782,forestryLoss_growthFactor_SSP5
-Utah,UT,2098,0.466889828,forestryLoss_growthFactor_SSP5
-Utah,UT,2099,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2000,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2001,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2002,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2003,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2004,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2005,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2006,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2007,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2008,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2009,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2010,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2011,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2012,NA,forestryLoss_growthFactor_SSP5
-Virginia,VA,2013,0.991220271,forestryLoss_growthFactor_SSP5
-Virginia,VA,2014,0.995664124,forestryLoss_growthFactor_SSP5
-Virginia,VA,2015,1,forestryLoss_growthFactor_SSP5
-Virginia,VA,2016,0.998467366,forestryLoss_growthFactor_SSP5
-Virginia,VA,2017,0.996972981,forestryLoss_growthFactor_SSP5
-Virginia,VA,2018,0.995515359,forestryLoss_growthFactor_SSP5
-Virginia,VA,2019,0.994093096,forestryLoss_growthFactor_SSP5
-Virginia,VA,2020,0.992704862,forestryLoss_growthFactor_SSP5
-Virginia,VA,2021,0.980183661,forestryLoss_growthFactor_SSP5
-Virginia,VA,2022,0.968065739,forestryLoss_growthFactor_SSP5
-Virginia,VA,2023,0.956331824,forestryLoss_growthFactor_SSP5
-Virginia,VA,2024,0.944963858,forestryLoss_growthFactor_SSP5
-Virginia,VA,2025,0.933944903,forestryLoss_growthFactor_SSP5
-Virginia,VA,2026,0.929893256,forestryLoss_growthFactor_SSP5
-Virginia,VA,2027,0.925970178,forestryLoss_growthFactor_SSP5
-Virginia,VA,2028,0.922169584,forestryLoss_growthFactor_SSP5
-Virginia,VA,2029,0.918485769,forestryLoss_growthFactor_SSP5
-Virginia,VA,2030,0.914913379,forestryLoss_growthFactor_SSP5
-Virginia,VA,2031,0.906622217,forestryLoss_growthFactor_SSP5
-Virginia,VA,2032,0.898609612,forestryLoss_growthFactor_SSP5
-Virginia,VA,2033,0.890861727,forestryLoss_growthFactor_SSP5
-Virginia,VA,2034,0.883365629,forestryLoss_growthFactor_SSP5
-Virginia,VA,2035,0.876109214,forestryLoss_growthFactor_SSP5
-Virginia,VA,2036,0.86653181,forestryLoss_growthFactor_SSP5
-Virginia,VA,2037,0.857263355,forestryLoss_growthFactor_SSP5
-Virginia,VA,2038,0.848289114,forestryLoss_growthFactor_SSP5
-Virginia,VA,2039,0.839595275,forestryLoss_growthFactor_SSP5
-Virginia,VA,2040,0.831168878,forestryLoss_growthFactor_SSP5
-Virginia,VA,2041,0.825645044,forestryLoss_growthFactor_SSP5
-Virginia,VA,2042,0.820292682,forestryLoss_growthFactor_SSP5
-Virginia,VA,2043,0.815103923,forestryLoss_growthFactor_SSP5
-Virginia,VA,2044,0.810071374,forestryLoss_growthFactor_SSP5
-Virginia,VA,2045,0.805188081,forestryLoss_growthFactor_SSP5
-Virginia,VA,2046,0.80712407,forestryLoss_growthFactor_SSP5
-Virginia,VA,2047,0.809006704,forestryLoss_growthFactor_SSP5
-Virginia,VA,2048,0.81083817,forestryLoss_growthFactor_SSP5
-Virginia,VA,2049,0.812620537,forestryLoss_growthFactor_SSP5
-Virginia,VA,2050,0.814355763,forestryLoss_growthFactor_SSP5
-Virginia,VA,2051,0.794982496,forestryLoss_growthFactor_SSP5
-Virginia,VA,2052,0.776137465,forestryLoss_growthFactor_SSP5
-Virginia,VA,2053,0.757799371,forestryLoss_growthFactor_SSP5
-Virginia,VA,2054,0.739948045,forestryLoss_growthFactor_SSP5
-Virginia,VA,2055,0.722564372,forestryLoss_growthFactor_SSP5
-Virginia,VA,2056,0.719687715,forestryLoss_growthFactor_SSP5
-Virginia,VA,2057,0.716891172,forestryLoss_growthFactor_SSP5
-Virginia,VA,2058,0.714171456,forestryLoss_growthFactor_SSP5
-Virginia,VA,2059,0.711525457,forestryLoss_growthFactor_SSP5
-Virginia,VA,2060,0.708950232,forestryLoss_growthFactor_SSP5
-Virginia,VA,2061,0.703197642,forestryLoss_growthFactor_SSP5
-Virginia,VA,2062,0.697612431,forestryLoss_growthFactor_SSP5
-Virginia,VA,2063,0.692187425,forestryLoss_growthFactor_SSP5
-Virginia,VA,2064,0.686915852,forestryLoss_growthFactor_SSP5
-Virginia,VA,2065,0.681791314,forestryLoss_growthFactor_SSP5
-Virginia,VA,2066,0.674401785,forestryLoss_growthFactor_SSP5
-Virginia,VA,2067,0.667231038,forestryLoss_growthFactor_SSP5
-Virginia,VA,2068,0.660269559,forestryLoss_growthFactor_SSP5
-Virginia,VA,2069,0.653508374,forestryLoss_growthFactor_SSP5
-Virginia,VA,2070,0.646939013,forestryLoss_growthFactor_SSP5
-Virginia,VA,2071,0.639726008,forestryLoss_growthFactor_SSP5
-Virginia,VA,2072,0.632725794,forestryLoss_growthFactor_SSP5
-Virginia,VA,2073,0.625929094,forestryLoss_growthFactor_SSP5
-Virginia,VA,2074,0.619327163,forestryLoss_growthFactor_SSP5
-Virginia,VA,2075,0.612911748,forestryLoss_growthFactor_SSP5
-Virginia,VA,2076,0.605857873,forestryLoss_growthFactor_SSP5
-Virginia,VA,2077,0.599017769,forestryLoss_growthFactor_SSP5
-Virginia,VA,2078,0.592381865,forestryLoss_growthFactor_SSP5
-Virginia,VA,2079,0.585941157,forestryLoss_growthFactor_SSP5
-Virginia,VA,2080,0.579687161,forestryLoss_growthFactor_SSP5
-Virginia,VA,2081,0.574017161,forestryLoss_growthFactor_SSP5
-Virginia,VA,2082,0.568520876,forestryLoss_growthFactor_SSP5
-Virginia,VA,2083,0.563190445,forestryLoss_growthFactor_SSP5
-Virginia,VA,2084,0.558018476,forestryLoss_growthFactor_SSP5
-Virginia,VA,2085,0.552998009,forestryLoss_growthFactor_SSP5
-Virginia,VA,2086,0.547896508,forestryLoss_growthFactor_SSP5
-Virginia,VA,2087,0.542954317,forestryLoss_growthFactor_SSP5
-Virginia,VA,2088,0.538164098,forestryLoss_growthFactor_SSP5
-Virginia,VA,2089,0.533518956,forestryLoss_growthFactor_SSP5
-Virginia,VA,2090,0.529012406,forestryLoss_growthFactor_SSP5
-Virginia,VA,2091,0.530175817,forestryLoss_growthFactor_SSP5
-Virginia,VA,2092,0.531311676,forestryLoss_growthFactor_SSP5
-Virginia,VA,2093,0.532421121,forestryLoss_growthFactor_SSP5
-Virginia,VA,2094,0.533505223,forestryLoss_growthFactor_SSP5
-Virginia,VA,2095,0.53456499,forestryLoss_growthFactor_SSP5
-Virginia,VA,2096,0.534678879,forestryLoss_growthFactor_SSP5
-Virginia,VA,2097,0.534798986,forestryLoss_growthFactor_SSP5
-Virginia,VA,2098,0.534924875,forestryLoss_growthFactor_SSP5
-Virginia,VA,2099,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2000,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2001,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2002,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2003,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2004,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2005,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2006,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2007,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2008,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2009,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2010,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2011,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2012,NA,forestryLoss_growthFactor_SSP5
-Vermont,VT,2013,1.002758283,forestryLoss_growthFactor_SSP5
-Vermont,VT,2014,1.001303433,forestryLoss_growthFactor_SSP5
-Vermont,VT,2015,1,forestryLoss_growthFactor_SSP5
-Vermont,VT,2016,0.993106028,forestryLoss_growthFactor_SSP5
-Vermont,VT,2017,0.98654289,forestryLoss_growthFactor_SSP5
-Vermont,VT,2018,0.980291601,forestryLoss_growthFactor_SSP5
-Vermont,VT,2019,0.974334486,forestryLoss_growthFactor_SSP5
-Vermont,VT,2020,0.968655081,forestryLoss_growthFactor_SSP5
-Vermont,VT,2021,0.950502479,forestryLoss_growthFactor_SSP5
-Vermont,VT,2022,0.933066484,forestryLoss_growthFactor_SSP5
-Vermont,VT,2023,0.916308296,forestryLoss_growthFactor_SSP5
-Vermont,VT,2024,0.900191765,forestryLoss_growthFactor_SSP5
-Vermont,VT,2025,0.88468317,forestryLoss_growthFactor_SSP5
-Vermont,VT,2026,0.871337839,forestryLoss_growthFactor_SSP5
-Vermont,VT,2027,0.858547159,forestryLoss_growthFactor_SSP5
-Vermont,VT,2028,0.846280287,forestryLoss_growthFactor_SSP5
-Vermont,VT,2029,0.834508518,forestryLoss_growthFactor_SSP5
-Vermont,VT,2030,0.823205112,forestryLoss_growthFactor_SSP5
-Vermont,VT,2031,0.810829754,forestryLoss_growthFactor_SSP5
-Vermont,VT,2032,0.798942306,forestryLoss_growthFactor_SSP5
-Vermont,VT,2033,0.787516198,forestryLoss_growthFactor_SSP5
-Vermont,VT,2034,0.776526693,forestryLoss_growthFactor_SSP5
-Vermont,VT,2035,0.765950734,forestryLoss_growthFactor_SSP5
-Vermont,VT,2036,0.760514423,forestryLoss_growthFactor_SSP5
-Vermont,VT,2037,0.755335916,forestryLoss_growthFactor_SSP5
-Vermont,VT,2038,0.750400335,forestryLoss_growthFactor_SSP5
-Vermont,VT,2039,0.745693841,forestryLoss_growthFactor_SSP5
-Vermont,VT,2040,0.741203546,forestryLoss_growthFactor_SSP5
-Vermont,VT,2041,0.74301314,forestryLoss_growthFactor_SSP5
-Vermont,VT,2042,0.744845162,forestryLoss_growthFactor_SSP5
-Vermont,VT,2043,0.74669618,forestryLoss_growthFactor_SSP5
-Vermont,VT,2044,0.748563063,forestryLoss_growthFactor_SSP5
-Vermont,VT,2045,0.750442957,forestryLoss_growthFactor_SSP5
-Vermont,VT,2046,0.762609842,forestryLoss_growthFactor_SSP5
-Vermont,VT,2047,0.77450629,forestryLoss_growthFactor_SSP5
-Vermont,VT,2048,0.786141359,forestryLoss_growthFactor_SSP5
-Vermont,VT,2049,0.797523698,forestryLoss_growthFactor_SSP5
-Vermont,VT,2050,0.808661574,forestryLoss_growthFactor_SSP5
-Vermont,VT,2051,0.819571998,forestryLoss_growthFactor_SSP5
-Vermont,VT,2052,0.830249317,forestryLoss_growthFactor_SSP5
-Vermont,VT,2053,0.84070097,forestryLoss_growthFactor_SSP5
-Vermont,VT,2054,0.850934078,forestryLoss_growthFactor_SSP5
-Vermont,VT,2055,0.860955464,forestryLoss_growthFactor_SSP5
-Vermont,VT,2056,0.85791437,forestryLoss_growthFactor_SSP5
-Vermont,VT,2057,0.8550239,forestryLoss_growthFactor_SSP5
-Vermont,VT,2058,0.852275905,forestryLoss_growthFactor_SSP5
-Vermont,VT,2059,0.849662747,forestryLoss_growthFactor_SSP5
-Vermont,VT,2060,0.847177272,forestryLoss_growthFactor_SSP5
-Vermont,VT,2061,0.861816158,forestryLoss_growthFactor_SSP5
-Vermont,VT,2062,0.87609613,forestryLoss_growthFactor_SSP5
-Vermont,VT,2063,0.890030649,forestryLoss_growthFactor_SSP5
-Vermont,VT,2064,0.903632493,forestryLoss_growthFactor_SSP5
-Vermont,VT,2065,0.916913798,forestryLoss_growthFactor_SSP5
-Vermont,VT,2066,0.908784774,forestryLoss_growthFactor_SSP5
-Vermont,VT,2067,0.900979091,forestryLoss_growthFactor_SSP5
-Vermont,VT,2068,0.893480454,forestryLoss_growthFactor_SSP5
-Vermont,VT,2069,0.886273576,forestryLoss_growthFactor_SSP5
-Vermont,VT,2070,0.879344104,forestryLoss_growthFactor_SSP5
-Vermont,VT,2071,0.861407656,forestryLoss_growthFactor_SSP5
-Vermont,VT,2072,0.844006568,forestryLoss_growthFactor_SSP5
-Vermont,VT,2073,0.827117337,forestryLoss_growthFactor_SSP5
-Vermont,VT,2074,0.810717814,forestryLoss_growthFactor_SSP5
-Vermont,VT,2075,0.794787103,forestryLoss_growthFactor_SSP5
-Vermont,VT,2076,0.784532114,forestryLoss_growthFactor_SSP5
-Vermont,VT,2077,0.77459251,forestryLoss_growthFactor_SSP5
-Vermont,VT,2078,0.764954068,forestryLoss_growthFactor_SSP5
-Vermont,VT,2079,0.7556034,forestryLoss_growthFactor_SSP5
-Vermont,VT,2080,0.746527901,forestryLoss_growthFactor_SSP5
-Vermont,VT,2081,0.728765598,forestryLoss_growthFactor_SSP5
-Vermont,VT,2082,0.711548143,forestryLoss_growthFactor_SSP5
-Vermont,VT,2083,0.694850873,forestryLoss_growthFactor_SSP5
-Vermont,VT,2084,0.678650587,forestryLoss_growthFactor_SSP5
-Vermont,VT,2085,0.662925444,forestryLoss_growthFactor_SSP5
-Vermont,VT,2086,0.657661674,forestryLoss_growthFactor_SSP5
-Vermont,VT,2087,0.652564087,forestryLoss_growthFactor_SSP5
-Vermont,VT,2088,0.647624994,forestryLoss_growthFactor_SSP5
-Vermont,VT,2089,0.64283717,forestryLoss_growthFactor_SSP5
-Vermont,VT,2090,0.638193825,forestryLoss_growthFactor_SSP5
-Vermont,VT,2091,0.641668854,forestryLoss_growthFactor_SSP5
-Vermont,VT,2092,0.645082835,forestryLoss_growthFactor_SSP5
-Vermont,VT,2093,0.648437824,forestryLoss_growthFactor_SSP5
-Vermont,VT,2094,0.651735764,forestryLoss_growthFactor_SSP5
-Vermont,VT,2095,0.654978502,forestryLoss_growthFactor_SSP5
-Vermont,VT,2096,0.657104122,forestryLoss_growthFactor_SSP5
-Vermont,VT,2097,0.659200256,forestryLoss_growthFactor_SSP5
-Vermont,VT,2098,0.661267774,forestryLoss_growthFactor_SSP5
-Vermont,VT,2099,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2000,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2001,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2002,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2003,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2004,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2005,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2006,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2007,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2008,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2009,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2010,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2011,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2012,NA,forestryLoss_growthFactor_SSP5
-Washington,WA,2013,0.990101596,forestryLoss_growthFactor_SSP5
-Washington,WA,2014,0.995139414,forestryLoss_growthFactor_SSP5
-Washington,WA,2015,1,forestryLoss_growthFactor_SSP5
-Washington,WA,2016,0.998924139,forestryLoss_growthFactor_SSP5
-Washington,WA,2017,0.997820536,forestryLoss_growthFactor_SSP5
-Washington,WA,2018,0.996692381,forestryLoss_growthFactor_SSP5
-Washington,WA,2019,0.99554259,forestryLoss_growthFactor_SSP5
-Washington,WA,2020,0.994373833,forestryLoss_growthFactor_SSP5
-Washington,WA,2021,0.98525812,forestryLoss_growthFactor_SSP5
-Washington,WA,2022,0.976374636,forestryLoss_growthFactor_SSP5
-Washington,WA,2023,0.967714404,forestryLoss_growthFactor_SSP5
-Washington,WA,2024,0.959268915,forestryLoss_growthFactor_SSP5
-Washington,WA,2025,0.951030097,forestryLoss_growthFactor_SSP5
-Washington,WA,2026,0.947737005,forestryLoss_growthFactor_SSP5
-Washington,WA,2027,0.944493041,forestryLoss_growthFactor_SSP5
-Washington,WA,2028,0.941297818,forestryLoss_growthFactor_SSP5
-Washington,WA,2029,0.938150883,forestryLoss_growthFactor_SSP5
-Washington,WA,2030,0.935051729,forestryLoss_growthFactor_SSP5
-Washington,WA,2031,0.935898294,forestryLoss_growthFactor_SSP5
-Washington,WA,2032,0.936681453,forestryLoss_growthFactor_SSP5
-Washington,WA,2033,0.937405486,forestryLoss_growthFactor_SSP5
-Washington,WA,2034,0.938074347,forestryLoss_growthFactor_SSP5
-Washington,WA,2035,0.938691692,forestryLoss_growthFactor_SSP5
-Washington,WA,2036,0.938491415,forestryLoss_growthFactor_SSP5
-Washington,WA,2037,0.938256635,forestryLoss_growthFactor_SSP5
-Washington,WA,2038,0.937990281,forestryLoss_growthFactor_SSP5
-Washington,WA,2039,0.937695044,forestryLoss_growthFactor_SSP5
-Washington,WA,2040,0.937373401,forestryLoss_growthFactor_SSP5
-Washington,WA,2041,0.943327357,forestryLoss_growthFactor_SSP5
-Washington,WA,2042,0.94905465,forestryLoss_growthFactor_SSP5
-Washington,WA,2043,0.954566961,forestryLoss_growthFactor_SSP5
-Washington,WA,2044,0.959875214,forestryLoss_growthFactor_SSP5
-Washington,WA,2045,0.964989638,forestryLoss_growthFactor_SSP5
-Washington,WA,2046,0.971808908,forestryLoss_growthFactor_SSP5
-Washington,WA,2047,0.978393826,forestryLoss_growthFactor_SSP5
-Washington,WA,2048,0.984755448,forestryLoss_growthFactor_SSP5
-Washington,WA,2049,0.990904176,forestryLoss_growthFactor_SSP5
-Washington,WA,2050,0.996849797,forestryLoss_growthFactor_SSP5
-Washington,WA,2051,1.004830058,forestryLoss_growthFactor_SSP5
-Washington,WA,2052,1.012552634,forestryLoss_growthFactor_SSP5
-Washington,WA,2053,1.020029134,forestryLoss_growthFactor_SSP5
-Washington,WA,2054,1.027270508,forestryLoss_growthFactor_SSP5
-Washington,WA,2055,1.034287082,forestryLoss_growthFactor_SSP5
-Washington,WA,2056,1.060557377,forestryLoss_growthFactor_SSP5
-Washington,WA,2057,1.086059825,forestryLoss_growthFactor_SSP5
-Washington,WA,2058,1.110827011,forestryLoss_growthFactor_SSP5
-Washington,WA,2059,1.134889722,forestryLoss_growthFactor_SSP5
-Washington,WA,2060,1.158277072,forestryLoss_growthFactor_SSP5
-Washington,WA,2061,1.130002499,forestryLoss_growthFactor_SSP5
-Washington,WA,2062,1.102495359,forestryLoss_growthFactor_SSP5
-Washington,WA,2063,1.07572434,forestryLoss_growthFactor_SSP5
-Washington,WA,2064,1.049659829,forestryLoss_growthFactor_SSP5
-Washington,WA,2065,1.0242738,forestryLoss_growthFactor_SSP5
-Washington,WA,2066,1.053205854,forestryLoss_growthFactor_SSP5
-Washington,WA,2067,1.081232908,forestryLoss_growthFactor_SSP5
-Washington,WA,2068,1.108395628,forestryLoss_growthFactor_SSP5
-Washington,WA,2069,1.134732319,forestryLoss_growthFactor_SSP5
-Washington,WA,2070,1.160279091,forestryLoss_growthFactor_SSP5
-Washington,WA,2071,1.102091454,forestryLoss_growthFactor_SSP5
-Washington,WA,2072,1.045614631,forestryLoss_growthFactor_SSP5
-Washington,WA,2073,0.990774182,forestryLoss_growthFactor_SSP5
-Washington,WA,2074,0.937499928,forestryLoss_growthFactor_SSP5
-Washington,WA,2075,0.885725649,forestryLoss_growthFactor_SSP5
-Washington,WA,2076,0.87143092,forestryLoss_growthFactor_SSP5
-Washington,WA,2077,0.857565114,forestryLoss_growthFactor_SSP5
-Washington,WA,2078,0.844109133,forestryLoss_growthFactor_SSP5
-Washington,WA,2079,0.831045001,forestryLoss_growthFactor_SSP5
-Washington,WA,2080,0.818355779,forestryLoss_growthFactor_SSP5
-Washington,WA,2081,0.816714426,forestryLoss_growthFactor_SSP5
-Washington,WA,2082,0.815122378,forestryLoss_growthFactor_SSP5
-Washington,WA,2083,0.813577424,forestryLoss_growthFactor_SSP5
-Washington,WA,2084,0.812077485,forestryLoss_growthFactor_SSP5
-Washington,WA,2085,0.810620602,forestryLoss_growthFactor_SSP5
-Washington,WA,2086,0.799100544,forestryLoss_growthFactor_SSP5
-Washington,WA,2087,0.787937662,forestryLoss_growthFactor_SSP5
-Washington,WA,2088,0.777115551,forestryLoss_growthFactor_SSP5
-Washington,WA,2089,0.766618797,forestryLoss_growthFactor_SSP5
-Washington,WA,2090,0.756432902,forestryLoss_growthFactor_SSP5
-Washington,WA,2091,0.762723163,forestryLoss_growthFactor_SSP5
-Washington,WA,2092,0.76877047,forestryLoss_growthFactor_SSP5
-Washington,WA,2093,0.774586912,forestryLoss_growthFactor_SSP5
-Washington,WA,2094,0.780183815,forestryLoss_growthFactor_SSP5
-Washington,WA,2095,0.785571807,forestryLoss_growthFactor_SSP5
-Washington,WA,2096,0.789467916,forestryLoss_growthFactor_SSP5
-Washington,WA,2097,0.793200864,forestryLoss_growthFactor_SSP5
-Washington,WA,2098,0.796778984,forestryLoss_growthFactor_SSP5
-Washington,WA,2099,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2000,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2001,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2002,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2003,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2004,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2005,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2006,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2007,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2008,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2009,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2010,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2011,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2012,NA,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2013,1.01097913,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2014,1.005389757,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2015,1,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2016,0.989090802,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2017,0.978604369,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2018,0.968518468,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2019,0.958812337,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2020,0.949466568,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2021,0.932708925,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2022,0.91657734,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2023,0.901038918,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2024,0.886062965,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2025,0.871620817,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2026,0.860239213,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2027,0.84930248,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2028,0.838786632,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2029,0.828669316,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2030,0.818929682,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2031,0.811066754,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2032,0.803512844,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2033,0.79625115,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2034,0.789266028,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2035,0.782542899,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2036,0.770864998,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2037,0.759618358,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2038,0.748780701,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2039,0.738331216,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2040,0.728250441,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2041,0.719410647,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2042,0.710899226,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2043,0.70269946,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2044,0.694795704,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2045,0.687173307,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2046,0.688987087,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2047,0.690801092,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2048,0.692613742,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2049,0.694423608,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2050,0.696229398,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2051,0.691635243,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2052,0.687211149,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2053,0.682948891,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2054,0.678840741,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2055,0.674879422,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2056,0.670377942,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2057,0.666047517,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2058,0.661879761,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2059,0.657866797,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2060,0.654001213,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2061,0.651664542,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2062,0.649440455,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2063,0.647322844,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2064,0.645305993,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2065,0.643384549,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2066,0.639604373,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2067,0.635996518,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2068,0.632551857,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2069,0.629261844,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2070,0.626118467,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2071,0.621795667,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2072,0.617604421,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2073,0.613538888,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2074,0.609593567,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2075,0.60576327,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2076,0.608443247,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2077,0.611045593,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2078,0.613573697,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2079,0.616030753,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2080,0.618419771,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2081,0.598200999,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2082,0.57860196,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2083,0.559594609,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2084,0.541152567,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2085,0.523250999,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2086,0.51447392,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2087,0.505971761,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2088,0.497731843,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2089,0.489742253,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2090,0.481991787,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2091,0.475800281,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2092,0.469837588,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2093,0.464092466,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2094,0.458554371,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2095,0.453213413,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2096,0.447382799,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2097,0.441765517,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2098,0.436351001,forestryLoss_growthFactor_SSP5
-Wisconsin,WI,2099,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2000,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2001,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2002,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2003,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2004,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2005,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2006,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2007,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2008,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2009,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2010,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2011,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2012,NA,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2013,0.998503572,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2014,0.999196635,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2015,1,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2016,0.995161003,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2017,0.990591467,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2018,0.98627518,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2019,0.982197074,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2020,0.978343131,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2021,0.960521519,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2022,0.943404292,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2023,0.926953286,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2024,0.911132947,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2025,0.895910112,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2026,0.883820273,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2027,0.872235065,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2028,0.861126366,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2029,0.85046801,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2030,0.840235621,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2031,0.828928814,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2032,0.818065177,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2033,0.807620649,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2034,0.797572824,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2035,0.787900817,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2036,0.784706597,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2037,0.781683828,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2038,0.778822188,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2039,0.776112094,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2040,0.773544632,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2041,0.778633926,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2042,0.783626716,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2043,0.788525547,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2044,0.793332892,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2045,0.798051142,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2046,0.814766022,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2047,0.831065296,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2048,0.846964593,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2049,0.862478752,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2050,0.877621874,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2051,0.892415375,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2052,0.906856143,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2053,0.920956859,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2054,0.934729592,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2055,0.948185839,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2056,0.946423114,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2057,0.94476437,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2058,0.943203696,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2059,0.94173557,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2060,0.94035482,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2061,0.959003957,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2062,0.977168429,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2063,0.994867348,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2064,1.012118815,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2065,1.028939987,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2066,1.021249646,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2067,1.013853359,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2068,1.006736547,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2069,0.999885522,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2070,0.993287429,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2071,0.973169495,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2072,0.953650106,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2073,0.934703036,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2074,0.916303564,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2075,0.898428373,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2076,0.887169681,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2077,0.87625594,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2078,0.865671623,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2079,0.855402117,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2080,0.845433657,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2081,0.825391936,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2082,0.80596461,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2083,0.787123871,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2084,0.768843567,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2085,0.751099075,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2086,0.745690548,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2087,0.740452134,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2088,0.735375973,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2089,0.730454683,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2090,0.72568132,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2091,0.730739914,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2092,0.735675577,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2093,0.740493451,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2094,0.745198376,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2095,0.749794913,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2096,0.753052629,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2097,0.756235065,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2098,0.759345415,forestryLoss_growthFactor_SSP5
-West Virginia,WV,2099,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2000,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2001,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2002,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2003,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2004,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2005,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2006,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2007,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2008,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2009,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2010,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2011,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2012,NA,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2013,1.003633772,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2014,1.001801714,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2015,1,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2016,0.99249804,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2017,0.985229051,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2018,0.978182222,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2019,0.971347403,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2020,0.96471506,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2021,0.953091136,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2022,0.941833347,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2023,0.930924481,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2024,0.920348397,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2025,0.910089943,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2026,0.902674973,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2027,0.895486465,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2028,0.888514009,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2029,0.88174783,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2030,0.875178745,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2031,0.871323773,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2032,0.867586891,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2033,0.863962602,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2034,0.860445755,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2035,0.857031511,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2036,0.851073705,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2037,0.845291433,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2038,0.839676845,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2039,0.834222562,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2040,0.828921637,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2041,0.835888276,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2042,0.842615572,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2043,0.849115215,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2044,0.855398161,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2045,0.861474686,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2046,0.853265632,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2047,0.84525551,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2048,0.83743702,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2049,0.829803221,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2050,0.82234751,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2051,0.844221488,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2052,0.86546333,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2053,0.886099613,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2054,0.90615546,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2055,0.92565464,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2056,0.919417194,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2057,0.91330466,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2058,0.907313374,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2059,0.901439809,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2060,0.895680575,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2061,0.901161869,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2062,0.906441977,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2063,0.911530723,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2064,0.916437332,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2065,0.921170474,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2066,0.931505795,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2067,0.941481282,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2068,0.951114039,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2069,0.960420143,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2070,0.96941472,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2071,0.965413872,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2072,0.96152562,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2073,0.957745198,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2074,0.954068105,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2075,0.950490091,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2076,0.895378068,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2077,0.841929798,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2078,0.790070966,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2079,0.739731618,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2080,0.690845853,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2081,0.671187057,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2082,0.652128849,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2083,0.633644092,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2084,0.61570726,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2085,0.598294321,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2086,0.589114394,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2087,0.58021829,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2088,0.571592987,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2089,0.56322625,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2090,0.555106573,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2091,0.550326623,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2092,0.545644155,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2093,0.541055489,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2094,0.536557154,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2095,0.532145867,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2096,0.527087191,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2097,0.522140951,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2098,0.517302465,forestryLoss_growthFactor_SSP5
-Wyoming,WY,2099,NA,forestryLoss_growthFactor_SSP5
+"state","postal","year","value","scalarName"
+"Alabama","AL",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2013,0.973014130246988,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2014,0.986631221795851,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2015,1,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2016,1.00731159088278,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2017,1.01442917834604,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2018,1.0213607374844,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2019,1.02811379540267,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2020,1.034695463173,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2021,1.03438691395037,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2022,1.03413096808532,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2023,1.03392363872544,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2024,1.03376125666218,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2025,1.03364044194429,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2026,1.00875699327408,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2027,0.984731858325231,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2028,0.961522003939035,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2029,0.939087200371357,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2030,0.917389798028951,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2031,0.921598414749612,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2032,0.925687094681779,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2033,0.929661100635923,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2034,0.933525381662776,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2035,0.937284596695923,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2036,0.932506367288195,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2037,0.927909668422931,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2038,0.923484983955253,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2039,0.919223429457054,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2040,0.915116701660079,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2041,0.918522459829459,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2042,0.921848505243512,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2043,0.925097699821109,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2044,0.928272765051912,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2045,0.931376290822479,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2046,0.913608122756696,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2047,0.896365921606858,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2048,0.879626992211241,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2049,0.863369914531914,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2050,0.847574455916777,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2051,0.862348730030945,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2052,0.876744773847859,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2053,0.890777088117301,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2054,0.904459434935474,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2055,0.91780488453584,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2056,0.925186328216867,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2057,0.932393441173276,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2058,0.939432440474248,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2059,0.946309245836216,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2060,0.953029497480207,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2061,0.969165660700076,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2062,0.984863372110306,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2063,1.0001405358224,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2064,1.01501408327733,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2065,1.02950003894727,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2066,1.03747438335427,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2067,1.04525157771246,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2068,1.05283914483167,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2069,1.06024421692508,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2070,1.06747356126783,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2071,1.07564380353407,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2072,1.08357589978555,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2073,1.09128015793369,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2074,1.09876629791155,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2075,1.10604349307371,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2076,1.09500328118754,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2077,1.08429945741035,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2078,1.07391692251432,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2079,1.06384146625568,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2080,1.05405970295071,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2081,1.04346149090734,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2082,1.03318819823779,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2083,1.02322511951051,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2084,1.0135584232001,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2085,1.0041750877306,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2086,0.9991477289335,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2087,0.99427783464009,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2088,0.98955814218809,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2089,0.984981828258081,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2090,0.980542476162869,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2091,0.980288016509914,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2092,0.980060417553312,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2093,0.979858114329051,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2094,0.979679644733044,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2095,0.979523641557906,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2096,0.977790067630912,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2097,0.976127740087879,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2098,0.974533034968473,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2099,0.974533034968473,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2100,0.974533034968473,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2200,0.974533034968473,"forestryLoss_growthFactor_SSP5"
+"Alabama","AL",2300,0.974533034968473,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2013,0.967512279956741,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2014,0.983917643967375,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2015,1,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2016,1.00993814972701,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2017,1.01958457115012,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2018,1.028952277449,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2019,1.03805350404224,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2020,1.04689976661569,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2021,1.04858728397556,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2022,1.05024534143886,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2023,1.0518744873015,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2024,1.05347527427105,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2025,1.05504825695331,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2026,1.03020299379262,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2027,1.0061975170402,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2028,0.982990276340394,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2029,0.960542404288517,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2030,0.938817504044601,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2031,0.945034389402833,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2032,0.951051664046066,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2033,0.956878943289505,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2034,0.962525227893678,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2035,0.967998952751554,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2036,0.964577365691979,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2037,0.961276672164033,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2038,0.958090776677386,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2039,0.955013979296916,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2040,0.952040944423575,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2041,0.957339819810422,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2042,0.962481444758511,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2043,0.967472813247715,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2044,0.972320506547122,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2045,0.977030723418324,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2046,0.959377132539368,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2047,0.942226923333687,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2048,0.925558933997674,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2049,0.909353169908045,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2050,0.893590724373364,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2051,0.910777809358279,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2052,0.92750171070761,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2053,0.943780938534607,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2054,0.959633028217048,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2055,0.975074603795123,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2056,0.984169014709616,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2057,0.993019344633764,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2058,1.00163533164941,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2059,1.01002620091216,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2060,1.01820069806832,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2061,1.03651246805749,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2062,1.05430137885141,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2063,1.07158955960041,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2064,1.08839790613162,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2065,1.10474616577976,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2066,1.11410451695297,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2067,1.12319471497265,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2068,1.13202818142709,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2069,1.14061569619581,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2070,1.14896744198832,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2071,1.15840240040587,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2072,1.16755931328578,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2073,1.17645029528243,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2074,1.1850867672566,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2075,1.19347950524367,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2076,1.18220751129472,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2077,1.17127668520494,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2078,1.16067176687329,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2079,1.15037839297953,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2080,1.14038303206014,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2081,1.12948253476414,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2082,1.11891570985598,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2083,1.10866746662434,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2084,1.09872361085587,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2085,1.08907077923566,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2086,1.08407398526085,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2087,1.07923283092739,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2088,1.07454015410038,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2089,1.06998922549648,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2090,1.06557371646933,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2091,1.06535546676317,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2092,1.06514156439419,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2093,1.06493184790743,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2094,1.06472616485893,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2095,1.06452437115851,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2096,1.06260303738673,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2097,1.06074055853026,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2098,1.05893415929502,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2099,1.05893415929502,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2100,1.05893415929502,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2200,1.05893415929502,"forestryLoss_growthFactor_SSP5"
+"Arkansas","AR",2300,1.05893415929502,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2013,1.00650426435292,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2014,1.00326075303134,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2015,1,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2016,0.991003968463317,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2017,0.982218061763532,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2018,0.973634682574185,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2019,0.965246612672696,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2020,0.957046988493404,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2021,0.947699520654589,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2022,0.938578005335079,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2023,0.929674238685086,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2024,0.920980415757183,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2025,0.912489106081032,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2026,0.903485870609397,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2027,0.894710981390754,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2028,0.886155635610601,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2029,0.8778114899212,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2030,0.869670629981782,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2031,0.862862406348818,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2032,0.856245485284621,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2033,0.849811576163155,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2034,0.84355287762949,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2035,0.837462041020042,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2036,0.829228508470489,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2037,0.821216130255076,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2038,0.813415750783548,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2039,0.80581873070777,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2040,0.798416910014516,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2041,0.791854562631674,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2042,0.785453399846263,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2043,0.779207326666144,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2044,0.773110563053019,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2045,0.767157623153199,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2046,0.759119129960365,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2047,0.751268381090877,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2048,0.743598737294862,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2049,0.736103875342093,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2050,0.728777769056033,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2051,0.72474727110939,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2052,0.720794313412077,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2053,0.716916755382631,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2054,0.713112530251653,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2055,0.709379642213514,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2056,0.699899774361176,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2057,0.690644148192908,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2058,0.681604754285998,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2059,0.672773966862065,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2060,0.664144520716154,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2061,0.655528480213739,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2062,0.647124489381331,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2063,0.638924568196725,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2064,0.630921143015158,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2065,0.623107020447798,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2066,0.611175237860106,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2067,0.599533208143553,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2068,0.588170044306885,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2069,0.577075417698799,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2070,0.566239521669615,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2071,0.562985956524542,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2072,0.559823776635669,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2073,0.556749117089107,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2074,0.55375833029955,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2075,0.550847970841841,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2076,0.540138999871617,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2077,0.529751301905586,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2078,0.519670574277823,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2079,0.509883352722661,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2080,0.5003769507593,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2081,0.494497020725599,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2082,0.48879657794261,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2083,0.483267515516409,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2084,0.477902207863913,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2085,0.472693475504226,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2086,0.46769998316997,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2087,0.462861253369174,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2088,0.458170179011997,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2089,0.453620082164565,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2090,0.449204682120979,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2091,0.435432132232457,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2092,0.42207826057713,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2093,0.409123759794344,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2094,0.396550502872753,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2095,0.384341454006434,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2096,0.371852170594506,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2097,0.359754966070954,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2098,0.348031213555284,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2099,0.348031213555284,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2100,0.348031213555284,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2200,0.348031213555284,"forestryLoss_growthFactor_SSP5"
+"Arizona","AZ",2300,0.348031213555284,"forestryLoss_growthFactor_SSP5"
+"California","CA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"California","CA",2013,1.00973268612116,"forestryLoss_growthFactor_SSP5"
+"California","CA",2014,1.00482590913228,"forestryLoss_growthFactor_SSP5"
+"California","CA",2015,1,"forestryLoss_growthFactor_SSP5"
+"California","CA",2016,0.989540313831612,"forestryLoss_growthFactor_SSP5"
+"California","CA",2017,0.979394396655555,"forestryLoss_growthFactor_SSP5"
+"California","CA",2018,0.969548030552067,"forestryLoss_growthFactor_SSP5"
+"California","CA",2019,0.959987856720301,"forestryLoss_growthFactor_SSP5"
+"California","CA",2020,0.950701310901026,"forestryLoss_growthFactor_SSP5"
+"California","CA",2021,0.937786683831946,"forestryLoss_growthFactor_SSP5"
+"California","CA",2022,0.925279792966184,"forestryLoss_growthFactor_SSP5"
+"California","CA",2023,0.913161438120158,"forestryLoss_growthFactor_SSP5"
+"California","CA",2024,0.901413614712543,"forestryLoss_growthFactor_SSP5"
+"California","CA",2025,0.890019421639794,"forestryLoss_growthFactor_SSP5"
+"California","CA",2026,0.877902207957688,"forestryLoss_growthFactor_SSP5"
+"California","CA",2027,0.866174244528443,"forestryLoss_growthFactor_SSP5"
+"California","CA",2028,0.854816939684935,"forestryLoss_growthFactor_SSP5"
+"California","CA",2029,0.84381287310536,"forestryLoss_growthFactor_SSP5"
+"California","CA",2030,0.833145704669228,"forestryLoss_growthFactor_SSP5"
+"California","CA",2031,0.8243666455005,"forestryLoss_growthFactor_SSP5"
+"California","CA",2032,0.81588075091068,"forestryLoss_growthFactor_SSP5"
+"California","CA",2033,0.807673516734175,"forestryLoss_growthFactor_SSP5"
+"California","CA",2034,0.799731382624426,"forestryLoss_growthFactor_SSP5"
+"California","CA",2035,0.792041656378972,"forestryLoss_growthFactor_SSP5"
+"California","CA",2036,0.782267423244059,"forestryLoss_growthFactor_SSP5"
+"California","CA",2037,0.772809642300572,"forestryLoss_growthFactor_SSP5"
+"California","CA",2038,0.763653184380975,"forestryLoss_growthFactor_SSP5"
+"California","CA",2039,0.754783869829627,"forestryLoss_growthFactor_SSP5"
+"California","CA",2040,0.746188395152205,"forestryLoss_growthFactor_SSP5"
+"California","CA",2041,0.735349274343578,"forestryLoss_growthFactor_SSP5"
+"California","CA",2042,0.724851554719057,"forestryLoss_growthFactor_SSP5"
+"California","CA",2043,0.71467942027594,"forestryLoss_growthFactor_SSP5"
+"California","CA",2044,0.704818014598014,"forestryLoss_growthFactor_SSP5"
+"California","CA",2045,0.695253369289624,"forestryLoss_growthFactor_SSP5"
+"California","CA",2046,0.686849702110948,"forestryLoss_growthFactor_SSP5"
+"California","CA",2047,0.678691364388695,"forestryLoss_growthFactor_SSP5"
+"California","CA",2048,0.670767870249435,"forestryLoss_growthFactor_SSP5"
+"California","CA",2049,0.663069319069127,"forestryLoss_growthFactor_SSP5"
+"California","CA",2050,0.655586355393606,"forestryLoss_growthFactor_SSP5"
+"California","CA",2051,0.647872836154021,"forestryLoss_growthFactor_SSP5"
+"California","CA",2052,0.640382160343493,"forestryLoss_growthFactor_SSP5"
+"California","CA",2053,0.633104961079062,"forestryLoss_growthFactor_SSP5"
+"California","CA",2054,0.62603238347313,"forestryLoss_growthFactor_SSP5"
+"California","CA",2055,0.619156050392385,"forestryLoss_growthFactor_SSP5"
+"California","CA",2056,0.610446754495785,"forestryLoss_growthFactor_SSP5"
+"California","CA",2057,0.60199498589477,"forestryLoss_growthFactor_SSP5"
+"California","CA",2058,0.59378973167705,"forestryLoss_growthFactor_SSP5"
+"California","CA",2059,0.585820589125728,"forestryLoss_growthFactor_SSP5"
+"California","CA",2060,0.57807772444994,"forestryLoss_growthFactor_SSP5"
+"California","CA",2061,0.567927955164974,"forestryLoss_growthFactor_SSP5"
+"California","CA",2062,0.558091666819985,"forestryLoss_growthFactor_SSP5"
+"California","CA",2063,0.548554898633504,"forestryLoss_growthFactor_SSP5"
+"California","CA",2064,0.539304494644298,"forestryLoss_growthFactor_SSP5"
+"California","CA",2065,0.530328047078485,"forestryLoss_growthFactor_SSP5"
+"California","CA",2066,0.518700246296475,"forestryLoss_growthFactor_SSP5"
+"California","CA",2067,0.507446184051335,"forestryLoss_growthFactor_SSP5"
+"California","CA",2068,0.496548810024424,"forestryLoss_growthFactor_SSP5"
+"California","CA",2069,0.485992073335219,"forestryLoss_growthFactor_SSP5"
+"California","CA",2070,0.475760851295985,"forestryLoss_growthFactor_SSP5"
+"California","CA",2071,0.46913035533485,"forestryLoss_growthFactor_SSP5"
+"California","CA",2072,0.462698770300392,"forestryLoss_growthFactor_SSP5"
+"California","CA",2073,0.456457338252781,"forestryLoss_growthFactor_SSP5"
+"California","CA",2074,0.450397805943218,"forestryLoss_growthFactor_SSP5"
+"California","CA",2075,0.444512389059344,"forestryLoss_growthFactor_SSP5"
+"California","CA",2076,0.441392873068882,"forestryLoss_growthFactor_SSP5"
+"California","CA",2077,0.438370968086312,"forestryLoss_growthFactor_SSP5"
+"California","CA",2078,0.435442232481762,"forestryLoss_growthFactor_SSP5"
+"California","CA",2079,0.432602488010811,"forestryLoss_growthFactor_SSP5"
+"California","CA",2080,0.429847800654272,"forestryLoss_growthFactor_SSP5"
+"California","CA",2081,0.420645744867493,"forestryLoss_growthFactor_SSP5"
+"California","CA",2082,0.411726154191111,"forestryLoss_growthFactor_SSP5"
+"California","CA",2083,0.403076237243745,"forestryLoss_growthFactor_SSP5"
+"California","CA",2084,0.394683963009601,"forestryLoss_growthFactor_SSP5"
+"California","CA",2085,0.386538005184001,"forestryLoss_growthFactor_SSP5"
+"California","CA",2086,0.383968649612533,"forestryLoss_growthFactor_SSP5"
+"California","CA",2087,0.381480727569405,"forestryLoss_growthFactor_SSP5"
+"California","CA",2088,0.379070465078506,"forestryLoss_growthFactor_SSP5"
+"California","CA",2089,0.376734316916788,"forestryLoss_growthFactor_SSP5"
+"California","CA",2090,0.374468949568681,"forestryLoss_growthFactor_SSP5"
+"California","CA",2091,0.36084807011728,"forestryLoss_growthFactor_SSP5"
+"California","CA",2092,0.347695172596996,"forestryLoss_growthFactor_SSP5"
+"California","CA",2093,0.334987756211157,"forestryLoss_growthFactor_SSP5"
+"California","CA",2094,0.32270471600053,"forestryLoss_growthFactor_SSP5"
+"California","CA",2095,0.310826236875624,"forestryLoss_growthFactor_SSP5"
+"California","CA",2096,0.2987893801942,"forestryLoss_growthFactor_SSP5"
+"California","CA",2097,0.287176615252154,"forestryLoss_growthFactor_SSP5"
+"California","CA",2098,0.275967137243907,"forestryLoss_growthFactor_SSP5"
+"California","CA",2099,0.275967137243907,"forestryLoss_growthFactor_SSP5"
+"California","CA",2100,0.275967137243907,"forestryLoss_growthFactor_SSP5"
+"California","CA",2200,0.275967137243907,"forestryLoss_growthFactor_SSP5"
+"California","CA",2300,0.275967137243907,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2013,0.998307165314432,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2014,0.999236055259427,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2015,1,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2016,0.994865177195352,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2017,0.989763816901134,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2018,0.984698286399003,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2019,0.979670648529334,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2020,0.974682692747624,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2021,0.96847702328466,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2022,0.962334275507119,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2023,0.956256171316782,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2024,0.950244110100644,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2025,0.944299205718335,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2026,0.938557218965327,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2027,0.932877209440901,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2028,0.927260449578901,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2029,0.921707940209877,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2030,0.916220442342638,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2031,0.912438295243956,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2032,0.908709173047011,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2033,0.905032838652549,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2034,0.901408968312206,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2035,0.897837163962046,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2036,0.891899969993409,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2037,0.886067699628247,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2038,0.880338061393631,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2039,0.87470879543722,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2040,0.869177676799204,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2041,0.865943753815455,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2042,0.862725683467699,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2043,0.859525324498266,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2044,0.856344319236988,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2045,0.853184114881574,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2046,0.846448376892504,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2047,0.839820651234566,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2048,0.833298937655869,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2049,0.826881244541176,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2050,0.820565593374432,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2051,0.820868531314515,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2052,0.821089073892336,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2053,0.821232802303499,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2054,0.821304910906369,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2055,0.821310237045835,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2056,0.812564239151933,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2057,0.803976202761731,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2058,0.795542209120487,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2059,0.78725844865283,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2060,0.779121218741479,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2061,0.77204759008776,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2062,0.765101799984127,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2063,0.758280608828822,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2064,0.751580873817149,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2065,0.744999546278003,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2066,0.734455530811256,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2067,0.724117251784328,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2068,0.71397863531479,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2069,0.704033850176303,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2070,0.694277295419679,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2071,0.690932098530348,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2072,0.687678160222084,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2073,0.684511694543493,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2074,0.681429125827811,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2075,0.678427074128946,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2076,0.661835735481765,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2077,0.645741512558632,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2078,0.63012228945549,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2079,0.614957246194812,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2080,0.600226765050031,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2081,0.592387747795442,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2082,0.584787637993507,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2083,0.577415653021598,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2084,0.570261650200133,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2085,0.563316079987629,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2086,0.557336322970429,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2087,0.551541287499127,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2088,0.545922502279753,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2089,0.54047200725892,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2090,0.535182315598071,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2091,0.520250014116808,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2092,0.505755349226977,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2093,0.491678417342,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2094,0.478000525550884,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2095,0.46470410035007,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2096,0.450991880270051,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2097,0.437697927237685,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2098,0.424802543728215,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2099,0.424802543728215,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2100,0.424802543728215,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2200,0.424802543728215,"forestryLoss_growthFactor_SSP5"
+"Colorado","CO",2300,0.424802543728215,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2013,1.03232169560975,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2014,1.01591667594333,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2015,1,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2016,0.978900492169964,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2017,0.958601966626013,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2018,0.939062715643584,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2019,0.920243776631175,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2020,0.902108714397213,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2021,0.882385597576777,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2022,0.863435251135008,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2023,0.845215999133132,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2024,0.827689003742427,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2025,0.810818032864855,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2026,0.793308799423325,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2027,0.776487174116915,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2028,0.760315990002249,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2029,0.74476061740101,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2030,0.729788755592074,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2031,0.715889843291305,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2032,0.702522617247973,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2033,0.689658572670843,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2034,0.677271153744726,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2035,0.665335592397198,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2036,0.652350781650655,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2037,0.639855273952181,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2038,0.627823525722066,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2039,0.616231685057112,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2040,0.605057456536732,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2041,0.593694210142191,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2042,0.582748900213517,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2043,0.572200355279467,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2044,0.562028760714697,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2045,0.552215553958615,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2046,0.543075253855977,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2047,0.534252518245834,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2048,0.525732276107632,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2049,0.51750035654258,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2050,0.5095434242378,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2051,0.501475343569516,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2052,0.493678437243298,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2053,0.486140211539412,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2054,0.478848897936537,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2055,0.471793402567716,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2056,0.462667157319749,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2057,0.453843655840541,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2058,0.445309024813992,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2059,0.43705019487847,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2060,0.42905484456598,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2061,0.421036146237407,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2062,0.413295295704419,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2063,0.405819101898409,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2064,0.398595164160199,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2065,0.391611815239736,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2066,0.380086083737443,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2067,0.368959407390017,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2068,0.358212869663537,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2069,0.347828687201392,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2070,0.337790127988992,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2071,0.333426593843009,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2072,0.329196255769185,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2073,0.325093190708218,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2074,0.321111818915188,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2075,0.317246879553539,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2076,0.313303412639849,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2077,0.309482831277162,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2078,0.305779555373268,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2079,0.302188335373884,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2080,0.29870422823113,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2081,0.294649467304091,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2082,0.290719661932959,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2083,0.286909143162589,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2084,0.283212579310949,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2085,0.279624951272545,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2086,0.276147162907462,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2087,0.272779122894467,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2088,0.269515753921041,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2089,0.266352286205379,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2090,0.263284234587578,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2091,0.254813787360331,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2092,0.246642533639555,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2093,0.238755964754958,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2094,0.231140474686659,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2095,0.22378329146912,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2096,0.216368814470804,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2097,0.209217987294776,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2098,0.202317845364598,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2099,0.202317845364598,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2100,0.202317845364598,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2200,0.202317845364598,"forestryLoss_growthFactor_SSP5"
+"Connecticut","CT",2300,0.202317845364598,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2000,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2001,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2002,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2003,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2004,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2005,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2006,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2007,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2008,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2009,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2010,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2011,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2012,NA,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2013,0.990855483050442,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2014,0.995598223835908,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2015,1,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2016,0.998315592474967,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2017,0.996468439671695,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2018,0.994472785623662,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2019,0.992341728177136,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2020,0.990087319602504,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2021,0.987618120014497,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2022,0.985008421715223,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2023,0.982272535653783,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2024,0.979423528014832,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2025,0.976473336065793,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2026,0.973462217502754,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2027,0.970341178176972,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2028,0.967122609726991,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2029,0.963817800072241,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2030,0.960437037260321,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2031,0.959270336715209,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2032,0.958011351387539,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2033,0.956668921178426,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2034,0.955251127921187,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2035,0.953765365810011,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2036,0.950845357595645,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2037,0.947851416984266,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2038,0.944792336870439,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2039,0.941676141793937,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2040,0.938510158323894,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2041,0.935281047136917,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2042,0.931975034688118,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2043,0.928601068711675,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2044,0.925167338839852,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2045,0.921681343817102,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2046,0.918794799147862,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2047,0.91580985754365,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2048,0.912736117349947,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2049,0.909582428898643,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2050,0.906356956150832,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2051,0.902764767050164,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2052,0.899097985724008,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2053,0.895364877104457,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2054,0.891573056311914,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2055,0.887729541687449,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2056,0.880400994654418,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2057,0.873077969223352,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2058,0.865766180209127,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2059,0.858470799296181,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2060,0.851196502604348,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2061,0.840730754028336,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2062,0.830399425758329,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2063,0.820201643160016,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2064,0.810136394601924,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2065,0.80020254973681,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2066,0.781179600459248,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2067,0.762521297897576,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2068,0.744217144330154,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2069,0.726257047270937,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2070,0.708631299697789,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2071,0.706044857357714,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2072,0.703520612222706,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2073,0.701056218654276,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2074,0.698649452835639,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2075,0.696298204705885,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2076,0.693845346410898,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2077,0.691451843128223,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2078,0.689115392331749,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2079,0.686833815772214,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2080,0.684605050908531,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2081,0.682322020460369,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2082,0.68010525975872,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2083,0.677951848196405,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2084,0.675859036527362,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2085,0.673824234402212,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2086,0.669964263928811,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2087,0.666218843851487,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2088,0.662582810560926,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2089,0.659051309810443,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2090,0.655619773776423,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2091,0.634834885296508,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2092,0.614578782972428,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2093,0.594828840103781,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2094,0.575563774539943,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2095,0.556763548185528,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2096,0.537215686399006,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2097,0.518212118969046,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2098,0.499727973892877,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2099,0.499727973892877,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2100,0.499727973892877,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2200,0.499727973892877,"forestryLoss_growthFactor_SSP5"
+"District of Columbia","DC",2300,0.499727973892877,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2013,1.01147658642674,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2014,1.00569128064466,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2015,1,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2016,0.988692750100578,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2017,0.977721272524346,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2018,0.967070462523536,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2019,0.956726123475453,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2020,0.946674898853475,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2021,0.934070759062429,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2022,0.921864050928113,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2023,0.910036077185842,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2024,0.898569304043743,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2025,0.887447271579743,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2026,0.875588533487458,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2027,0.864112012803259,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2028,0.852999409866217,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2029,0.842233579948837,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2030,0.831798443279644,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2031,0.822083534004342,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2032,0.812694617545568,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2033,0.803615514226824,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2034,0.794831099416576,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2035,0.786327218819385,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2036,0.776379592755349,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2037,0.766756348624366,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2038,0.757441905863539,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2039,0.748421664727921,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2040,0.739681930369917,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2041,0.730798738726066,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2042,0.722196915446404,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2043,0.713863378216092,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2044,0.705785840344708,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2045,0.697952751334568,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2046,0.691207488489283,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2047,0.684659207390628,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2048,0.678299486685279,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2049,0.672120375119064,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2050,0.66611435933948,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2051,0.659596852975833,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2052,0.653264846457687,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2053,0.647110622839919,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2054,0.641126883888206,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2055,0.635306722226413,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2056,0.625997658890984,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2057,0.616951491637666,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2058,0.60815732643044,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2059,0.599604859579684,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2060,0.591284338449547,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2061,0.583499124736616,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2062,0.575945579858041,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2063,0.568613624245237,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2064,0.561493750686762,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2065,0.554576984455072,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2066,0.540759080972217,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2067,0.527350401939944,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2068,0.5143331463362,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2069,0.501690526860932,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2070,0.489406698961952,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2071,0.484107291968535,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2072,0.478964980928978,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2073,0.473972897050873,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2074,0.469124565734574,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2075,0.464413878715867,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2076,0.459814622967389,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2077,0.455355110623122,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2078,0.451029078354324,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2079,0.446830631304463,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2080,0.442754216397486,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2081,0.437538559515629,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2082,0.432482716700992,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2083,0.427579456818598,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2084,0.422821978409707,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2085,0.418203878247784,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2086,0.413989010226807,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2087,0.409905876709574,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2088,0.405948407076349,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2089,0.402110897806503,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2090,0.398387985150838,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2091,0.38708829475809,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2092,0.376158689455435,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2093,0.365581649286428,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2094,0.355340735359219,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2095,0.345420507930095,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2096,0.33520711686118,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2097,0.325338136556168,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2098,0.315796866675423,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2099,0.315796866675423,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2100,0.315796866675423,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2200,0.315796866675423,"forestryLoss_growthFactor_SSP5"
+"Delaware","DE",2300,0.315796866675423,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2013,0.995410709159692,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2014,0.997785047268744,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2015,1,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2016,0.996312081707347,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2017,0.992644463501509,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2018,0.988999135019223,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2019,0.985377844756989,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2020,0.98178212431951,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2021,0.973514531698375,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2022,0.965418072629798,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2023,0.957487854712127,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2024,0.94971914469236,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2025,0.94210736440584,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2026,0.936840929990947,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2027,0.93166071482681,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2028,0.926565467773205,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2029,0.921553886850033,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2030,0.916624630405348,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2031,0.910553183486023,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2032,0.904636616124789,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2033,0.898868824617439,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2034,0.893244035757534,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2035,0.887756783855799,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2036,0.879948636527144,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2037,0.872335977091361,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2038,0.864911248273424,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2039,0.857667293443966,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2040,0.850597329420579,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2041,0.844066902942542,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2042,0.837686805673496,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2043,0.83145174249755,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2044,0.825356672853321,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2045,0.819396795057985,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2046,0.816047039682275,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2047,0.812745583290878,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2048,0.809491822571989,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2049,0.806285130366156,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2050,0.803124860121731,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2051,0.790908906760903,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2052,0.77898511504777,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2053,0.76734295165859,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2054,0.755972391562817,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2055,0.744863887290888,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2056,0.737858585504602,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2057,0.731001791599156,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2058,0.724288807054403,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2059,0.717715130797897,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2060,0.711276448858499,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2061,0.70228172920916,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2062,0.6935055711983,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2063,0.684939845129314,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2064,0.676576831166298,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2065,0.668409193204664,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2066,0.655371440071092,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2067,0.642657152285508,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2068,0.630253950509193,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2069,0.618150099657632,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2070,0.606334466505544,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2071,0.601445518920006,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2072,0.596696963486803,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2073,0.592082778913026,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2074,0.587597285452835,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2075,0.583235120940799,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2076,0.577980928962612,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2077,0.572883287573617,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2078,0.567935253063423,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2079,0.563130287941936,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2080,0.558462231601607,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2081,0.553810209501923,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2082,0.54930017219924,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2083,0.544925707097399,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2084,0.540680782307727,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2085,0.536559718800093,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2086,0.531723400742334,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2087,0.527037084240032,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2088,0.522493878737449,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2089,0.518087309812501,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2090,0.513811288215926,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2091,0.503949382746866,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2092,0.494389465715021,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2093,0.485117573522113,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2094,0.476120597053517,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2095,0.467386217122492,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2096,0.457980178372868,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2097,0.448880098748904,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2098,0.440071291004301,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2099,0.440071291004301,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2100,0.440071291004301,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2200,0.440071291004301,"forestryLoss_growthFactor_SSP5"
+"Florida","FL",2300,0.440071291004301,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2013,0.976183779244442,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2014,0.988238616730084,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2015,1,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2016,1.00567239279216,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2017,1.0111318708839,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2018,1.01638945926617,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2019,1.02145545951231,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2020,1.02633950705304,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2021,1.01546185574428,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2022,1.00490741483691,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2023,0.994661676503032,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2024,0.984711003599924,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2025,0.975042564425992,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2026,0.976368329528141,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2027,0.977619067013793,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2028,0.97879948146045,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2029,0.979913930336158,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2030,0.980966453828717,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2031,0.974644604719944,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2032,0.968517963244939,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2033,0.962577389468948,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2034,0.95681431606103,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2035,0.951220703551826,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2036,0.943119614916687,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2037,0.935259305465295,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2038,0.927628935005313,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2039,0.920218316044238,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2040,0.913017864775392,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2041,0.910548559229256,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2042,0.908135531762921,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2043,0.905776823370615,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2044,0.903470567997802,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2045,0.901214986893741,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2046,0.909105782147073,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2047,0.916756534601445,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2048,0.924177790111359,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2049,0.931379494677091,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2050,0.938371036076731,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2051,0.914069450836952,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2052,0.8904141595378,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2053,0.867379600271441,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2054,0.844941546415983,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2055,0.823077020328653,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2056,0.823647548635406,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2057,0.824187494190414,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2058,0.824698551255482,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2059,0.825182305511182,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2060,0.825640242103914,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2061,0.822146224946654,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2062,0.818735965405855,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2063,0.815406387337751,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2064,0.812154567956446,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2065,0.808977728148099,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2066,0.804624684606575,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2067,0.800369847134609,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2068,0.796209772813922,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2069,0.79214118502963,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2070,0.788160963155863,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2071,0.779427006388407,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2072,0.770948370020522,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2073,0.762713983242866,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2074,0.754713407416074,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2075,0.746936791530447,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2076,0.738441644065178,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2077,0.730202203199956,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2078,0.722207064923365,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2079,0.7144454943476,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2080,0.706907377306741,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2081,0.700322269935648,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2082,0.693938498511855,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2083,0.687746962449973,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2084,0.681739101663747,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2085,0.675906857020979,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2086,0.6703164162157,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2087,0.664899793356298,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2088,0.65964899571617,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2089,0.654556513469089,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2090,0.649615283754471,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2091,0.656684785938831,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2092,0.663521097516436,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2093,0.670135283966891,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2094,0.67653772741595,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2095,0.682738178430959,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2096,0.6876166682326,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2097,0.692328798758657,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2098,0.696882661180465,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2099,0.696882661180465,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2100,0.696882661180465,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2200,0.696882661180465,"forestryLoss_growthFactor_SSP5"
+"Georgia","GA",2300,0.696882661180465,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2013,1.02244349773613,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2014,1.01107618047564,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2015,1,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2016,0.983526116870013,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2017,0.967623935436915,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2018,0.952265053115626,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2019,0.937422887317345,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2020,0.923072533391736,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2021,0.908062264240239,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2022,0.893576137018652,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2023,0.879587700270078,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2024,0.866072231007942,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2025,0.853006596947757,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2026,0.839886838678763,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2027,0.82722141204861,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2028,0.814987480776124,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2029,0.803163698738234,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2030,0.79173009116059,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2031,0.781649458232045,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2032,0.771918879766247,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2033,0.762520599778185,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2034,0.753438036408169,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2035,0.744655686794199,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2036,0.734368181766524,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2037,0.72441823885802,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2038,0.714789579454889,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2039,0.705466952367943,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2040,0.696436054169154,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2041,0.689200832348013,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2042,0.682188571017101,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2043,0.675389089732908,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2044,0.668792819779919,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2045,0.662390758842498,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2046,0.654684777363426,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2047,0.647186437328785,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2048,0.639887375063158,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2049,0.632779673563558,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2050,0.625855832897774,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2051,0.619886141879344,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2052,0.614062974758231,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2053,0.608380918616934,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2054,0.602834827606686,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2055,0.597419806478921,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2056,0.589529946705354,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2057,0.581831755908103,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2058,0.574318210616097,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2059,0.566982631863407,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2060,0.559818664024622,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2061,0.552538853209124,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2062,0.545443614514855,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2063,0.53852581823045,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2064,0.531778705692964,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2065,0.52519586502115,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2066,0.514411101776975,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2067,0.50390164030843,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2068,0.493656695382523,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2069,0.483666053226236,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2070,0.473920033424925,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2071,0.47003848868937,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2072,0.466267258240151,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2073,0.462601641431246,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2074,0.459037203183747,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2075,0.455569755396686,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2076,0.45366441579437,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2077,0.451812726380888,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2078,0.450012382561251,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2079,0.448261212194336,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2080,0.446557166119345,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2081,0.442898479918914,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2082,0.439350692340391,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2083,0.435908811073935,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2084,0.432568139738925,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2085,0.429324256252525,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2086,0.42675905516877,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2087,0.424271727626159,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2088,0.421858728525743,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2089,0.419516726054829,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2090,0.417242585843496,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2091,0.406787254244039,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2092,0.396606877707192,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2093,0.386689508240987,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2094,0.377023912177312,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2095,0.367599516660811,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2096,0.357977594159025,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2097,0.348613190060209,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2098,0.339494703481324,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2099,0.339494703481324,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2100,0.339494703481324,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2200,0.339494703481324,"forestryLoss_growthFactor_SSP5"
+"Iowa","IA",2300,0.339494703481324,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2013,0.981586440833607,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2014,0.990914453277469,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2015,1,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2016,1.00306122867521,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2017,1.00598643312891,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2018,1.00878320053954,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2019,1.01145860047166,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2020,1.01401922677888,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2021,1.00541115233417,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2022,0.997039776657388,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2023,0.988895189065699,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2024,0.980968039245849,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2025,0.973249497276577,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2026,0.972737493506289,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2027,0.972201629761754,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2028,0.971644438632999,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2029,0.971068230145511,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2030,0.970475112582479,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2031,0.974361714554368,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2032,0.978093538499659,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2033,0.981679055821216,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2034,0.985126151854888,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2035,0.988442174696979,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2036,0.987801628155949,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2037,0.987155652537525,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2038,0.986505324133811,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2039,0.985851618059403,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2040,0.985195417780361,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2041,1.0135939600382,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2042,1.04108088274685,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2043,1.0676989352557,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2044,1.09348825256874,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2045,1.11848655134716,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2046,1.10885828795681,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2047,1.09947231861795,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2048,1.09031943222404,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2049,1.08139088669145,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2050,1.07267837905121,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2051,1.1321369789122,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2052,1.18995241316319,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2053,1.24619160464256,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2054,1.30091790099693,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2055,1.35419130977793,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2056,1.35012835289324,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2057,1.34614696425444,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2058,1.34224474257382,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2059,1.33841937824587,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2060,1.33466864912494,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2061,1.35940806596894,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2062,1.38340702186656,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2063,1.4066978533462,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2064,1.42931105623251,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2065,1.45127541409007,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2066,1.4936223549949,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2067,1.53469052602527,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2068,1.57453621809708,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2069,1.6132124926237,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2070,1.65076940869096,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2071,1.64455440795734,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2072,1.63851846783232,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2073,1.63265389285919,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2074,1.62695342464023,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2075,1.62141021114434,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2076,1.49619007863003,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2077,1.37475752769036,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2078,1.25694320127278,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2079,1.14258769301699,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2080,1.03154082692622,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2081,0.988594118957181,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2082,0.946961369081378,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2083,0.906583166296164,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2084,0.867403628645417,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2085,0.829370145002103,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2086,0.811761878314162,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2087,0.794700849155681,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2088,0.778161898259357,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2089,0.762121386303396,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2090,0.746557080809261,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2091,0.753232540994346,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2092,0.759658482399583,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2093,0.765847206401258,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2094,0.771810244829302,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2095,0.777558418560758,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2096,0.78192595104208,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2097,0.786114102244577,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2098,0.790131995175691,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2099,0.790131995175691,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2100,0.790131995175691,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2200,0.790131995175691,"forestryLoss_growthFactor_SSP5"
+"Idaho","ID",2300,0.790131995175691,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2013,1.03351828318078,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2014,1.01650815191299,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2015,1,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2016,0.97832551684088,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2017,0.957471044023594,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2018,0.937393954266103,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2019,0.918054423366459,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2020,0.899415207993332,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2021,0.879225796865329,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2022,0.859832072585518,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2023,0.841190991430785,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2024,0.82326244622549,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2025,0.806009025629415,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2026,0.787787625725155,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2027,0.770289897875292,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2028,0.753476496917347,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2029,0.737310772800793,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2030,0.721758548850523,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2031,0.706993390609368,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2032,0.692801072797857,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2033,0.67915065635342,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2034,0.666013326626438,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2035,0.653362217181773,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2036,0.638939697939444,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2037,0.625072271499236,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2038,0.611730648373422,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2039,0.598887490574387,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2040,0.586517255089538,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2041,0.574266067997611,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2042,0.562482076285377,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2043,0.551141184532678,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2044,0.540220857223034,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2045,0.529699997545942,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2046,0.518418491262506,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2047,0.50753886238638,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2048,0.497041792479111,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2049,0.486909125627625,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2050,0.477123784694827,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2051,0.467349940439425,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2052,0.457921999191475,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2053,0.44882359426072,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2054,0.440039324109378,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2055,0.431554684394473,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2056,0.421164079129904,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2057,0.411153020826948,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2058,0.401503240991816,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2059,0.392197560884699,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2060,0.383219814107558,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2061,0.373720629182096,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2062,0.364586006840198,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2063,0.355797784535549,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2064,0.347338917415266,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2065,0.339193396413706,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2066,0.328123785214924,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2067,0.317502685473138,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2068,0.307307329753691,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2069,0.297516364115457,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2070,0.288109743924771,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2071,0.28319537483867,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2072,0.278435173525339,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2073,0.273822180065284,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2074,0.269349841460496,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2075,0.265011982559129,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2076,0.261113129911718,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2077,0.257339629853575,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2078,0.253685701579488,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2079,0.250145909447109,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2080,0.246715137776725,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2081,0.242432546767193,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2082,0.23828275348967,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2083,0.234259715945146,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2084,0.230357752084082,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2085,0.226571513432629,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2086,0.222920016483677,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2087,0.219385289985946,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2088,0.215961902929518,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2089,0.212644753978994,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2090,0.209429046892687,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2091,0.201870249892513,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2092,0.194622625493701,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2093,0.187670435439951,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2094,0.180998934210369,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2095,0.174594293215367,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2096,0.168204741704406,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2097,0.162080127772759,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2098,0.156206949910565,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2099,0.156206949910565,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2100,0.156206949910565,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2200,0.156206949910565,"forestryLoss_growthFactor_SSP5"
+"Illinois","IL",2300,0.156206949910565,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2013,1.02413417576601,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2014,1.01190254807671,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2015,1,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2016,0.982740418866931,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2017,0.966095355743972,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2018,0.950033847955253,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2019,0.934526933279058,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2020,0.919547493020962,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2021,0.903105562414183,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2022,0.887263085013074,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2023,0.871989002327624,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2024,0.857254319961351,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2025,0.843031941234624,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2026,0.828628072459075,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2027,0.814751615091161,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2028,0.801375142378811,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2029,0.788473056695307,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2030,0.776021441587267,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2031,0.764582411139752,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2032,0.753560925385033,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2033,0.742935168654825,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2034,0.7326847944057,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2035,0.722790804811991,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2036,0.711014899586455,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2037,0.699656466935467,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2038,0.688694417737422,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2039,0.678109032971542,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2040,0.667881855505889,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2041,0.6600048027245,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2042,0.652407692476476,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2043,0.645076596006727,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2044,0.637998468008995,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2045,0.631161078835406,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2046,0.621928088381367,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2047,0.612988065839239,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2048,0.604327797527538,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2049,0.59593483449054,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2050,0.587797438791715,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2051,0.580789175186089,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2052,0.574000597836109,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2053,0.567421977422269,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2054,0.561044135548445,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2055,0.554858406973204,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2056,0.545925524429603,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2057,0.537271003399163,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2058,0.528882539215438,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2059,0.520748524234027,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2060,0.512857999961295,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2061,0.505575524162421,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2062,0.498534049339785,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2063,0.491722407324584,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2064,0.485130089736484,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2065,0.478747200820404,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2066,0.469037034936057,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2067,0.459651923062623,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2068,0.450576713793703,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2069,0.441797154879416,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2070,0.43329982865128,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2071,0.427665755442517,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2072,0.422200981395504,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2073,0.416898045206398,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2074,0.411749915784642,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2075,0.406749961764437,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2076,0.404043092576508,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2077,0.401420756666195,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2078,0.398879111281616,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2079,0.396414541426423,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2080,0.394023643296011,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2081,0.388687227971693,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2082,0.383514787482696,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2083,0.378498892693207,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2084,0.373632556181665,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2085,0.368909199906299,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2086,0.365582347293729,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2087,0.362360246212613,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2088,0.359238054894719,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2089,0.35621122472638,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2090,0.353275478413997,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2091,0.344851775891014,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2092,0.336720480393856,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2093,0.328867487747332,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2094,0.321279569681897,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2095,0.313944307312119,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2096,0.306372909870211,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2097,0.299067213762648,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2098,0.292014197820148,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2099,0.292014197820148,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2100,0.292014197820148,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2200,0.292014197820148,"forestryLoss_growthFactor_SSP5"
+"Indiana","IN",2300,0.292014197820148,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2013,1.02519311124772,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2014,1.0124250675251,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2015,1,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2016,0.982234202002018,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2017,0.965101321742305,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2018,0.9485694592612,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2019,0.932608775991287,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2020,0.917191333032137,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2021,0.90121756066393,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2022,0.885827327681116,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2023,0.870990364890114,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2024,0.856678416206634,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2025,0.84286507631089,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2026,0.827977355477095,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2027,0.813629245667578,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2028,0.799792852990554,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2029,0.786442136885132,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2030,0.773552760576501,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2031,0.762058013302578,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2032,0.75098023953244,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2033,0.740297731050844,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2034,0.729990238387528,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2035,0.720038851421113,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2036,0.708669865047214,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2037,0.697700324937495,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2038,0.687110155219332,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2039,0.676880580293749,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2040,0.666994022335247,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2041,0.656233893383392,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2042,0.645836433435699,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2043,0.635784124970513,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2044,0.6260605419131,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2045,0.616650266815751,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2046,0.606373592892579,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2047,0.596410194888676,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2048,0.586746291075419,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2049,0.577368884345604,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2050,0.568265707723783,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2051,0.560234995932252,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2052,0.552440946033509,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2053,0.544873476444964,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2054,0.537523061813303,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2055,0.53038069556529,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2056,0.522006453749958,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2057,0.513880976809999,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2058,0.505993594287469,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2059,0.498334228173241,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2060,0.490893352779165,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2061,0.483861821187915,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2062,0.477051705998788,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2063,0.470453031607383,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2064,0.464056401701825,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2065,0.457852958305391,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2066,0.443977463850377,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2067,0.430533273880649,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2068,0.417501076945049,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2069,0.40486268107382,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2070,0.392600934518164,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2071,0.391026082268232,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2072,0.389498855588181,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2073,0.388017147828419,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2074,0.386578974068924,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2075,0.385182462481401,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2076,0.377705931034813,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2077,0.370456685605738,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2078,0.363424536364303,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2079,0.356599893037489,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2080,0.349973721474451,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2081,0.346431803140977,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2082,0.342998517780633,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2083,0.339668947853396,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2084,0.336438468082724,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2085,0.333302724065345,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2086,0.329223705021431,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2087,0.325272137860796,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2088,0.321442150009972,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2089,0.317728224001056,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2090,0.314125171037403,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2091,0.303465317055728,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2092,0.293148462871143,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2093,0.283158467814826,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2094,0.273480185091524,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2095,0.264099386525856,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2096,0.254676976134594,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2097,0.245560130220425,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2098,0.236734193203802,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2099,0.236734193203802,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2100,0.236734193203802,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2200,0.236734193203802,"forestryLoss_growthFactor_SSP5"
+"Kansas","KS",2300,0.236734193203802,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2013,1.00506757259159,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2014,1.00247653062257,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2015,1,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2016,0.991906025298818,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2017,0.984125679176595,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2018,0.97664246878726,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2019,0.969440992674585,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2020,0.962506853935124,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2021,0.952267519638684,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2022,0.942420269635821,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2023,0.93294421696058,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2024,0.923819886671874,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2025,0.915029100773805,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2026,0.895917629249917,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2027,0.877485335455023,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2028,0.85969752517934,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2029,0.842521792060575,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2030,0.825927833891107,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2031,0.820289466908939,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2032,0.81487007413064,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2033,0.809657822505356,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2034,0.804641691737675,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2035,0.799811406865521,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2036,0.790582301731469,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2037,0.781684608434063,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2038,0.773101464825719,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2039,0.7648171089402,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2040,0.756816791868131,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2041,0.751428981708788,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2042,0.746239171516327,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2043,0.741237335357016,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2044,0.736414089690453,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2045,0.731760643768522,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2046,0.718857616336016,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2047,0.706346783905709,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2048,0.694210925235595,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2049,0.682433798287307,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2050,0.671000072282744,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2051,0.671574698588074,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2052,0.672158889217801,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2053,0.672751489691891,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2054,0.673351437686317,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2055,0.673957755465397,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2056,0.671077880210809,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2057,0.668304939294257,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2058,0.665633746054073,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2059,0.663059424564873,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2060,0.660577387504402,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2061,0.661093765246042,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2062,0.661619936684623,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2063,0.66215476876476,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2064,0.662697219301455,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2065,0.663246329407717,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2066,0.658767993241224,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2067,0.654449018183749,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2068,0.650281750530614,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2069,0.646258998341903,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2070,0.642373997955834,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2071,0.643603023932277,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2072,0.644797819797455,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2073,0.645959825312976,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2074,0.647090399561036,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2075,0.648190826563293,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2076,0.641678520151763,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2077,0.635364987858327,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2078,0.629241299250713,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2079,0.623299049941534,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2080,0.617530323456296,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2081,0.611401032695421,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2082,0.605459725508993,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2083,0.599697892478808,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2084,0.5941075299223,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2085,0.588681102878835,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2086,0.584573687171399,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2087,0.580594864981949,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2088,0.576738706325702,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2089,0.57299963991566,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2090,0.56937242645713,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2091,0.562774958195245,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2092,0.556398964058798,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2093,0.5502338739527,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2094,0.544269771839936,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2095,0.538497346131791,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2096,0.532075912344254,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2097,0.525871081941329,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2098,0.519872351077115,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2099,0.519872351077115,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2100,0.519872351077115,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2200,0.519872351077115,"forestryLoss_growthFactor_SSP5"
+"Kentucky","KY",2300,0.519872351077115,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2013,0.979231913505069,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2014,0.989720592622954,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2015,1,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2016,1.00427839951328,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2017,1.0084345342433,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2018,1.01247374863254,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2019,1.01640107232163,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2020,1.02022124340012,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2021,1.01849732967647,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2022,1.01684337110902,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2023,1.01525552655669,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2024,1.01373021920358,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2025,1.01226411477489,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2026,0.990600341723838,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2027,0.969661629643258,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2028,0.949412340596375,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2029,0.929819127517108,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2030,0.910850753420968,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2031,0.913140291668171,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2032,0.915359255636559,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2033,0.917510945407376,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2034,0.91959845451176,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2035,0.921624686059497,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2036,0.916326664983802,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2037,0.9112086571234,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2038,0.906261791492153,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2039,0.901477764752805,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2040,0.896848796810298,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2041,0.898236565439392,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2042,0.899588379199964,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2043,0.90090566992075,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2044,0.902189791904664,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2045,0.903442027247131,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2046,0.88786087347094,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2047,0.872723676440413,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2048,0.858011782525943,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2049,0.843707566539813,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2050,0.829794361927551,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2051,0.840719684975032,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2052,0.851350530616973,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2053,0.861698668388257,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2054,0.871775247987947,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2055,0.881590839596944,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2056,0.886104483712744,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2057,0.890496628436959,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2058,0.894772132387676,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2059,0.898935597813368,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2060,0.902991387318181,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2061,0.914220461973621,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2062,0.925130722728026,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2063,0.93573560979527,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2064,0.94604781637317,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2065,0.956079339927353,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2066,0.959512417299931,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2067,0.962855030927937,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2068,0.966110813379798,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2069,0.969283201220622,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2070,0.972375448249987,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2071,0.978522489192614,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2072,0.984488893102574,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2073,0.990282517105547,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2074,0.995910768816805,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2075,1.00138063804828,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2076,0.99187038331784,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2077,0.982648266501414,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2078,0.97370139255403,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2079,0.965017624442484,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2080,0.956585528259249,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2081,0.947491188738889,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2082,0.93867525535295,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2083,0.930125136412059,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2084,0.921828988277552,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2085,0.913775660623824,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2086,0.90907084497725,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2087,0.904512568320416,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2088,0.90009408742337,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2089,0.895809066587798,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2090,0.89165154731698,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2091,0.888404756177957,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2092,0.885258659781498,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2093,0.88220858056786,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2094,0.879250127687675,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2095,0.876379175328301,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2096,0.872177433685953,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2097,0.868109239049221,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2098,0.864168223540859,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2099,0.864168223540859,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2100,0.864168223540859,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2200,0.864168223540859,"forestryLoss_growthFactor_SSP5"
+"Louisiana","LA",2300,0.864168223540859,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2013,1.0193571640535,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2014,1.00956214999494,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2015,1,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2016,0.984976119310787,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2017,0.970455155194374,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2018,0.956412636470572,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2019,0.942825640549238,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2020,0.929672673487282,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2021,0.914870706780099,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2022,0.900580955715325,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2023,0.886777718884873,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2024,0.873436967985329,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2025,0.860536214803981,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2026,0.847018924986273,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2027,0.833969894980243,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2028,0.821365583238757,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2029,0.809183984617152,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2030,0.797404507864844,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2031,0.78663900938023,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2032,0.776250460666172,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2033,0.766219644021743,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2034,0.756528616595907,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2035,0.747160606887967,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2036,0.736283390425899,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2037,0.725774186513407,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2038,0.715614906242909,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2039,0.705788616342573,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2040,0.696279448864954,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2041,0.686380128280345,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2042,0.67680407279067,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2043,0.667535960906041,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2044,0.65856141453542,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2045,0.649866927942736,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2046,0.64169330399082,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2047,0.633765556195263,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2048,0.626072960913508,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2049,0.618605401463669,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2050,0.611353326144019,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2051,0.603753161930294,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2052,0.596373342185639,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2053,0.589204582754816,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2054,0.582238107817501,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2055,0.575465615850361,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2056,0.56617074297215,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2057,0.55714154850979,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2058,0.548366929213691,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2059,0.539836387206678,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2060,0.53153998951088,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2061,0.522753662673059,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2062,0.514230553873918,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2063,0.505959161473882,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2064,0.497928638795621,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2065,0.490128748409335,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2066,0.476628471680688,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2067,0.463541724375904,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2068,0.450850148095008,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2069,0.438536443188885,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2070,0.426584294039133,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2071,0.422108890204689,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2072,0.417767414537473,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2073,0.413553978707506,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2074,0.409463033422459,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2075,0.405489344420852,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2076,0.401426199119425,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2077,0.397486971157066,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2078,0.393666095613033,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2079,0.38995833529264,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2080,0.386358756973886,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2081,0.382139815072982,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2082,0.378050293980326,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2083,0.37408433465576,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2084,0.370236426292297,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2085,0.366501380829125,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2086,0.362528643705989,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2087,0.358680320454537,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2088,0.354950673136218,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2089,0.351334310911037,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2090,0.347826164195102,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2091,0.336607253126808,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2092,0.325757617709283,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2093,0.315259747228624,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2094,0.305097212089047,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2095,0.295254581875614,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2096,0.285236810586512,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2097,0.275556600173794,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2098,0.26619758579864,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2099,0.26619758579864,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2100,0.26619758579864,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2200,0.26619758579864,"forestryLoss_growthFactor_SSP5"
+"Massachusetts","MA",2300,0.26619758579864,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2013,1.01557805345873,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2014,1.00770098182195,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2015,1,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2016,0.986772434706471,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2017,0.973975996535121,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2018,0.961590043998769,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2019,0.949595228824746,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2020,0.93797339642122,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2021,0.92407650487686,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2022,0.9106461083351,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2023,0.89765926231003,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2024,0.88509449599158,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2025,0.872931696162707,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2026,0.860325959553784,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2027,0.848145454334371,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2028,0.83636916915433,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2029,0.824977448168712,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2030,0.813951883800264,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2031,0.803750111365423,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2032,0.793899715688326,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2033,0.784382964041679,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2034,0.775183292516727,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2035,0.766285211521262,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2036,0.756317400847336,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2037,0.746680430270396,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2038,0.737358229297211,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2039,0.728335746460531,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2040,0.719598870066914,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2041,0.710961163701583,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2042,0.702599568419468,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2043,0.694501170841939,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2044,0.686653845947272,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2045,0.679046198033074,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2046,0.672673876916385,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2047,0.666488572198845,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2048,0.660482261246742,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2049,0.654647370343306,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2050,0.648976743889262,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2051,0.642977005792705,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2052,0.637145785486272,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2053,0.631476138038097,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2054,0.625961492781733,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2055,0.620595628544573,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2056,0.611852961630297,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2057,0.603351370328385,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2058,0.595081036677966,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2059,0.587032668001863,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2060,0.579197462274563,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2061,0.572055428232967,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2062,0.565120122726486,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2063,0.558382714295641,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2064,0.551834866848593,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2065,0.5454687054377,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2066,0.532134639689109,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2067,0.519190704788063,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2068,0.506620058879386,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2069,0.494406814590681,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2070,0.482535972411927,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2071,0.477462598592822,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2072,0.472538708770383,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2073,0.46775779051225,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2074,0.463113704322275,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2075,0.458600657319578,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2076,0.454331231324043,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2077,0.450190489452489,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2078,0.446172688526655,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2079,0.442272422475239,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2080,0.438484597943899,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2081,0.433568198119519,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2082,0.428802144541005,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2083,0.424179640770671,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2084,0.419694294040618,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2085,0.41534008571802,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2086,0.411609363793596,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2087,0.407994477452816,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2088,0.404490103230253,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2089,0.401091239214413,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2090,0.39779318112188,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2091,0.387141337381311,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2092,0.376815118891048,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2093,0.36679947847028,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2094,0.357080289524705,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2095,0.34764427650229,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2096,0.337933181713482,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2097,0.328527274336534,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2098,0.319412050912399,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2099,0.319412050912399,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2100,0.319412050912399,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2200,0.319412050912399,"forestryLoss_growthFactor_SSP5"
+"Maryland","MD",2300,0.319412050912399,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2013,0.955924340064139,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2014,0.978168781229579,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2015,1,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2016,1.015566093328,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2017,1.03069187294856,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2018,1.04539643297499,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2019,1.05969774941379,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2020,1.07361276240371,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2021,1.0602752524684,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2022,1.04744048456178,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2023,1.03508190848588,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2024,1.02317475950849,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2025,1.01169591333688,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2026,1.00731663889289,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2027,1.00314380398627,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2028,0.999165275887223,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2029,0.995369789060031,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2030,0.991746871968493,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2031,0.984665964062602,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2032,0.977862647311985,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2033,0.971321848458926,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2034,0.965029532399921,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2035,0.958972615923437,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2036,0.967209969581113,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2037,0.97522752699306,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2038,0.98303433257143,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2039,0.990638923368161,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2040,0.998049365199052,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2041,1.02129003625008,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2042,1.04385371060744,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2043,1.06577009250717,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2044,1.08706715027077,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2045,1.1077712424814,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2046,1.15256466953012,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2047,1.19613931603659,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2048,1.23854465117748,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2049,1.27982748640042,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2050,1.32003215236415,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2051,1.35970995444545,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2052,1.39834725372626,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2053,1.4359847439054,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2054,1.47266101181662,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2055,1.50841267265247,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2056,1.51473782157481,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2057,1.5209304491095,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2058,1.52699468637395,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2059,1.53293449405195,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2060,1.53875367112459,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2061,1.5865360391043,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2062,1.63297965199059,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2063,1.67814042121276,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2064,1.72207117099309,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2065,1.76482184931366,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2066,1.76078732628194,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2067,1.7569199875804,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2068,1.75321127324422,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2069,1.74965315700109,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2070,1.74623810684131,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2071,1.70915364499573,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2072,1.67316650679549,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2073,1.63822876528056,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2074,1.60429524219203,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2075,1.5713233137987,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2076,1.55221094539788,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2077,1.53368011226582,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2078,1.51570473037634,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2079,1.49826025083814,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2080,1.4813235486676,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2081,1.4437055132568,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2082,1.40723973886313,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2083,1.37187409741621,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2084,1.33755955807376,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2085,1.30424996057238,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2086,1.2967159996301,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2087,1.28941790861571,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2088,1.282344810593,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2089,1.27548648655852,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2090,1.26883332645764,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2091,1.28774594061361,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2092,1.30608321131574,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2093,1.32387167754102,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2094,1.34113625566051,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2095,1.35790036198812,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2096,1.37195802108208,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2097,1.38557687051179,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2098,1.39877772162068,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2099,1.39877772162068,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2100,1.39877772162068,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2200,1.39877772162068,"forestryLoss_growthFactor_SSP5"
+"Maine","ME",2300,1.39877772162068,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2013,1.02037905337224,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2014,1.01002090253372,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2015,1,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2016,0.984617637112909,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2017,0.969833547174158,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2018,0.955616213058308,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2019,0.941936205231569,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2020,0.928766015559239,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2021,0.910522450843348,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2022,0.892980095899991,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2023,0.876101519832981,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2024,0.859851825292988,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2025,0.844198441833111,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2026,0.830236090581862,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2027,0.816828018508232,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2028,0.803944096914648,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2029,0.791556260625605,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2030,0.779638338228077,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2031,0.769266734146915,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2032,0.75930253304791,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2033,0.749723590465118,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2034,0.740509287981583,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2035,0.731640406383447,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2036,0.71890257501038,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2037,0.706645597115088,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2038,0.694844347229912,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2039,0.683475364740256,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2040,0.672516720792496,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2041,0.662212353660276,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2042,0.652295387335546,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2043,0.642745980060727,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2044,0.633545569641229,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2045,0.624676774259769,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2046,0.622261407160934,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2047,0.619976824827094,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2048,0.617815657870719,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2049,0.615771018264157,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2050,0.613836462937609,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2051,0.607504708250257,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2052,0.601401443557427,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2053,0.59551575425684,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2054,0.589837372932903,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2055,0.584356633628508,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2056,0.578063319333879,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2057,0.572003488505498,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2058,0.566165820866257,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2059,0.560539674195687,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2060,0.555115036039828,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2061,0.550465028654997,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2062,0.546005237177688,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2063,0.541725928896438,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2064,0.537617978429687,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2065,0.533672822857175,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2066,0.52747369384349,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2067,0.521533949308156,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2068,0.515840260296807,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2069,0.510380130354588,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2070,0.505141833959934,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2071,0.500727147346418,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2072,0.496448886457138,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2073,0.492300942773541,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2074,0.488277563248804,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2075,0.484373324978366,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2076,0.484719836313308,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2077,0.48506112303099,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2078,0.485397294233092,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2079,0.485728456511317,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2080,0.486054713977562,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2081,0.471107209945266,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2082,0.456618480292136,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2083,0.442567750606518,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2084,0.428935481351432,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2085,0.415703277479777,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2086,0.408572541971514,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2087,0.40166600042852,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2088,0.394973296454969,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2089,0.388484700549321,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2090,0.382191063417315,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2091,0.375532133636434,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2092,0.369129515861342,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2093,0.362970470978574,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2094,0.357043058923332,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2095,0.351336077783553,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2096,0.345289998893814,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2097,0.339476868995245,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2098,0.33388500777831,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2099,0.33388500777831,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2100,0.33388500777831,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2200,0.33388500777831,"forestryLoss_growthFactor_SSP5"
+"Michigan","MI",2300,0.33388500777831,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2013,1.00426957545683,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2014,1.00210406730442,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2015,1,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2016,0.992226618507761,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2017,0.984716663689751,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2018,0.977457224740773,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2019,0.970436211473268,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2020,0.963642290584241,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2021,0.950048911297726,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2022,0.93691417697686,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2023,0.924215451771291,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2024,0.911931557091836,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2025,0.900042656634382,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2026,0.891197500176937,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2027,0.882654738780763,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2028,0.874399298335719,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2029,0.866417082991559,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2030,0.858694897451096,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2031,0.853003102401795,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2032,0.847511160625007,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2033,0.842208865867943,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2034,0.83708668965129,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2035,0.83213572620652,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2036,0.822320729690704,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2037,0.812833530876247,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2038,0.803658145260047,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2039,0.79477960441659,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2040,0.786183876848838,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2041,0.778821246333067,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2042,0.771697273942502,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2043,0.76480069971614,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2044,0.758120954997445,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2045,0.751648110473066,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2046,0.75430531155104,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2047,0.756895288658883,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2048,0.759420609585209,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2049,0.761883710829281,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2050,0.764286906001959,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2051,0.760557149442512,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2052,0.7569322296448,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2053,0.753407823809126,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2054,0.749979842183205,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2055,0.74664441263301,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2056,0.742433543001928,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2057,0.738337224913944,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2058,0.7343508403698,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2059,0.730470016558144,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2060,0.726690609783646,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2061,0.724016918106853,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2062,0.721420689702767,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2063,0.718898613243288,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2064,0.71644756321678,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2065,0.714064587086794,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2066,0.70884202100221,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2067,0.703773183683403,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2068,0.698851413400056,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2069,0.694070426878909,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2070,0.689424292847389,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2071,0.685596164359614,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2072,0.68188029607835,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2073,0.678271811124677,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2074,0.674766111419548,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2075,0.671358858027021,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2076,0.674176379070455,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2077,0.676907808343703,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2078,0.679557015921599,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2079,0.682127643845114,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2080,0.684623122653736,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2081,0.665479553703104,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2082,0.646921789618376,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2083,0.628923340819858,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2084,0.611459291286372,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2085,0.594506183417089,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2086,0.586114493961979,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2087,0.577983852008981,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2088,0.570102251197123,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2089,0.562458410623066,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2090,0.555041720854642,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2091,0.546662211959056,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2092,0.538534311893621,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2093,0.530646471001794,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2094,0.522987844537809,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2095,0.515548239461312,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2096,0.507539366160632,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2097,0.499776213264771,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2098,0.492247188184777,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2099,0.492247188184777,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2100,0.492247188184777,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2200,0.492247188184777,"forestryLoss_growthFactor_SSP5"
+"Minnesota","MN",2300,0.492247188184777,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2013,1.02258722196795,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2014,1.01113096956858,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2015,1,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2016,0.98350351822566,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2017,0.967608753061843,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2018,0.952284996910283,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2019,0.93750354072035,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2020,0.923237516521579,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2021,0.906236896147341,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2022,0.889867739491974,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2023,0.874096974466877,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2024,0.858893741728211,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2025,0.844229215534768,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2026,0.830345591133688,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2027,0.816986217248232,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2028,0.804123349784259,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2029,0.791731114947841,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2030,0.779785356911264,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2031,0.768688830795144,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2032,0.758007754970016,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2033,0.747720113118862,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2034,0.73780538412184,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2035,0.728244418871966,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2036,0.716568052744122,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2037,0.70531830546518,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2038,0.694473264584457,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2039,0.68401245532043,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2040,0.673916726319367,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2041,0.67124913593948,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2042,0.668712132921724,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2043,0.666298263594076,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2044,0.664000582625281,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2045,0.661812612329725,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2046,0.653152729157094,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2047,0.644781892567257,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2048,0.636686678319484,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2049,0.628854453538475,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2050,0.621273320452948,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2051,0.61721745365799,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2052,0.613311585515415,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2053,0.609548467090515,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2054,0.605921282122653,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2055,0.602423616327071,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2056,0.594925883175191,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2057,0.587679243425076,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2058,0.580672131070265,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2059,0.573893652467054,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2060,0.567333539352958,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2061,0.564552687175891,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2062,0.561897062984245,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2063,0.559360024775585,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2064,0.556935352497947,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2065,0.554617216558014,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2066,0.550514598453421,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2067,0.546596808298949,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2068,0.542854096829747,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2069,0.539277331344731,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2070,0.535857949798292,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2071,0.526818118003777,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2072,0.518049681532081,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2073,0.50954068574391,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2074,0.501279865084618,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2075,0.493256594258793,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2076,0.492265057153247,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2077,0.491307443833943,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2078,0.490382144293239,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2079,0.489487646038506,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2080,0.488622526919684,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2081,0.480144937068518,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2082,0.47192774912035,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2083,0.463959167130819,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2084,0.456228096452109,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2085,0.448724092398408,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2086,0.446073225004767,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2087,0.443506542950975,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2088,0.441020141592532,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2089,0.438610353036514,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2090,0.436273728497541,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2091,0.432374215619842,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2092,0.428636316869072,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2093,0.425051844601424,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2094,0.421613127906088,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2095,0.418312973140932,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2096,0.414482727029205,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2097,0.410807343676398,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2098,0.407278973681224,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2099,0.407278973681224,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2100,0.407278973681224,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2200,0.407278973681224,"forestryLoss_growthFactor_SSP5"
+"Missouri","MO",2300,0.407278973681224,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2013,0.963091926031289,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2014,0.981722742991917,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2015,1,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2016,1.0120905128941,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2017,1.02383591158727,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2018,1.03525126822946,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2019,1.04635076776246,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2020,1.05714777341725,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2021,1.05994390903123,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2022,1.06269100086877,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2023,1.06538997637335,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2024,1.06804176874622,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2025,1.07064731292239,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2026,1.04371196066635,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2027,1.01770167769914,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2028,0.992570213376728,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2029,0.968274324497549,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2030,0.944773536089977,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2031,0.952230669634301,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2032,0.959457269496183,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2033,0.966464139157783,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2034,0.973261404848045,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2035,0.97985856848564,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2036,0.976593890893599,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2037,0.973460325881714,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2038,0.970450811885651,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2039,0.967558763189081,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2040,0.964778031500372,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2041,0.971234328628643,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2042,0.977513821478998,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2043,0.983623900304565,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2044,0.989571538971724,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2045,0.995363324427383,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2046,0.976092950710333,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2047,0.957388035773615,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2048,0.939224325277163,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2049,0.921578921957347,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2050,0.904430192525433,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2051,0.92412302596402,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2052,0.943301043249652,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2053,0.961984327818302,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2054,0.980191925421073,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2055,0.997941910617737,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2056,1.00892419751008,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2057,1.01963025379287,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2058,1.03007052528458,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2059,1.04025493105344,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2060,1.05019289655499,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2061,1.07170614175831,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2062,1.09262354039206,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2063,1.1129697711327,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2064,1.13276815805644,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2065,1.15204076281906,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2066,1.16434393461538,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2067,1.17631990319845,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2068,1.18798189862258,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2069,1.19934243353728,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2070,1.21041335180703,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2071,1.22108615731155,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2072,1.23144654547964,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2073,1.24150807382826,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2074,1.25128352532928,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2075,1.2607849629971,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2076,1.2483619229682,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2077,1.23631676239071,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2078,1.22463253475171,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2079,1.21329329081186,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2080,1.20228400635201,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2081,1.19029386082694,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2082,1.1786711704077,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2083,1.16739930746822,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2084,1.15646263243803,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2085,1.14584642149428,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2086,1.14058315845233,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2087,1.13548460483455,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2088,1.13054316653939,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2089,1.12575170878994,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2090,1.1211035219378,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2091,1.1229810370934,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2092,1.12481563306113,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2093,1.12660904755078,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2094,1.12836291735704,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2095,1.13007878583672,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2096,1.12993333267847,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2097,1.1298043562968,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2098,1.12969090457949,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2099,1.12969090457949,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2100,1.12969090457949,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2200,1.12969090457949,"forestryLoss_growthFactor_SSP5"
+"Mississippi","MS",2300,1.12969090457949,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2013,0.984495015912438,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2014,0.992336238481524,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2015,1,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2016,1.00170915831572,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2017,1.00335572101836,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2018,1.00494288927975,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2019,1.00647365568174,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2020,1.00795082066281,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2021,0.997759541729622,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2022,0.987889893231305,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2023,0.978326734089068,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2024,0.969055865861901,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2025,0.960063960125132,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2026,0.95858481790968,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2027,0.957141175215616,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2028,0.955731751746842,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2029,0.954355329089274,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2030,0.95301074694036,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2031,0.956277158893019,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2032,0.959424819603677,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2033,0.962459919271506,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2034,0.965388231808773,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2035,0.968215148929602,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2036,0.967248830523053,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2037,0.966302703082602,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2038,0.965376147590418,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2039,0.964468569620129,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2040,0.963579398163379,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2041,0.992655417838373,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2042,1.0208122367392,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2043,1.04809254063718,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2044,1.07453642139344,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2045,1.10018157061523,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2046,1.09051619989182,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2047,1.08110157181228,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2048,1.07192789671956,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2049,1.06298589483046,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2050,1.05426676310984,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2051,1.11600395293309,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2052,1.1760359962044,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2053,1.23443231039084,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2054,1.29125860568289,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2055,1.34657712871814,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2056,1.34335628886971,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2057,1.34018799850792,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2058,1.33707121334903,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2059,1.33400490118703,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2060,1.33098804326649,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2061,1.35737161438054,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2062,1.38296181076263,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2063,1.40779338319158,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2064,1.43189910044683,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2065,1.45530988779228,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2066,1.49994824704981,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2067,1.54323730055142,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2068,1.58523647966943,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2069,1.62600180484115,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2070,1.66558612556231,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2071,1.65954121138254,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2072,1.65366986324615,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2073,1.64796463762484,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2074,1.64241851319151,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2075,1.63702486119483,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2076,1.50864704855635,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2077,1.38415206066137,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2078,1.26336628813378,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2079,1.14612632193879,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2080,1.03227821498995,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2081,0.988631930052423,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2082,0.946320754220928,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2083,0.905284325492221,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2084,0.865465867249631,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2085,0.826811925928481,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2086,0.809225893336611,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2087,0.792185904616644,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2088,0.77566686493314,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2089,0.759645195263422,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2090,0.744098719610348,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2091,0.752033507442109,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2092,0.75966556767486,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2093,0.767009910051699,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2094,0.774080603585784,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2095,0.780890848234261,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2096,0.78625345672334,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2097,0.791394209498152,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2098,0.796324407181983,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2099,0.796324407181983,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2100,0.796324407181983,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2200,0.796324407181983,"forestryLoss_growthFactor_SSP5"
+"Montana","MT",2300,0.796324407181983,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2000,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2001,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2002,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2003,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2004,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2005,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2006,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2007,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2008,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2009,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2010,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2011,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2012,NA,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2013,0.987955431915783,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2014,0.994058878998781,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2015,1,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2016,1.00001165699876,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2017,0.999995019609978,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2018,0.999952270038452,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2019,0.999885421222082,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2020,0.999796331449257,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2021,0.988349307472854,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2022,0.977249629175445,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2023,0.966481435251837,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2024,0.956029829333556,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2025,0.945880806920425,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2026,0.94317117076541,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2027,0.940525290528072,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2028,0.937940925842813,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2029,0.935415941096083,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2030,0.932948299300037,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2031,0.925655250732452,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2032,0.918593591319639,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2033,0.911752268952756,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2034,0.905120933779867,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2035,0.898689882792577,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2036,0.889902432464979,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2037,0.881382296623559,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2038,0.873117231824329,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2039,0.86509574093523,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2040,0.857307016608142,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2041,0.85268426549591,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2042,0.848187465855668,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2043,0.843811375281744,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2044,0.839551045754223,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2045,0.835401802858194,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2046,0.838407391434841,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2047,0.841312108241051,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2048,0.844120652342365,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2049,0.846837445275491,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2050,0.849466650802966,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2051,0.82997385403435,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2052,0.810998255587978,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2053,0.792519437197305,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2054,0.774518045644152,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2055,0.756975723997096,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2056,0.754483134572814,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2057,0.752045620769664,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2058,0.749661352273021,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2059,0.747328580202098,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2060,0.745045632557861,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2061,0.739579620134793,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2062,0.734254577055416,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2063,0.729064979282842,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2064,0.724005593588824,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2065,0.719071458365002,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2066,0.711876799318349,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2067,0.704860981531283,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2068,0.698017149536556,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2069,0.691338805094253,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2070,0.684819783662545,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2071,0.677840593145995,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2072,0.671064611304593,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2073,0.664483048248636,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2074,0.65808761527635,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2075,0.651870489593494,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2076,0.645025278013539,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2077,0.63838516295135,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2078,0.63194102003504,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2079,0.625684259552255,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2080,0.619606787802573,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2081,0.614174881398191,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2082,0.608908814650632,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2083,0.603801096481291,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2084,0.598844680578082,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2085,0.594032932859467,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2086,0.589107451337751,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2087,0.584334749562975,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2088,0.579707809116431,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2089,0.575220035441048,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2090,0.570865226305404,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2091,0.571950844829953,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2092,0.572984268192233,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2093,0.573968230810561,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2094,0.574905292723688,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2095,0.575797852956105,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2096,0.575741706275557,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2097,0.575670410528198,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2098,0.575584925851549,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2099,0.575584925851549,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2100,0.575584925851549,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2200,0.575584925851549,"forestryLoss_growthFactor_SSP5"
+"North Carolina","NC",2300,0.575584925851549,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2000,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2001,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2002,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2003,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2004,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2005,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2006,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2007,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2008,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2009,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2010,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2011,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2012,NA,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2013,0.985588871043974,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2014,0.993013170158764,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2015,1,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2016,1.00079411291734,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2017,1.00131060596764,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2018,1.00157023380587,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2019,1.00159215724911,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2020,1.00139408028315,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2021,1.00351798134184,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2022,1.005269942899,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2023,1.00667821877198,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2024,1.0077688098826,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2025,1.00856566567063,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2026,1.01042627768942,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2027,1.01191868261163,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2028,1.0130711262059,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2029,1.01390959255369,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2030,1.0144580068487,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2031,1.01849428992151,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2032,1.02219429603276,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2033,1.02558122410819,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2034,1.02867648277326,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2035,1.03149984870916,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2036,1.03394806709803,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2037,1.03605199979747,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2038,1.03783637846093,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2039,1.03932404198334,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2040,1.04053610006662,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2041,1.04210989883012,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2042,1.04335249897176,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2043,1.04428773508113,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2044,1.04493765629269,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2045,1.04532267627703,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2046,1.04676483388513,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2047,1.04786264356753,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2048,1.04863974645745,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2049,1.04911811291881,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2050,1.04931817420136,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2051,1.05159709822767,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2052,1.05349437537449,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2053,1.05503512958464,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2054,1.05624276087183,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2055,1.05713907756485,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2056,1.05585074179099,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2057,1.05419585608467,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2058,1.05220149840088,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2059,1.04989281239771,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2060,1.04729315901482,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2061,1.04365953133718,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2062,1.03972736733971,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2063,1.03552108242993,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2064,1.0310632767853,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2065,1.02637488188428,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2066,1.0092664598887,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2067,0.992069561067474,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2068,0.97480409884041,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2069,0.957488275862589,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2070,0.940138729556914,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2071,0.945149602689715,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2072,0.949964275158415,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2073,0.954592556371183,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2074,0.959043650668979,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2075,0.963326201873736,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2076,0.962827039750756,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2077,0.962300884834434,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2078,0.961749941097246,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2079,0.961176251783426,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2080,0.96058171225737,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2081,0.963335715908997,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2082,0.965994414933063,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2083,0.968562352440627,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2084,0.971043795123884,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2085,0.973442753709589,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2086,0.974512531686358,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2087,0.975527758110439,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2088,0.97649134590192,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2089,0.977406021821041,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2090,0.9782743406386,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2091,0.954934639021892,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2092,0.931776902835847,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2093,0.908801740871027,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2094,0.886009526472121,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2095,0.863400420695793,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2096,0.840427521682459,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2097,0.817695156429153,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2098,0.795198731262235,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2099,0.795198731262235,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2100,0.795198731262235,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2200,0.795198731262235,"forestryLoss_growthFactor_SSP5"
+"North Dakota","ND",2300,0.795198731262235,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2013,1.01756515992179,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2014,1.00868569680426,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2015,1,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2016,0.985810505393123,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2017,0.972079499536353,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2018,0.95878514922579,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2019,0.945906984481382,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2020,0.933425793852153,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2021,0.920968148815269,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2022,0.908909669238768,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2023,0.897231352227369,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2024,0.885915387683534,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2025,0.874945065864627,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2026,0.863136136822569,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2027,0.851699699166305,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2028,0.84061819859925,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2029,0.829875176096336,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2030,0.819455183275426,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2031,0.810803519166565,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2032,0.802431270947207,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2033,0.794324923861336,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2034,0.786471829362206,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2035,0.77886013635801,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2036,0.770055516689633,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2037,0.761513312442983,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2038,0.753221684650448,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2039,0.745169508260876,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2040,0.737346318471244,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2041,0.728854060320825,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2042,0.720597178453999,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2043,0.712565736651383,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2044,0.704750362855129,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2045,0.697142209012605,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2046,0.688852075345032,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2047,0.680760138057138,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2048,0.672859219464558,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2049,0.665142491564067,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2050,0.657603454585273,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2051,0.651400331436613,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2052,0.645324450345943,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2053,0.639371957322698,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2054,0.633539151336885,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2055,0.627822476878826,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2056,0.620679494099137,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2057,0.613679514518529,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2058,0.606818344863071,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2059,0.600091951042186,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2060,0.593496450881366,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2061,0.587235010216008,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2062,0.581101220439594,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2063,0.575091176290494,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2064,0.569201132390977,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2065,0.563427495005075,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2066,0.548708351590822,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2067,0.534341940327089,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2068,0.520315162904119,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2069,0.506615586316264,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2070,0.493231399881645,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2071,0.493003596032901,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2072,0.492774987381161,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2073,0.492545804304366,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2074,0.492316257280419,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2075,0.492086538577136,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2076,0.485420531613872,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2077,0.478949465264374,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2078,0.472664781434842,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2079,0.466558419905176,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2080,0.460622782480801,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2081,0.458172123080608,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2082,0.455794680543656,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2083,0.453487181641451,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2084,0.451246546531783,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2085,0.449069874645184,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2086,0.445707287573062,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2087,0.442446226661041,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2088,0.439282080835703,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2089,0.436210516169027,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2090,0.433227455299863,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2091,0.420188668157528,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2092,0.407476419233145,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2093,0.395076841593279,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2094,0.382976889814761,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2095,0.371164278653175,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2096,0.359219223960563,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2097,0.347580927772781,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2098,0.336235786719596,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2099,0.336235786719596,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2100,0.336235786719596,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2200,0.336235786719596,"forestryLoss_growthFactor_SSP5"
+"Nebraska","NE",2300,0.336235786719596,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2000,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2001,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2002,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2003,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2004,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2005,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2006,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2007,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2008,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2009,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2010,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2011,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2012,NA,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2013,1.00250550326262,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2014,1.00119342854265,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2015,1,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2016,0.993184769903481,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2017,0.986670857514928,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2018,0.980441488808819,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2019,0.97448103300894,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2020,0.968774910087583,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2021,0.951839497058235,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2022,0.935553237809866,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2023,0.919881531600576,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2024,0.904792117590587,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2025,0.890254884100153,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2026,0.877480502619621,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2027,0.865218295770566,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2028,0.853440282132748,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2029,0.842120402359138,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2030,0.831234360765408,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2031,0.819330118515997,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2032,0.807886237611076,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2033,0.796877895593655,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2034,0.786281972795629,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2035,0.776076911190281,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2036,0.769927517241387,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2037,0.764050286936734,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2038,0.758429927846192,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2039,0.753052201203235,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2040,0.747903835725417,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2041,0.747994570764116,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2042,0.748157860656435,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2043,0.74838807044108,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2044,0.74867999791374,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2045,0.7490288368449,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2046,0.758303273835018,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2047,0.767390781210257,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2048,0.776296874150718,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2049,0.785026857436513,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2050,0.793585835076552,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2051,0.801804657209349,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2052,0.809867682422489,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2053,0.817779111470863,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2054,0.825543006147528,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2055,0.833163294194682,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2056,0.828946556555331,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2057,0.824916360108207,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2058,0.821062984524431,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2059,0.817377314391898,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2060,0.813850795130078,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2061,0.825567994611565,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2062,0.837010522693396,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2063,0.848188250551753,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2064,0.85911056687602,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2065,0.869786407828375,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2066,0.860840354072078,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2067,0.852241750020858,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2068,0.84397325471671,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2069,0.836018594680333,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2070,0.828362485602669,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2071,0.81172548007614,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2072,0.795585974269903,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2073,0.779922104387818,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2074,0.764713265183883,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2075,0.74994002085956,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2076,0.740065381066215,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2077,0.730495393282831,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2078,0.721216293957143,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2079,0.712215132653856,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2080,0.703479713021173,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2081,0.68691651860949,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2082,0.670861716384338,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2083,0.655292284519766,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2084,0.640186569672322,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2085,0.625524186816445,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2086,0.620239877209092,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2087,0.615122596701939,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2088,0.610164612890442,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2089,0.60535866184604,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2090,0.600697913214112,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2091,0.602496993801219,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2092,0.604292594787464,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2093,0.606084002952644,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2094,0.607870567921867,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2095,0.609651696897377,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2096,0.610449980531308,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2097,0.611265082360452,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2098,0.612095607988322,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2099,0.612095607988322,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2100,0.612095607988322,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2200,0.612095607988322,"forestryLoss_growthFactor_SSP5"
+"New Hampshire","NH",2300,0.612095607988322,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2000,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2001,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2002,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2003,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2004,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2005,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2006,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2007,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2008,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2009,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2010,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2011,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2012,NA,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2013,1.02694620724251,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2014,1.01328601585357,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2015,1,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2016,0.981407856599918,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2017,0.963486080925274,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2018,0.946200668214314,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2019,0.929519819228924,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2020,0.913413766837257,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2021,0.896133703531808,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2022,0.879496277135384,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2023,0.863467806615149,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2024,0.848016865407331,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2025,0.833114098845609,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2026,0.817471591674596,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2027,0.802410967733446,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2028,0.787901691150888,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2029,0.77391527401588,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2030,0.760425110121329,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2031,0.747987961659102,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2032,0.736009086680878,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2033,0.724464413557048,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2034,0.713331496889443,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2035,0.702589383963715,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2036,0.690350141838603,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2037,0.678550063628458,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2038,0.667166814361696,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2039,0.656179515955501,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2040,0.645568631861461,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2041,0.634442518813006,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2042,0.623702988908562,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2043,0.613331043297522,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2044,0.603308879377326,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2045,0.593619799417187,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2046,0.584206253750255,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2047,0.575096334651189,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2048,0.566276213809562,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2049,0.557732868206858,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2050,0.549454023324576,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2051,0.540919579003139,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2052,0.532651087998385,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2053,0.524636813656225,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2054,0.516865682382954,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2055,0.509327238260308,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2056,0.499715982611893,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2057,0.490405100633655,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2058,0.481381291289958,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2059,0.472632007868084,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2060,0.464145406131342,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2061,0.454792888089383,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2062,0.445744356130948,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2063,0.436985862761623,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2064,0.42850427955765,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2065,0.420287238837922,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2066,0.407627309641862,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2067,0.395382733681638,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2068,0.383534352217582,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2069,0.372064136723277,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2070,0.360955108006124,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2071,0.356989682824603,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2072,0.353144479350032,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2073,0.349414172097138,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2074,0.34579374356448,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2075,0.342278462369226,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2076,0.338405635448361,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2077,0.334652623900873,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2078,0.331014007025865,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2079,0.327484684602546,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2080,0.324059853613701,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2081,0.320349813403515,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2082,0.316753947340778,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2083,0.313267078923451,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2084,0.309884339531357,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2085,0.306601145884984,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2086,0.302987605485629,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2087,0.29948761172255,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2088,0.296095920652296,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2089,0.292807605727747,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2090,0.289618034161459,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2091,0.279475751649671,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2092,0.269677403165736,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2093,0.260206520595914,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2094,0.251047655981353,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2095,0.242186304109682,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2096,0.233218211093411,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2097,0.22456060065966,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2098,0.216198310886515,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2099,0.216198310886515,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2100,0.216198310886515,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2200,0.216198310886515,"forestryLoss_growthFactor_SSP5"
+"New Jersey","NJ",2300,0.216198310886515,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2000,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2001,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2002,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2003,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2004,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2005,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2006,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2007,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2008,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2009,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2010,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2011,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2012,NA,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2013,1.02477795237154,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2014,1.01220124510836,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2015,1,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2016,0.982486883535358,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2017,0.965631828841827,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2018,0.949400742569423,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2019,0.933761769100745,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2020,0.918685113352696,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2021,0.900536056329399,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2022,0.883083934357501,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2023,0.866291563309064,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2024,0.850124275146969,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2025,0.834549712743336,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2026,0.819491381864729,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2027,0.805019951238725,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2028,0.791103823460108,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2029,0.777713553138033,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2030,0.764821670475542,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2031,0.753469813191492,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2032,0.742555062650246,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2033,0.732053903497827,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2034,0.721944431414386,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2035,0.712206219677003,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2036,0.700465512145103,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2037,0.689166957340366,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2038,0.678287480335664,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2039,0.667805534116613,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2040,0.657700977488333,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2041,0.652336541858282,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2042,0.647195579207236,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2043,0.64226609329828,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2044,0.637536881412288,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2045,0.632997471909574,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2046,0.622460987568564,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2047,0.612272763513681,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2048,0.602416713813394,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2049,0.592877697607404,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2050,0.583641452066416,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2051,0.586423840459343,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2052,0.589175043297568,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2053,0.591894956598482,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2054,0.594583536688479,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2055,0.597240793528836,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2056,0.588456496174949,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2057,0.579962315934451,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2058,0.571744990344817,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2059,0.563792024354376,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2060,0.556091636862067,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2061,0.55256860349315,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2062,0.549193285377135,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2063,0.54595805083456,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2064,0.542855746757823,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2065,0.539879663155001,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2066,0.53771887714699,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2067,0.535684244032748,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2068,0.533768598369583,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2069,0.531965243006003,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2070,0.530267913604983,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2071,0.525954808568657,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2072,0.521773472927159,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2073,0.517718044238047,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2074,0.513782999954834,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2075,0.509963133259982,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2076,0.484472684360468,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2077,0.459757976832407,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2078,0.435784212504426,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2079,0.412518641299849,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2080,0.389930412839391,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2081,0.379380080416852,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2082,0.369153654469631,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2083,0.359236465794246,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2084,0.349614717209678,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2085,0.340275419729111,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2086,0.334130343414477,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2087,0.328178397631244,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2088,0.322410662311632,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2089,0.316818757303511,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2090,0.311394802162069,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2091,0.305276872827819,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2092,0.299392996951051,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2093,0.293731561033478,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2094,0.288281679627331,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2095,0.283033139860672,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2096,0.277574640703852,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2097,0.272323857460688,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2098,0.267270405086938,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2099,0.267270405086938,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2100,0.267270405086938,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2200,0.267270405086938,"forestryLoss_growthFactor_SSP5"
+"New Mexico","NM",2300,0.267270405086938,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2013,1.00411915584025,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2014,1.00209044662906,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2015,1,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2016,0.992125293459037,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2017,0.984408013117576,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2018,0.976843563556684,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2019,0.969427521555331,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2020,0.962155628487893,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2021,0.954159119092026,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2022,0.946318308447276,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2023,0.938629273182582,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2024,0.931088177602978,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2025,0.923691275763919,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2026,0.915902632891098,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2027,0.908278561974997,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2028,0.900814161807788,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2029,0.893504706136426,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2030,0.886345637493407,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2031,0.88061352292746,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2032,0.875022059979014,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2033,0.869565943188819,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2034,0.864240141616849,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2035,0.859039880562929,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2036,0.851582875673816,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2037,0.844306025145403,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2038,0.837202628530073,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2039,0.830266327155623,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2040,0.823491081733885,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2041,0.817825678281129,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2042,0.812277668045547,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2043,0.806843453292127,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2044,0.801519581000267,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2045,0.796302735719778,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2046,0.788681928716643,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2047,0.781222405276985,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2048,0.773919078336663,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2049,0.766767073636927,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2050,0.759761718640475,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2051,0.756577616875661,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2052,0.753435072547581,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2053,0.750333789148669,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2054,0.74727343038351,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2055,0.744253625536766,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2056,0.734903968256887,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2057,0.725760263952427,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2058,0.716815692172708,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2059,0.708063734748431,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2060,0.699498158964218,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2061,0.691091198235002,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2062,0.682876871092769,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2063,0.674848413018881,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2064,0.666999382937615,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2065,0.659323643523563,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2066,0.647463250652574,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2067,0.63587132861393,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2068,0.624538433562356,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2069,0.61345557923406,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2070,0.602614208492366,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2071,0.599416660547185,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2072,0.5963075496544,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2073,0.59328317306037,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2074,0.590340034895951,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2075,0.587474831794455,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2076,0.575856460481088,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2077,0.564585503553912,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2078,0.553646521814559,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2079,0.543024980229372,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2080,0.532707182592721,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2081,0.52665798607221,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2082,0.520793064201649,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2083,0.515104101909437,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2084,0.509583277568441,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2085,0.504223226907608,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2086,0.49928272141945,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2087,0.494494472867644,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2088,0.489851505680409,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2089,0.485347265086084,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2090,0.480975585819723,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2091,0.466737537385666,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2092,0.45291314604468,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2093,0.439483663066551,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2094,0.426431478714745,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2095,0.413740036421215,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2096,0.400711945512655,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2097,0.388077391749519,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2098,0.375817898721677,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2099,0.375817898721677,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2100,0.375817898721677,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2200,0.375817898721677,"forestryLoss_growthFactor_SSP5"
+"Nevada","NV",2300,0.375817898721677,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2000,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2001,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2002,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2003,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2004,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2005,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2006,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2007,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2008,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2009,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2010,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2011,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2012,NA,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2013,1.02315656612099,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2014,1.01141626182725,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2015,1,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2016,0.983218895511831,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2017,0.967041969105485,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2018,0.951438597371682,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2019,0.936380142227437,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2020,0.921839794854273,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2021,0.904869118606837,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2022,0.888527141930194,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2023,0.872780986963033,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2024,0.857599973550151,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2025,0.842955441425054,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2026,0.827744363697284,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2027,0.813100406210181,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2028,0.798993769449837,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2029,0.785396654056511,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2030,0.772283098366786,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2031,0.75995983389638,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2032,0.748091844176395,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2033,0.73665517974612,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2034,0.725627510546886,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2035,0.714987992862908,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2036,0.703389149167878,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2037,0.69221130639216,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2038,0.681432917678784,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2039,0.67103384690085,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2040,0.66099525670469,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2041,0.651077334880637,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2042,0.64151122221579,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2043,0.632279431913972,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2044,0.623365585641002,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2045,0.614754328499444,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2046,0.607326832248441,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2047,0.600150519206161,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2048,0.593213639171224,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2049,0.586505137682174,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2050,0.580014606412329,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2051,0.573150092018224,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2052,0.566511553779542,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2053,0.560088697677068,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2054,0.553871823076456,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2055,0.54785178155927,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2056,0.538638934996519,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2057,0.529722559416005,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2058,0.521089298677786,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2059,0.512726562467135,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2060,0.504622473265602,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2061,0.497229565788561,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2062,0.490095030258429,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2063,0.483206546963656,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2064,0.476552536222682,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2065,0.470122104935472,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2066,0.457439190466643,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2067,0.445194958936464,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2068,0.433368625420601,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2069,0.421940649763552,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2070,0.410892646698612,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2071,0.405093497340141,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2072,0.39947103658991,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2073,0.394017415591512,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2074,0.388725240148712,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2075,0.383587538415609,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2076,0.378763296675946,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2077,0.374089245782858,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2078,0.3695585689893,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2079,0.365164853239491,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2080,0.360902059822693,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2081,0.35559168521819,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2082,0.35044479330739,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2083,0.345453970757613,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2084,0.340612245192483,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2085,0.335913052906629,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2086,0.331880451275275,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2087,0.327975148845825,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2088,0.324191255548717,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2089,0.320523238093409,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2090,0.316965893390296,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2091,0.308051697808052,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2092,0.29946059033428,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2093,0.291176782888114,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2094,0.283185472165119,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2095,0.275472764732748,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2096,0.26750855194551,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2097,0.259840871795884,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2098,0.252454975370546,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2099,0.252454975370546,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2100,0.252454975370546,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2200,0.252454975370546,"forestryLoss_growthFactor_SSP5"
+"New York","NY",2300,0.252454975370546,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2013,1.0295127433735,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2014,1.01453888112162,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2015,1,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2016,0.980219709472662,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2017,0.961177519110257,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2018,0.942835321342119,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2019,0.925157504990349,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2020,0.908110757813581,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2021,0.889477216158024,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2022,0.871558916115839,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2023,0.854317705463193,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2024,0.837718013224008,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2025,0.821726639193136,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2026,0.805388674837235,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2027,0.789683681249918,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2028,0.774577689025141,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2029,0.760039037974976,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2030,0.746038188045345,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2031,0.732883648447646,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2032,0.720230344530712,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2033,0.70805146018173,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2034,0.696322010585889,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2035,0.685018690839605,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2036,0.671755554866838,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2037,0.658990760480046,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2038,0.646698331122507,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2039,0.634854009123062,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2040,0.623435118398492,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2041,0.614409740346945,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2042,0.605731983227857,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2043,0.597383832941232,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2044,0.58934844467072,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2045,0.5816100518924,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2046,0.571513137604681,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2047,0.561762709366249,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2048,0.552342430617023,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2049,0.543236936708814,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2050,0.534431765396347,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2051,0.526852855333841,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2052,0.51953550797424,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2053,0.512467503608532,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2054,0.50563733776786,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2055,0.499034171102812,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2056,0.489976667129937,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2057,0.481228998938009,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2058,0.472776732797727,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2059,0.464606279771392,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2060,0.456704836422086,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2061,0.449623632867936,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2062,0.442803934277186,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2063,0.436232935967098,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2064,0.429898613908329,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2065,0.423789667833942,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2066,0.414886914820873,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2067,0.406324955118163,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2068,0.39808688237618,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2069,0.390156827766342,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2070,0.382519884002666,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2071,0.376473309947576,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2072,0.370611699296893,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2073,0.364926817111092,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2074,0.359410906098519,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2075,0.354056652645739,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2076,0.351167615840573,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2077,0.34837122033327,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2078,0.345663199294098,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2079,0.343039540493551,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2080,0.340496467720391,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2081,0.335083303704572,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2082,0.329836978177755,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2083,0.324749921607377,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2084,0.31981501482073,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2085,0.315025556027264,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2086,0.311812566273157,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2087,0.30870162347135,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2088,0.305687994343949,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2089,0.302767232612033,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2090,0.299935157606766,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2091,0.293101383347912,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2092,0.286528275687169,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2093,0.280202911086783,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2094,0.274113175971445,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2095,0.268247705017904,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2096,0.262188629961063,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2097,0.256361684588957,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2098,0.250755244964314,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2099,0.250755244964314,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2100,0.250755244964314,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2200,0.250755244964314,"forestryLoss_growthFactor_SSP5"
+"Ohio","OH",2300,0.250755244964314,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2013,1.0140018238267,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2014,1.00693169595287,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2015,1,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2016,0.987501682041859,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2017,0.975392625422513,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2018,0.963654729601666,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2019,0.952271006958012,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2020,0.94122549816276,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2021,0.928905467035216,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2022,0.916961704811025,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2023,0.905376940260521,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2024,0.894134957090224,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2025,0.883220513815522,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2026,0.872283382649157,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2027,0.861672424159557,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2028,0.851372929242773,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2029,0.841371076184228,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2030,0.831653863797825,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2031,0.823503128556926,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2032,0.815603023256328,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2033,0.807941849997441,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2034,0.800508642065946,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2035,0.793293106890028,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2036,0.840255988543505,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2037,0.885659616353693,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2038,0.929579746480242,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2039,0.972087330766979,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2040,1.01324889041752,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2041,0.988543427214185,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2042,0.964563093008949,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2043,0.941275893586132,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2044,0.918651711986634,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2045,0.896662171671145,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2046,0.900286618869013,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2047,0.90375859380062,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2048,0.907085991042041,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2049,0.910276210314402,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2050,0.913336193033985,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2051,0.918066832309671,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2052,0.922612931596836,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2053,0.926983624447588,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2054,0.931187492019223,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2055,0.935232602586755,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2056,0.935564090798083,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2057,0.935817300228508,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2058,0.935997508058341,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2059,0.936109625632316,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2060,0.93615822671466,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2061,0.937797341722668,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2062,0.939319785021072,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2063,0.940732540570201,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2064,0.942042124157806,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2065,0.943254619365642,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2066,0.937863470509815,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2067,0.932529056563083,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2068,0.927251687858624,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2069,0.922031557313082,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2070,0.916868753101605,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2071,0.91243701719421,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2072,0.908127194875195,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2073,0.903934199992136,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2074,0.899853229920753,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2075,0.895879745883225,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2076,0.892388754529402,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2077,0.888995610749256,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2078,0.885696122885139,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2079,0.882486339815685,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2080,0.879362533766719,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2081,0.877158274323036,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2082,0.875019457253936,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2083,0.872943165850929,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2084,0.870926655474341,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2085,0.868967341004419,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2086,0.875940119425899,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2087,0.882691721562173,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2088,0.889232401018381,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2089,0.895571789811344,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2090,0.901718944689964,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2091,0.881494965911193,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2092,0.861809410965494,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2093,0.842638753388436,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2094,0.82396087630061,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2095,0.805754966729424,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2096,0.786894251944299,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2097,0.768551689999955,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2098,0.75070371579335,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2099,0.75070371579335,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2100,0.75070371579335,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2200,0.75070371579335,"forestryLoss_growthFactor_SSP5"
+"Oklahoma","OK",2300,0.75070371579335,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2013,0.983824572942676,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2014,0.992012183340666,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2015,1,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2016,1.00201031491634,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2017,1.00393484005751,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2018,1.00577828369296,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2019,1.00754503548083,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2020,1.00923919214437,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2021,0.998357144400113,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2022,0.987808672374568,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2023,0.977578419919809,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2024,0.967651970952054,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2025,0.958015777928595,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2026,0.957555056111371,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2027,0.957090456923982,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2028,0.956622811029103,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2029,0.956152867561044,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2030,0.955681302093335,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2031,0.962630616966727,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2032,0.969334820125853,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2033,0.975806463299981,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2034,0.982057263270586,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2035,0.988098169776209,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2036,0.992240156630248,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2037,0.996237309597813,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2038,1.00009688797076,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2039,1.00382568165274,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2040,1.00743004812241,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2041,1.02345003147451,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2042,1.03896044537621,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2043,1.05398504684671,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2044,1.06854614551419,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2045,1.08266471186024,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2046,1.09785597008161,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2047,1.11260790004711,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2048,1.12693915694252,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2049,1.14086735957533,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2050,1.15440916111207,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2051,1.17670534953599,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2052,1.19838673997395,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2053,1.21947833080623,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2054,1.2400037865728,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2055,1.25998552560263,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2056,1.31333664561087,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2057,1.36522007871907,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2058,1.41569549319741,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2059,1.46481936909067,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2060,1.51264520821208,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2061,1.46521709486464,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2062,1.41914885411459,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2063,1.37438276617304,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2064,1.33086433452857,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2065,1.28854206393834,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2066,1.35275839143097,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2067,1.41509961442253,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2068,1.47564657826453,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2069,1.53447555024568,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2070,1.59165853896241,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2071,1.48504053940666,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2072,1.38156550747206,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2073,1.28109647659849,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2074,1.18350432501896,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2075,1.08866722203471,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2076,1.07482546432449,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2077,1.06140258234632,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2078,1.04837984187895,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2079,1.03573960959091,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2080,1.02346527334157,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2081,1.02735677328564,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2082,1.03112912039595,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2083,1.03478770415255,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2084,1.03833759384272,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2085,1.04178356199115,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2086,1.02283689951781,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2087,1.00448062266959,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2088,0.986687558930779,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2089,0.969432178099586,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2090,0.952690470057012,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2091,0.976388973611522,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2092,0.999336757165021,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2093,1.02156895708791,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2094,1.0431185503153,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2095,1.06401651774348,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2096,1.08249408681922,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2097,1.10037204854781,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2098,1.11767916682811,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2099,1.11767916682811,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2100,1.11767916682811,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2200,1.11767916682811,"forestryLoss_growthFactor_SSP5"
+"Oregon","OR",2300,1.11767916682811,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2013,1.02303895838266,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2014,1.01133763879957,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2015,1,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2016,0.983333976339321,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2017,0.967305215094124,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2018,0.951880416861583,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2019,0.937028478170372,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2020,0.922720317111852,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2021,0.904302626589552,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2022,0.886595099673979,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2023,0.869559762086924,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2024,0.853161212528532,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2025,0.83736641267917,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2026,0.821689316779504,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2027,0.806622303236735,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2028,0.792132553185994,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2029,0.778189481899262,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2030,0.764764555687491,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2031,0.751845536911356,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2032,0.739417359348123,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2033,0.727453803524598,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2034,0.715930438916988,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2035,0.704824476145548,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2036,0.693820888247666,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2037,0.683238815549045,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2038,0.673056069037395,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2039,0.663251936160747,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2040,0.653807062497677,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2041,0.645647090249297,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2042,0.637803170328125,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2043,0.630258881077596,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2044,0.62299886831369,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2045,0.616008762184427,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2046,0.612014562138264,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2047,0.608189609342532,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2048,0.604525115659752,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2049,0.601012844630907,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2050,0.597645070692842,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2051,0.594089257050915,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2052,0.590679639858276,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2053,0.587408823891579,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2054,0.584269866416364,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2055,0.581256244592334,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2056,0.57345366439334,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2057,0.565916503330452,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2058,0.558632433090101,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2059,0.551589845655559,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2060,0.544777802811006,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2061,0.541916347490544,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2062,0.539184631839457,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2063,0.536575758183379,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2064,0.534083267544764,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2065,0.531701106880123,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2066,0.520534847742538,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2067,0.509762194105061,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2068,0.499364326228351,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2069,0.489323557073789,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2070,0.479623250276686,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2071,0.471789805350301,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2072,0.464192951730755,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2073,0.456822231787476,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2074,0.44966779190954,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2075,0.442720339655789,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2076,0.437198211158349,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2077,0.431846985810404,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2078,0.426658930142321,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2079,0.421626767943872,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2080,0.41674364705166,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2081,0.409497005276092,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2082,0.40247294187981,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2083,0.395661374562436,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2084,0.389052820432256,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2085,0.382638352130083,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2086,0.3787537805532,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2087,0.374991553832241,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2088,0.371346016398208,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2089,0.367811855125163,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2090,0.364384073824197,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2091,0.358427818378113,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2092,0.352688963171707,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2093,0.347156862930983,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2094,0.341821536829644,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2095,0.336673617937532,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2096,0.331191211900438,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2097,0.32590898174095,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2098,0.320817018494652,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2099,0.320817018494652,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2100,0.320817018494652,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2200,0.320817018494652,"forestryLoss_growthFactor_SSP5"
+"Pennsylvania","PA",2300,0.320817018494652,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2013,1.03267491894906,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2014,1.01609275179046,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2015,1,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2016,0.978726542633635,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2017,0.958257165172971,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2018,0.938550087830967,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2019,0.919566277469499,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2020,0.901269229896009,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2021,0.88182690635615,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2022,0.86314212151246,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2023,0.845174140938853,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2024,0.827884999385316,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2025,0.811239274291058,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2026,0.793694043215866,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2027,0.776835718229488,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2028,0.760627230144906,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2029,0.745034037976369,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2030,0.730023921498353,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2031,0.715991433226926,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2032,0.702495771868723,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2033,0.689508156153898,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2034,0.677001772727142,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2035,0.664951613345925,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2036,0.651514048055824,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2037,0.638584061172907,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2038,0.626135122506319,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2039,0.614142460110027,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2040,0.602582919709693,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2041,0.590666034633047,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2042,0.579187907991611,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2043,0.568126301672771,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2044,0.557460403202635,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2045,0.547170715632065,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2046,0.537447088473012,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2047,0.528058575569015,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2048,0.51898934041778,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2049,0.510224489967777,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2050,0.501750007085425,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2051,0.493187539539045,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2052,0.484910325021514,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2053,0.476905283907683,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2054,0.469160093569843,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2055,0.461663135717981,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2056,0.452442106214906,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2057,0.443525057940047,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2058,0.434898108766553,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2059,0.426548179331505,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2060,0.418462937135886,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2061,0.409963900439711,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2062,0.401754612543172,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2063,0.393821431812745,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2064,0.386151530086071,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2065,0.378732834183163,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2066,0.367149646531944,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2067,0.355965826350617,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2068,0.34516248102008,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2069,0.33472184839034,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2070,0.324627215194952,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2071,0.320502780410792,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2072,0.316504824103594,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2073,0.312627707368241,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2074,0.308866118633909,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2075,0.305215050373451,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2076,0.301590687259513,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2077,0.298078904359995,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2078,0.294674597847563,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2079,0.29137296596479,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2080,0.288169487072255,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2081,0.284777864420142,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2082,0.281490567115508,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2083,0.278302866233878,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2084,0.275210314082907,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2085,0.272208723613325,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2086,0.2689698623849,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2087,0.265832888405784,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2088,0.262793094057279,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2089,0.259846056708923,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2090,0.2569876174936,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2091,0.248394268857208,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2092,0.240090345937374,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2093,0.232062020886453,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2094,0.224296321811208,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2095,0.216781067840997,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2096,0.209212938084217,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2097,0.201902147329365,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2098,0.194836189114735,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2099,0.194836189114735,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2100,0.194836189114735,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2200,0.194836189114735,"forestryLoss_growthFactor_SSP5"
+"Rhode Island","RI",2300,0.194836189114735,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2000,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2001,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2002,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2003,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2004,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2005,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2006,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2007,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2008,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2009,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2010,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2011,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2012,NA,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2013,0.972016065732687,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2014,0.98618015277982,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2015,1,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2016,1.00767032524312,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2017,1.01505865240709,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2018,1.02217943158523,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2019,1.02904617024353,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2020,1.03567150759312,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2021,1.02500363476,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2022,1.01464948838789,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2023,1.00459510801722,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2024,0.994827365157826,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2025,0.985333901289116,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2026,0.987844247497585,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2027,0.99023966385651,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2028,0.992526824685103,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2029,0.994711930201819,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2030,0.996800746395681,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2031,0.990681830588883,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2032,0.984751291124654,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2033,0.979000327821383,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2034,0.973420690916679,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2035,0.968004638107909,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2036,0.959962370164073,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2037,0.952160027488772,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2038,0.944586777927098,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2039,0.937232442869557,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2040,0.930087448103968,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2041,0.928172423352833,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2042,0.92629765976095,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2043,0.9244618968773,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2044,0.922663926556297,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2045,0.920902590255575,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2046,0.930254290671367,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2047,0.939325564625215,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2048,0.948128617189881,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2049,0.956674963609925,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2050,0.964975476966264,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2051,0.939129490646427,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2052,0.913972567321697,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2053,0.889477400516111,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2054,0.865618112345416,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2055,0.842370161069392,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2056,0.84382386318396,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2057,0.84522455531586,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2058,0.846574786892084,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2059,0.847876955330913,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2060,0.849133316836967,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2061,0.84616156006498,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2062,0.843261805523897,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2063,0.840431382155201,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2064,0.83766775324806,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2065,0.834968507890987,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2066,0.831467695172347,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2067,0.828044936385256,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2068,0.824697527902505,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2069,0.821422895229382,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2070,0.818218585071602,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2071,0.808894606931998,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2072,0.799843727270421,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2073,0.791054090533226,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2074,0.782514518626413,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2075,0.774214463163937,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2076,0.765300803994677,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2077,0.756655451042504,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2078,0.748266438323508,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2079,0.740122501952496,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2080,0.732213029355923,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2081,0.725381779074329,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2082,0.718759367444937,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2083,0.712336355239451,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2084,0.706103863827629,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2085,0.700053534162174,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2086,0.694316647716106,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2087,0.688758154472305,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2088,0.68336985090131,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2089,0.678144029120708,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2090,0.673073440011535,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2091,0.682034848748175,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2092,0.690705884712043,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2093,0.699100244696821,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2094,0.707230781402089,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2095,0.71510956736504,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2096,0.721546121884531,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2097,0.727768861578509,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2098,0.733788111420007,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2099,0.733788111420007,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2100,0.733788111420007,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2200,0.733788111420007,"forestryLoss_growthFactor_SSP5"
+"South Carolina","SC",2300,0.733788111420007,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2000,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2001,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2002,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2003,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2004,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2005,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2006,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2007,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2008,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2009,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2010,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2011,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2012,NA,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2013,1.00417812565835,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2014,1.00209074420829,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2015,1,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2016,0.992179429693426,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2017,0.984566443498985,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2018,0.977152505293993,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2019,0.969929558586665,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2020,0.962889992294992,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2021,0.956437361808098,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2022,0.950140171803192,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2023,0.943992803244655,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2024,0.937989908845148,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2025,0.932126396532312,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2026,0.922570878953879,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2027,0.913268484945352,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2028,0.904208985106139,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2029,0.895382710380138,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2030,0.886780513134818,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2031,0.882583476289911,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2032,0.878487140510517,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2033,0.874487808505398,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2034,0.870581968612898,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2035,0.86676628281727,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2036,0.863440994697489,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2037,0.860166460754028,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2038,0.856942030630606,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2039,0.853767021655235,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2040,0.850640725061696,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2041,0.84515463117747,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2042,0.839772368836173,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2043,0.834491207180045,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2044,0.829308497934276,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2045,0.824221673369762,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2046,0.811306148361059,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2047,0.79867386366987,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2048,0.786315482356617,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2049,0.774222079582128,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2050,0.762385119735201,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2051,0.76137074703576,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2052,0.760289322413165,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2053,0.759146435321732,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2054,0.757947262707598,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2055,0.756696601768511,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2056,0.759136512192695,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2057,0.761381627917107,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2058,0.763443735353502,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2059,0.765333836320481,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2060,0.767062207399109,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2061,0.782352352192769,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2062,0.797064899380305,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2063,0.811228424232967,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2064,0.82486975012444,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2065,0.838014076628324,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2066,0.817866327127569,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2067,0.798082850161136,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2068,0.778654073551641,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2069,0.759570745005926,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2070,0.740823919776917,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2071,0.755733894790028,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2072,0.77018347511076,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2073,0.784193266091301,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2074,0.797782674302048,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2075,0.810969992939289,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2076,0.778260125990459,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2077,0.746520670455033,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2078,0.715708685081547,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2079,0.685783737580968,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2080,0.656707723550378,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2081,0.654658278354286,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2082,0.65266603694169,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2083,0.650728529267639,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2084,0.648843428745502,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2085,0.647008541863781,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2086,0.642743153379981,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2087,0.638599282821901,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2088,0.63457155329306,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2089,0.630654907453188,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2090,0.626844583904167,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2091,0.616120576310116,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2092,0.605414264232653,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2093,0.594730091471964,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2094,0.584072114310343,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2095,0.573444033920761,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2096,0.562897536054205,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2097,0.552375264501963,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2098,0.541880431022345,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2099,0.541880431022345,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2100,0.541880431022345,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2200,0.541880431022345,"forestryLoss_growthFactor_SSP5"
+"South Dakota","SD",2300,0.541880431022345,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2013,0.999527312050313,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2014,0.999765523060931,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2015,1,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2016,0.994489421057787,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2017,0.989157359703495,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2018,0.983995301167565,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2019,0.978995262871208,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2020,0.974149753527773,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2021,0.96636884928335,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2022,0.958843818136152,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2023,0.951562251207273,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2024,0.944512528861566,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2025,0.937683758961875,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2026,0.921111122243634,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2027,0.905083790951091,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2028,0.889575272936797,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2029,0.874560765369223,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2030,0.860017022160635,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2031,0.856026250564047,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2032,0.852168864121014,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2033,0.848438259800113,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2034,0.844828264409738,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2035,0.841333100125026,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2036,0.833526058823247,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2037,0.825968578362141,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2038,0.818648827478472,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2039,0.811555713329235,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2040,0.804678824657627,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2041,0.800214083546767,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2042,0.795883925950175,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2043,0.791682299252638,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2044,0.787603510780534,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2045,0.783642201318565,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2046,0.77187809562162,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2047,0.76044092118861,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2048,0.749317191437131,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2049,0.738494153336192,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2050,0.727959738111507,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2051,0.728691046172317,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2052,0.729397638632575,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2053,0.730080657561708,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2054,0.730741178619458,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2055,0.73138021568981,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2056,0.728353036356128,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2057,0.725402595875418,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2058,0.722525972510076,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2059,0.719720392709452,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2060,0.71698322174268,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2061,0.716847853860802,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2062,0.716707460792392,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2063,0.716562515560254,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2064,0.716413454780286,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2065,0.716260681644643,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2066,0.710451430980948,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2067,0.704793129002224,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2068,0.699279778948575,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2069,0.693905705117051,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2070,0.688665531296291,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2071,0.689946724662934,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2072,0.691188682971391,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2073,0.692393154136571,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2074,0.69356178465309,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2075,0.694696126809683,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2076,0.688502038638337,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2077,0.682494304073718,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2078,0.676664614263002,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2079,0.671005147802803,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2080,0.665508535481666,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2081,0.659676757232113,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2082,0.654023176692723,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2083,0.648539741387499,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2084,0.643218877027837,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2085,0.638053452528617,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2086,0.63401239537929,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2087,0.63009657204982,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2088,0.626300231675427,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2089,0.622617970647912,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2090,0.619044706780899,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2091,0.610566551796333,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2092,0.602337638022985,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2093,0.59434661653952,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2094,0.586582829047057,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2095,0.5790362557976,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2096,0.5708128123062,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2097,0.562837606786179,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2098,0.555098987018804,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2099,0.555098987018804,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2100,0.555098987018804,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2200,0.555098987018804,"forestryLoss_growthFactor_SSP5"
+"Tennessee","TN",2300,0.555098987018804,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2013,0.992198107190551,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2014,0.996224444588262,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2015,1,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2016,0.997777471615142,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2017,0.995477423084324,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2018,0.993108011472486,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2019,0.99067670793747,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2020,0.988190359061011,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2021,0.984934734888894,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2022,0.981622917447971,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2023,0.978263152751813,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2024,0.974862915990937,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2025,0.97142898543411,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2026,0.964318511532712,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2027,0.957291174780615,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2028,0.950348024927834,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2029,0.943489818512336,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2030,0.936717054305233,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2031,0.93501447117499,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2032,0.9332775342479,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2033,0.931510913500444,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2034,0.929718847961136,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2035,0.927905186968053,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2036,0.929168677598189,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2037,0.930278360745134,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2038,0.931245113570808,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2039,0.932078985489174,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2040,0.932789269500919,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2041,0.927071016560969,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2042,0.921418026397637,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2043,0.915830738256456,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2044,0.91030942634247,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2045,0.904854218992925,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2046,0.899358474487547,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2047,0.893907273676561,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2048,0.8885021341375,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2049,0.883144354049951,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2050,0.877835033829605,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2051,0.876467186459271,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2052,0.875033061423185,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2053,0.873538487037091,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2054,0.871988855573532,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2055,0.870389158102192,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2056,0.86502020442667,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2057,0.859681684030683,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2058,0.854375911561829,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2059,0.849104935793539,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2060,0.843870564189206,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2061,0.838280597418983,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2062,0.832740410240341,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2063,0.827251112058635,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2064,0.821813626365809,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2065,0.81642870944568,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2066,0.803589553237145,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2067,0.790969030348801,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2068,0.778561992510219,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2069,0.766363428024091,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2070,0.754368459197966,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2071,0.753489604480133,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2072,0.752624608336019,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2073,0.751773179749083,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2074,0.750935033627807,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2075,0.750109890844596,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2076,0.745931563234315,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2077,0.741870373667769,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2078,0.737921303460334,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2079,0.73407962194345,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2080,0.730340865881705,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2081,0.726342219343789,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2082,0.722463870051998,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2083,0.718700421961975,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2084,0.715046798345664,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2085,0.711498218469362,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2086,0.708423798017574,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2087,0.705441456430249,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2088,0.70254702631562,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2089,0.699736590388292,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2090,0.697006462910077,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2091,0.679814410661949,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2092,0.663078473552411,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2093,0.646778752566345,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2094,0.630896540215718,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2095,0.615414231229352,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2096,0.599290734384342,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2097,0.583619872231762,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2098,0.56838090210477,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2099,0.56838090210477,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2100,0.56838090210477,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2200,0.56838090210477,"forestryLoss_growthFactor_SSP5"
+"Texas","TX",2300,0.56838090210477,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2013,0.998031656003113,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2014,0.999101014326467,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2015,1,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2016,0.994994292878432,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2017,0.990015715567675,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2018,0.985067001524861,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2019,0.980150554347353,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2020,0.975268480906495,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2021,0.969539943960338,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2022,0.963849638774411,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2023,0.958200788961807,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2024,0.952596186526909,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2025,0.947038238137208,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2026,0.941882253564684,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2027,0.936757316692737,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2028,0.931666595565635,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2029,0.92661284827333,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2030,0.921598466550649,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2031,0.918495055682907,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2032,0.915412578264093,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2033,0.912352691871968,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2034,0.909316831013055,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2035,0.906306231087293,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2036,0.901360205119564,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2037,0.896469053414185,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2038,0.891633437828366,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2039,0.886853843407805,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2040,0.882130598935778,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2041,0.880002189060631,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2042,0.87783264486112,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2043,0.875627133429582,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2044,0.873390378011183,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2045,0.871126697571187,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2046,0.865508707794765,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2047,0.85994152516506,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2048,0.854426319992577,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2049,0.848964065703856,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2050,0.843555558780035,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2051,0.844803107662002,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2052,0.845917452104485,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2053,0.846906985350337,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2054,0.847779533984164,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2055,0.848542401044564,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2056,0.840297573638291,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2057,0.832172055802636,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2058,0.82416425329569,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2059,0.816272526699461,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2060,0.808495200860613,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2061,0.801447636544299,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2062,0.794510265111639,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2063,0.787681088716058,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2064,0.780958118006845,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2065,0.774339376449886,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2066,0.763757426918048,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2067,0.753344380442757,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2068,0.743096789927723,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2069,0.733011264561055,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2070,0.723084472127476,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2071,0.720727006373755,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2072,0.71842641554425,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2073,0.71618054886098,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2074,0.713987367479913,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2075,0.711844937068894,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2076,0.696212938065882,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2077,0.681044263854205,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2078,0.666318422518877,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2079,0.652016119110873,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2080,0.6381191692729,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2081,0.631258494067868,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2082,0.624605513425196,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2083,0.618150883134609,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2084,0.611885812726456,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2085,0.605802025000559,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2086,0.600660179633619,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2087,0.59567458427139,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2088,0.590838122794813,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2089,0.586144107293699,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2090,0.581586246255806,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2091,0.566199928225937,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2092,0.551204898119536,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2093,0.536584415904853,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2094,0.522322736221124,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2095,0.508405034036798,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2096,0.494200692555297,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2097,0.480367820209166,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2098,0.466889827725081,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2099,0.466889827725081,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2100,0.466889827725081,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2200,0.466889827725081,"forestryLoss_growthFactor_SSP5"
+"Utah","UT",2300,0.466889827725081,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2013,0.991220270850365,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2014,0.995664123527799,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2015,1,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2016,0.998467366476002,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2017,0.99697298097631,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2018,0.995515359266379,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2019,0.994093096452134,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2020,0.99270486153999,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2021,0.980183661360992,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2022,0.968065739103694,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2023,0.95633182403895,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2024,0.944963858322344,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2025,0.933944902811425,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2026,0.929893255610061,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2027,0.925970178149423,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2028,0.922169584335967,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2029,0.918485769046695,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2030,0.914913378623044,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2031,0.90662221711855,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2032,0.898609612054542,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2033,0.890861727136663,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2034,0.883365628776384,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2035,0.876109213588679,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2036,0.866531809852572,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2037,0.857263355019584,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2038,0.848289113936016,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2039,0.839595274778496,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2040,0.831168877799967,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2041,0.825645044207508,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2042,0.82029268198307,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2043,0.815103923201943,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2044,0.810071374272304,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2045,0.805188080709704,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2046,0.807124069706735,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2047,0.809006703689985,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2048,0.810838169793025,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2049,0.812620536754356,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2050,0.814355762845077,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2051,0.794982495763466,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2052,0.776137464887661,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2053,0.757799371257052,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2054,0.739948045188094,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2055,0.722564372439387,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2056,0.719687714945587,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2057,0.716891171550244,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2058,0.714171455640151,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2059,0.711525457399258,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2060,0.708950232105078,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2061,0.70319764152203,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2062,0.697612431083731,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2063,0.692187425179852,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2064,0.686915851649071,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2065,0.681791313860523,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2066,0.674401784583114,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2067,0.667231038001401,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2068,0.660269558873102,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2069,0.653508373764118,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2070,0.646939013117383,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2071,0.639726007596534,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2072,0.63272579365169,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2073,0.625929093912425,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2074,0.619327162515547,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2075,0.612911747582539,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2076,0.605857873388677,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2077,0.599017768545856,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2078,0.592381864953614,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2079,0.585941156994752,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2080,0.579687160805514,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2081,0.57401716105835,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2082,0.568520875565053,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2083,0.563190444699582,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2084,0.558018475844571,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2085,0.552998009215721,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2086,0.547896507743303,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2087,0.54295431690822,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2088,0.538164097878803,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2089,0.533518955548922,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2090,0.529012405508069,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2091,0.53017581663084,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2092,0.531311676198411,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2093,0.532421121416633,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2094,0.533505222905342,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2095,0.534564989647509,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2096,0.534678879466851,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2097,0.534798986191886,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2098,0.534924875251838,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2099,0.534924875251838,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2100,0.534924875251838,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2200,0.534924875251838,"forestryLoss_growthFactor_SSP5"
+"Virginia","VA",2300,0.534924875251838,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2013,1.00275828326232,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2014,1.00130343275223,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2015,1,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2016,0.993106027938875,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2017,0.986542890231945,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2018,0.980291600714855,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2019,0.974334486490526,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2020,0.968655080808058,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2021,0.950502478783394,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2022,0.933066483729252,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2023,0.916308296188514,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2024,0.900191765044019,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2025,0.884683170361912,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2026,0.871337838638,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2027,0.858547158960435,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2028,0.846280286950052,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2029,0.834508518404002,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2030,0.823205111816013,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2031,0.810829753753297,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2032,0.798942305986817,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2033,0.787516198264479,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2034,0.776526693317702,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2035,0.765950734406391,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2036,0.760514423136468,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2037,0.755335916142547,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2038,0.750400335095885,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2039,0.74569384055832,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2040,0.741203546372652,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2041,0.743013140027592,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2042,0.744845162454945,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2043,0.746696179876331,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2044,0.748563062556215,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2045,0.750442957379377,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2046,0.762609841514467,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2047,0.774506289602017,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2048,0.7861413585048,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2049,0.797523698097806,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2050,0.808661574306693,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2051,0.819571997763654,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2052,0.83024931728398,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2053,0.840700970069034,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2054,0.850934077956949,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2055,0.860955464106602,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2056,0.857914369574095,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2057,0.855023900419572,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2058,0.852275904709576,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2059,0.849662747290397,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2060,0.847177271722977,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2061,0.861816157560788,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2062,0.876096129904255,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2063,0.890030649310239,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2064,0.903632492877076,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2065,0.916913798071569,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2066,0.908784774177512,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2067,0.900979090850468,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2068,0.893480453500357,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2069,0.886273575512787,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2070,0.879344104102807,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2071,0.861407656424763,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2072,0.84400656816971,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2073,0.827117337253112,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2074,0.810717813576048,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2075,0.794787103344329,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2076,0.784532113822202,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2077,0.774592510380316,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2078,0.764954067757009,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2079,0.755603400363919,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2080,0.74652790135231,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2081,0.728765597658375,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2082,0.711548143214786,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2083,0.694850872644221,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2084,0.678650586543347,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2085,0.662925444189583,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2086,0.657661673872925,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2087,0.652564086904958,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2088,0.647624993706832,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2089,0.642837170489325,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2090,0.638193824553789,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2091,0.641668853821314,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2092,0.645082835329161,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2093,0.648437823557191,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2094,0.651735764140565,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2095,0.654978501635633,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2096,0.657104122487857,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2097,0.659200255986925,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2098,0.661267773532737,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2099,0.661267773532737,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2100,0.661267773532737,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2200,0.661267773532737,"forestryLoss_growthFactor_SSP5"
+"Vermont","VT",2300,0.661267773532737,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2013,0.990101595578927,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2014,0.995139413883937,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2015,1,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2016,0.998924139211935,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2017,0.997820536054669,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2018,0.996692380726646,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2019,0.995542590320445,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2020,0.994373833419257,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2021,0.985258119574325,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2022,0.976374635831505,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2023,0.967714403878954,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2024,0.959268914538709,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2025,0.951030096689356,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2026,0.947737004660153,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2027,0.944493041422445,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2028,0.941297818462242,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2029,0.938150883185743,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2030,0.935051728831099,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2031,0.935898294047633,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2032,0.936681452562844,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2033,0.93740548566426,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2034,0.938074347097793,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2035,0.938691691912595,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2036,0.938491415340886,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2037,0.938256635292317,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2038,0.937990280631425,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2039,0.937695043731115,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2040,0.93737340142488,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2041,0.943327356618411,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2042,0.949054649578095,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2043,0.95456696060659,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2044,0.959875214188881,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2045,0.964989637699811,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2046,0.971808908343967,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2047,0.978393825812943,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2048,0.984755448295835,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2049,0.990904175788968,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2050,0.996849797182518,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2051,1.00483005843173,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2052,1.01255263356007,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2053,1.02002913439927,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2054,1.02727050794607,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2055,1.03428708228147,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2056,1.06055737706452,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2057,1.0860598250958,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2058,1.1108270105225,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2059,1.13488972168777,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2060,1.15827707212752,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2061,1.13000249928276,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2062,1.10249535914077,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2063,1.07572433967668,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2064,1.04965982890476,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2065,1.02427380009543,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2066,1.05320585400087,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2067,1.08123290754987,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2068,1.10839562775587,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2069,1.1347323190784,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2070,1.16027909091786,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2071,1.10209145445575,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2072,1.04561463092068,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2073,0.990774181779513,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2074,0.93749992798345,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2075,0.885725649482548,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2076,0.871430920248546,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2077,0.857565113822657,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2078,0.844109133297186,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2079,0.831045001252689,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2080,0.81835577881803,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2081,0.816714426333381,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2082,0.815122378010845,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2083,0.81357742388359,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2084,0.812077484716086,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2085,0.810620602457462,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2086,0.799100544016,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2087,0.787937661842251,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2088,0.777115550883216,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2089,0.766618796757658,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2090,0.756432902050855,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2091,0.762723162530927,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2092,0.76877047030991,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2093,0.774586911723584,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2094,0.780183814775019,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2095,0.785571806933569,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2096,0.789467915941715,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2097,0.793200864245802,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2098,0.796778984042783,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2099,0.796778984042783,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2100,0.796778984042783,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2200,0.796778984042783,"forestryLoss_growthFactor_SSP5"
+"Washington","WA",2300,0.796778984042783,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2013,1.01097913018714,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2014,1.00538975740964,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2015,1,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2016,0.989090801748034,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2017,0.978604368806464,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2018,0.968518467855341,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2019,0.958812336877809,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2020,0.949466568092901,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2021,0.932708924531189,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2022,0.916577340230516,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2023,0.901038917753318,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2024,0.886062965200384,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2025,0.871620817417151,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2026,0.860239213020405,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2027,0.849302480252474,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2028,0.83878663197578,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2029,0.828669316206266,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2030,0.818929681989961,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2031,0.811066754289848,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2032,0.803512843801722,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2033,0.796251149501741,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2034,0.789266028349426,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2035,0.782542899027144,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2036,0.770864997982886,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2037,0.759618357803609,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2038,0.748780700775331,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2039,0.738331215679075,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2040,0.728250441022077,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2041,0.719410647247665,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2042,0.710899226323227,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2043,0.70269945994798,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2044,0.694795704335789,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2045,0.687173307092849,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2046,0.688987087165992,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2047,0.690801092053173,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2048,0.692613742305984,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2049,0.694423608431863,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2050,0.69622939759232,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2051,0.691635243382238,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2052,0.687211148618238,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2053,0.682948891451857,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2054,0.678840740895535,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2055,0.674879421990959,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2056,0.670377942120493,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2057,0.666047516656282,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2058,0.661879761223364,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2059,0.657866796702409,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2060,0.654001213111167,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2061,0.651664542332393,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2062,0.649440455329451,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2063,0.647322844115402,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2064,0.645305992935091,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2065,0.643384548815373,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2066,0.639604373266911,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2067,0.635996517871622,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2068,0.632551857304012,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2069,0.629261844403624,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2070,0.626118467083209,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2071,0.621795667139635,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2072,0.61760442076627,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2073,0.613538887953508,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2074,0.609593566855602,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2075,0.60576326976495,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2076,0.60844324700525,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2077,0.611045592734862,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2078,0.613573696885315,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2079,0.616030752756033,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2080,0.618419771149609,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2081,0.598200999036762,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2082,0.578601960177336,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2083,0.559594609048011,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2084,0.541152566720655,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2085,0.523250998895422,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2086,0.514473919518143,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2087,0.505971761062838,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2088,0.497731843300511,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2089,0.489742253076332,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2090,0.481991787198108,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2091,0.475800280774802,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2092,0.469837588453709,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2093,0.464092465893208,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2094,0.458554371424771,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2095,0.45321341257106,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2096,0.447382799493593,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2097,0.441765517322421,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2098,0.436351000509684,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2099,0.436351000509684,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2100,0.436351000509684,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2200,0.436351000509684,"forestryLoss_growthFactor_SSP5"
+"Wisconsin","WI",2300,0.436351000509684,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2000,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2001,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2002,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2003,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2004,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2005,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2006,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2007,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2008,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2009,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2010,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2011,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2012,NA,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2013,0.998503571765133,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2014,0.999196634540176,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2015,1,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2016,0.995161002637073,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2017,0.990591467392011,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2018,0.986275180295614,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2019,0.982197073500971,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2020,0.978343130707647,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2021,0.960521519252985,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2022,0.943404291547731,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2023,0.926953286185776,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2024,0.911132947498838,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2025,0.89591011184425,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2026,0.883820273383961,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2027,0.87223506486562,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2028,0.861126366010642,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2029,0.850468009940848,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2030,0.840235621074519,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2031,0.828928814184949,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2032,0.818065177320561,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2033,0.80762064869888,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2034,0.797572823671305,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2035,0.787900817033391,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2036,0.784706597432512,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2037,0.781683827973278,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2038,0.778822188398631,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2039,0.776112093587424,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2040,0.773544632311093,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2041,0.778633926259891,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2042,0.783626715520497,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2043,0.788525547435766,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2044,0.793332891668427,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2045,0.798051142181743,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2046,0.814766021650886,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2047,0.831065295969119,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2048,0.846964592859571,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2049,0.862478751906895,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2050,0.877621874405045,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2051,0.892415374756723,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2052,0.906856143088075,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2053,0.920956859117318,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2054,0.934729592375054,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2055,0.948185839005119,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2056,0.946423114427646,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2057,0.944764369561739,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2058,0.943203696488313,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2059,0.941735570246822,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2060,0.94035482027461,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2061,0.959003957224916,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2062,0.977168429144691,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2063,0.994867348141225,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2064,1.01211881518023,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2065,1.02893998705758,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2066,1.02124964560384,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2067,1.01385335915313,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2068,1.00673654683193,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2069,0.999885522360836,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2070,0.993287428551636,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2071,0.97316949487103,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2072,0.953650106080096,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2073,0.934703035692329,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2074,0.916303564247182,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2075,0.898428372728232,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2076,0.887169680635038,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2077,0.876255940265258,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2078,0.865671623167246,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2079,0.855402116543528,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2080,0.845433656839772,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2081,0.825391936394971,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2082,0.8059646096144,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2083,0.787123870768614,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2084,0.768843566525358,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2085,0.751099075019919,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2086,0.745690547672861,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2087,0.740452133626842,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2088,0.735375973435165,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2089,0.730454683431109,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2090,0.725681320293953,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2091,0.730739914086154,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2092,0.735675576663626,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2093,0.740493450739028,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2094,0.745198376217888,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2095,0.749794912753236,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2096,0.753052628695677,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2097,0.756235065105772,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2098,0.759345414632827,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2099,0.759345414632827,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2100,0.759345414632827,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2200,0.759345414632827,"forestryLoss_growthFactor_SSP5"
+"West Virginia","WV",2300,0.759345414632827,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2000,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2001,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2002,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2003,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2004,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2005,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2006,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2007,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2008,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2009,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2010,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2011,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2012,NA,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2013,1.00363377245124,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2014,1.00180171409451,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2015,1,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2016,0.99249804012462,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2017,0.98522905132009,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2018,0.978182221538837,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2019,0.971347402664272,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2020,0.964715060067812,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2021,0.953091136254673,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2022,0.941833346885945,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2023,0.930924480808255,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2024,0.92034839723354,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2025,0.910089943342184,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2026,0.902674973230098,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2027,0.895486465384679,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2028,0.888514008865214,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2029,0.881747830318505,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2030,0.875178745387438,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2031,0.871323773357791,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2032,0.867586891005674,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2033,0.863962602468777,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2034,0.860445754688139,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2035,0.857031510704576,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2036,0.851073704535733,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2037,0.845291432791836,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2038,0.839676845127613,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2039,0.834222561582629,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2040,0.828921637379834,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2041,0.835888275537212,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2042,0.842615572145805,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2043,0.849115215488707,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2044,0.855398160704237,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2045,0.861474685653964,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2046,0.853265631714455,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2047,0.845255510119746,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2048,0.837437020123099,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2049,0.829803221133773,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2050,0.822347510374421,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2051,0.844221488248852,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2052,0.865463330347306,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2053,0.886099613195085,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2054,0.906155460421565,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2055,0.925654639937116,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2056,0.919417194382769,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2057,0.913304660434622,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2058,0.907313373762897,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2059,0.901439809227895,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2060,0.895680574519445,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2061,0.901161868569696,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2062,0.906441977042242,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2063,0.911530723084028,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2064,0.916437331894544,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2065,0.92117047426124,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2066,0.931505794888399,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2067,0.941481282073438,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2068,0.951114039147107,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2069,0.960420143364454,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2070,0.969414720069885,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2071,0.965413871544469,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2072,0.961525620119536,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2073,0.957745197717948,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2074,0.95406810459146,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2075,0.950490090583435,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2076,0.895378067927077,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2077,0.841929798269427,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2078,0.79007096572503,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2079,0.739731618485045,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2080,0.690845852995993,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2081,0.671187056828166,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2082,0.652128848859473,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2083,0.633644091830103,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2084,0.615707259929643,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2085,0.598294320906702,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2086,0.589114394437393,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2087,0.580218289944837,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2088,0.571592986752137,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2089,0.563226250094545,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2090,0.555106572660143,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2091,0.550326622909778,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2092,0.545644154936483,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2093,0.541055489292323,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2094,0.536557153500458,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2095,0.532145866911388,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2096,0.527087191178347,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2097,0.522140951258387,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2098,0.517302464833519,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2099,0.517302464833519,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2100,0.517302464833519,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2200,0.517302464833519,"forestryLoss_growthFactor_SSP5"
+"Wyoming","WY",2300,0.517302464833519,"forestryLoss_growthFactor_SSP5"

--- a/inst/extdata/fredi/scalars/Scalar_physAdj_rec_adultPop.csv
+++ b/inst/extdata/fredi/scalars/Scalar_physAdj_rec_adultPop.csv
@@ -1,442 +1,540 @@
-year,value,state,postal,scalarName
-2010,0.806481583,Alabama,AL,rec_adultPop
-2020,0.807188773,Alabama,AL,rec_adultPop
-2030,0.810505667,Alabama,AL,rec_adultPop
-2040,0.809635353,Alabama,AL,rec_adultPop
-2050,0.807541015,Alabama,AL,rec_adultPop
-2060,0.806504238,Alabama,AL,rec_adultPop
-2070,0.806157809,Alabama,AL,rec_adultPop
-2080,0.806448952,Alabama,AL,rec_adultPop
-2090,0.808037176,Alabama,AL,rec_adultPop
-2010,0.785037393,Arizona,AZ,rec_adultPop
-2020,0.793827499,Arizona,AZ,rec_adultPop
-2030,0.7987186,Arizona,AZ,rec_adultPop
-2040,0.800719904,Arizona,AZ,rec_adultPop
-2050,0.802876294,Arizona,AZ,rec_adultPop
-2060,0.804467694,Arizona,AZ,rec_adultPop
-2070,0.805692853,Arizona,AZ,rec_adultPop
-2080,0.807853067,Arizona,AZ,rec_adultPop
-2090,0.81141852,Arizona,AZ,rec_adultPop
-2010,0.80311044,Arkansas,AR,rec_adultPop
-2020,0.807404898,Arkansas,AR,rec_adultPop
-2030,0.80963849,Arkansas,AR,rec_adultPop
-2040,0.809873974,Arkansas,AR,rec_adultPop
-2050,0.809394909,Arkansas,AR,rec_adultPop
-2060,0.808792797,Arkansas,AR,rec_adultPop
-2070,0.808624533,Arkansas,AR,rec_adultPop
-2080,0.80914229,Arkansas,AR,rec_adultPop
-2090,0.810966324,Arkansas,AR,rec_adultPop
-2010,0.784847109,California,CA,rec_adultPop
-2020,0.784882239,California,CA,rec_adultPop
-2030,0.797441041,California,CA,rec_adultPop
-2040,0.798705303,California,CA,rec_adultPop
-2050,0.797704883,California,CA,rec_adultPop
-2060,0.800235924,California,CA,rec_adultPop
-2070,0.80089544,California,CA,rec_adultPop
-2080,0.802672499,California,CA,rec_adultPop
-2090,0.806802287,California,CA,rec_adultPop
-2010,0.801609529,Colorado,CO,rec_adultPop
-2020,0.810939061,Colorado,CO,rec_adultPop
-2030,0.818813431,Colorado,CO,rec_adultPop
-2040,0.817075562,Colorado,CO,rec_adultPop
-2050,0.815948525,Colorado,CO,rec_adultPop
-2060,0.815568291,Colorado,CO,rec_adultPop
-2070,0.814295846,Colorado,CO,rec_adultPop
-2080,0.815549233,Colorado,CO,rec_adultPop
-2090,0.818421449,Colorado,CO,rec_adultPop
-2010,0.814921816,Connecticut,CT,rec_adultPop
-2020,0.808947286,Connecticut,CT,rec_adultPop
-2030,0.810140375,Connecticut,CT,rec_adultPop
-2040,0.811866068,Connecticut,CT,rec_adultPop
-2050,0.80756029,Connecticut,CT,rec_adultPop
-2060,0.806170363,Connecticut,CT,rec_adultPop
-2070,0.806693863,Connecticut,CT,rec_adultPop
-2080,0.807498368,Connecticut,CT,rec_adultPop
-2090,0.809514158,Connecticut,CT,rec_adultPop
-2010,0.80584663,Delaware,DE,rec_adultPop
-2020,0.807563813,Delaware,DE,rec_adultPop
-2030,0.81345464,Delaware,DE,rec_adultPop
-2040,0.813407146,Delaware,DE,rec_adultPop
-2050,0.812185745,Delaware,DE,rec_adultPop
-2060,0.812805189,Delaware,DE,rec_adultPop
-2070,0.812072069,Delaware,DE,rec_adultPop
-2080,0.812807346,Delaware,DE,rec_adultPop
-2090,0.815390706,Delaware,DE,rec_adultPop
-2010,0.8012203,District of Columbia,DC,rec_adultPop
-2020,0.771706144,District of Columbia,DC,rec_adultPop
-2030,0.833978923,District of Columbia,DC,rec_adultPop
-2040,0.802862365,District of Columbia,DC,rec_adultPop
-2050,0.796167944,District of Columbia,DC,rec_adultPop
-2060,0.812516999,District of Columbia,DC,rec_adultPop
-2070,0.798185556,District of Columbia,DC,rec_adultPop
-2080,0.795426166,District of Columbia,DC,rec_adultPop
-2090,0.806157309,District of Columbia,DC,rec_adultPop
-2010,0.81439659,Florida,FL,rec_adultPop
-2020,0.811780086,Florida,FL,rec_adultPop
-2030,0.815864702,Florida,FL,rec_adultPop
-2040,0.813510717,Florida,FL,rec_adultPop
-2050,0.811711864,Florida,FL,rec_adultPop
-2060,0.81090547,Florida,FL,rec_adultPop
-2070,0.810468423,Florida,FL,rec_adultPop
-2080,0.811702045,Florida,FL,rec_adultPop
-2090,0.813971047,Florida,FL,rec_adultPop
-2010,0.793759574,Georgia,GA,rec_adultPop
-2020,0.808800575,Georgia,GA,rec_adultPop
-2030,0.814194474,Georgia,GA,rec_adultPop
-2040,0.815361507,Georgia,GA,rec_adultPop
-2050,0.816207557,Georgia,GA,rec_adultPop
-2060,0.814782311,Georgia,GA,rec_adultPop
-2070,0.814232117,Georgia,GA,rec_adultPop
-2080,0.815022555,Georgia,GA,rec_adultPop
-2090,0.816806474,Georgia,GA,rec_adultPop
-2010,0.790564559,Idaho,ID,rec_adultPop
-2020,0.800558676,Idaho,ID,rec_adultPop
-2030,0.802250974,Idaho,ID,rec_adultPop
-2040,0.80690052,Idaho,ID,rec_adultPop
-2050,0.807644384,Idaho,ID,rec_adultPop
-2060,0.808737876,Idaho,ID,rec_adultPop
-2070,0.810417877,Idaho,ID,rec_adultPop
-2080,0.811666664,Idaho,ID,rec_adultPop
-2090,0.813798926,Idaho,ID,rec_adultPop
-2010,0.797685634,Illinois,IL,rec_adultPop
-2020,0.798852632,Illinois,IL,rec_adultPop
-2030,0.804886941,Illinois,IL,rec_adultPop
-2040,0.80455168,Illinois,IL,rec_adultPop
-2050,0.80331805,Illinois,IL,rec_adultPop
-2060,0.803946464,Illinois,IL,rec_adultPop
-2070,0.803662531,Illinois,IL,rec_adultPop
-2080,0.804700636,Illinois,IL,rec_adultPop
-2090,0.807633064,Illinois,IL,rec_adultPop
-2010,0.799892301,Indiana,IN,rec_adultPop
-2020,0.802524564,Indiana,IN,rec_adultPop
-2030,0.804078229,Indiana,IN,rec_adultPop
-2040,0.804941054,Indiana,IN,rec_adultPop
-2050,0.803117721,Indiana,IN,rec_adultPop
-2060,0.802607489,Indiana,IN,rec_adultPop
-2070,0.802467195,Indiana,IN,rec_adultPop
-2080,0.802683932,Indiana,IN,rec_adultPop
-2090,0.80436771,Indiana,IN,rec_adultPop
-2010,0.808275363,Iowa,IA,rec_adultPop
-2020,0.800278665,Iowa,IA,rec_adultPop
-2030,0.801911368,Iowa,IA,rec_adultPop
-2040,0.803493712,Iowa,IA,rec_adultPop
-2050,0.799228192,Iowa,IA,rec_adultPop
-2060,0.800556549,Iowa,IA,rec_adultPop
-2070,0.800750665,Iowa,IA,rec_adultPop
-2080,0.800220737,Iowa,IA,rec_adultPop
-2090,0.802246007,Iowa,IA,rec_adultPop
-2010,0.798131032,Kansas,KS,rec_adultPop
-2020,0.800078505,Kansas,KS,rec_adultPop
-2030,0.804515857,Kansas,KS,rec_adultPop
-2040,0.8070819,Kansas,KS,rec_adultPop
-2050,0.806003406,Kansas,KS,rec_adultPop
-2060,0.807406146,Kansas,KS,rec_adultPop
-2070,0.80812227,Kansas,KS,rec_adultPop
-2080,0.808637977,Kansas,KS,rec_adultPop
-2090,0.810832585,Kansas,KS,rec_adultPop
-2010,0.808555249,Kentucky,KY,rec_adultPop
-2020,0.811531135,Kentucky,KY,rec_adultPop
-2030,0.813548519,Kentucky,KY,rec_adultPop
-2040,0.811450913,Kentucky,KY,rec_adultPop
-2050,0.809927081,Kentucky,KY,rec_adultPop
-2060,0.808487372,Kentucky,KY,rec_adultPop
-2070,0.807020501,Kentucky,KY,rec_adultPop
-2080,0.807002215,Kentucky,KY,rec_adultPop
-2090,0.808329753,Kentucky,KY,rec_adultPop
-2010,0.793975531,Louisiana,LA,rec_adultPop
-2020,0.797136847,Louisiana,LA,rec_adultPop
-2030,0.806572541,Louisiana,LA,rec_adultPop
-2040,0.807095625,Louisiana,LA,rec_adultPop
-2050,0.806026495,Louisiana,LA,rec_adultPop
-2060,0.807513532,Louisiana,LA,rec_adultPop
-2070,0.806852911,Louisiana,LA,rec_adultPop
-2080,0.807449141,Louisiana,LA,rec_adultPop
-2090,0.80953924,Louisiana,LA,rec_adultPop
-2010,0.834186891,Maine,ME,rec_adultPop
-2020,0.822219545,Maine,ME,rec_adultPop
-2030,0.823522379,Maine,ME,rec_adultPop
-2040,0.822881808,Maine,ME,rec_adultPop
-2050,0.81494077,Maine,ME,rec_adultPop
-2060,0.813382236,Maine,ME,rec_adultPop
-2070,0.812529949,Maine,ME,rec_adultPop
-2080,0.811549443,Maine,ME,rec_adultPop
-2090,0.812666496,Maine,ME,rec_adultPop
-2010,0.806911362,Maryland,MD,rec_adultPop
-2020,0.80751899,Maryland,MD,rec_adultPop
-2030,0.814599445,Maryland,MD,rec_adultPop
-2040,0.813361831,Maryland,MD,rec_adultPop
-2050,0.810294739,Maryland,MD,rec_adultPop
-2060,0.810063249,Maryland,MD,rec_adultPop
-2070,0.809077998,Maryland,MD,rec_adultPop
-2080,0.809220393,Maryland,MD,rec_adultPop
-2090,0.811589408,Maryland,MD,rec_adultPop
-2010,0.812652697,Massachusetts,MA,rec_adultPop
-2020,0.805056867,Massachusetts,MA,rec_adultPop
-2030,0.814583964,Massachusetts,MA,rec_adultPop
-2040,0.810702518,Massachusetts,MA,rec_adultPop
-2050,0.806756033,Massachusetts,MA,rec_adultPop
-2060,0.807966493,Massachusetts,MA,rec_adultPop
-2070,0.805794841,Massachusetts,MA,rec_adultPop
-2080,0.80604134,Massachusetts,MA,rec_adultPop
-2090,0.809107232,Massachusetts,MA,rec_adultPop
-2010,0.808151781,Michigan,MI,rec_adultPop
-2020,0.804633646,Michigan,MI,rec_adultPop
-2030,0.8059481,Michigan,MI,rec_adultPop
-2040,0.807618443,Michigan,MI,rec_adultPop
-2050,0.80398239,Michigan,MI,rec_adultPop
-2060,0.803290451,Michigan,MI,rec_adultPop
-2070,0.803642876,Michigan,MI,rec_adultPop
-2080,0.803701391,Michigan,MI,rec_adultPop
-2090,0.805161177,Michigan,MI,rec_adultPop
-2010,0.806228459,Minnesota,MN,rec_adultPop
-2020,0.804551531,Minnesota,MN,rec_adultPop
-2030,0.807264939,Minnesota,MN,rec_adultPop
-2040,0.808356109,Minnesota,MN,rec_adultPop
-2050,0.804823682,Minnesota,MN,rec_adultPop
-2060,0.804696615,Minnesota,MN,rec_adultPop
-2070,0.804588764,Minnesota,MN,rec_adultPop
-2080,0.804067334,Minnesota,MN,rec_adultPop
-2090,0.805723729,Minnesota,MN,rec_adultPop
-2010,0.793665674,Mississippi,MS,rec_adultPop
-2020,0.799857768,Mississippi,MS,rec_adultPop
-2030,0.806864629,Mississippi,MS,rec_adultPop
-2040,0.808630883,Mississippi,MS,rec_adultPop
-2050,0.808563422,Mississippi,MS,rec_adultPop
-2060,0.808878893,Mississippi,MS,rec_adultPop
-2070,0.808671363,Mississippi,MS,rec_adultPop
-2080,0.80930334,Mississippi,MS,rec_adultPop
-2090,0.810991359,Mississippi,MS,rec_adultPop
-2010,0.80727812,Missouri,MO,rec_adultPop
-2020,0.807330306,Missouri,MO,rec_adultPop
-2030,0.811720789,Missouri,MO,rec_adultPop
-2040,0.811849375,Missouri,MO,rec_adultPop
-2050,0.810104911,Missouri,MO,rec_adultPop
-2060,0.810389185,Missouri,MO,rec_adultPop
-2070,0.809738276,Missouri,MO,rec_adultPop
-2080,0.809850743,Missouri,MO,rec_adultPop
-2090,0.811820079,Missouri,MO,rec_adultPop
-2010,0.819343988,Montana,MT,rec_adultPop
-2020,0.809326232,Montana,MT,rec_adultPop
-2030,0.810164054,Montana,MT,rec_adultPop
-2040,0.810958175,Montana,MT,rec_adultPop
-2050,0.806500349,Montana,MT,rec_adultPop
-2060,0.807044252,Montana,MT,rec_adultPop
-2070,0.807833297,Montana,MT,rec_adultPop
-2080,0.807845485,Montana,MT,rec_adultPop
-2090,0.809726178,Montana,MT,rec_adultPop
-2010,0.797918693,Nebraska,NE,rec_adultPop
-2020,0.799656167,Nebraska,NE,rec_adultPop
-2030,0.801000442,Nebraska,NE,rec_adultPop
-2040,0.804727547,Nebraska,NE,rec_adultPop
-2050,0.803351437,Nebraska,NE,rec_adultPop
-2060,0.803942934,Nebraska,NE,rec_adultPop
-2070,0.805596218,Nebraska,NE,rec_adultPop
-2080,0.806068144,Nebraska,NE,rec_adultPop
-2090,0.807748339,Nebraska,NE,rec_adultPop
-2010,0.796894896,Nevada,NV,rec_adultPop
-2020,0.810145532,Nevada,NV,rec_adultPop
-2030,0.813408105,Nevada,NV,rec_adultPop
-2040,0.813531173,Nevada,NV,rec_adultPop
-2050,0.813610661,Nevada,NV,rec_adultPop
-2060,0.813193802,Nevada,NV,rec_adultPop
-2070,0.813496024,Nevada,NV,rec_adultPop
-2080,0.815295299,Nevada,NV,rec_adultPop
-2090,0.818237664,Nevada,NV,rec_adultPop
-2010,0.822632852,New Hampshire,NH,rec_adultPop
-2020,0.817148568,New Hampshire,NH,rec_adultPop
-2030,0.819154856,New Hampshire,NH,rec_adultPop
-2040,0.82108283,New Hampshire,NH,rec_adultPop
-2050,0.814784718,New Hampshire,NH,rec_adultPop
-2060,0.813147547,New Hampshire,NH,rec_adultPop
-2070,0.812922744,New Hampshire,NH,rec_adultPop
-2080,0.812487904,New Hampshire,NH,rec_adultPop
-2090,0.813854388,New Hampshire,NH,rec_adultPop
-2010,0.805105522,New Jersey,NJ,rec_adultPop
-2020,0.807000413,New Jersey,NJ,rec_adultPop
-2030,0.807187259,New Jersey,NJ,rec_adultPop
-2040,0.805753858,New Jersey,NJ,rec_adultPop
-2050,0.803907779,New Jersey,NJ,rec_adultPop
-2060,0.801015105,New Jersey,NJ,rec_adultPop
-2070,0.800795995,New Jersey,NJ,rec_adultPop
-2080,0.802474365,New Jersey,NJ,rec_adultPop
-2090,0.804331402,New Jersey,NJ,rec_adultPop
-2010,0.784128161,New Mexico,NM,rec_adultPop
-2020,0.788313537,New Mexico,NM,rec_adultPop
-2030,0.80571456,New Mexico,NM,rec_adultPop
-2040,0.807826547,New Mexico,NM,rec_adultPop
-2050,0.808456186,New Mexico,NM,rec_adultPop
-2060,0.811745938,New Mexico,NM,rec_adultPop
-2070,0.812941513,New Mexico,NM,rec_adultPop
-2080,0.815170216,New Mexico,NM,rec_adultPop
-2090,0.818800369,New Mexico,NM,rec_adultPop
-2010,0.810128809,New York,NY,rec_adultPop
-2020,0.803149706,New York,NY,rec_adultPop
-2030,0.810128672,New York,NY,rec_adultPop
-2040,0.806684855,New York,NY,rec_adultPop
-2050,0.803799017,New York,NY,rec_adultPop
-2060,0.804624999,New York,NY,rec_adultPop
-2070,0.804302963,New York,NY,rec_adultPop
-2080,0.805672398,New York,NY,rec_adultPop
-2090,0.808532244,New York,NY,rec_adultPop
-2010,0.80372852,North Carolina,NC,rec_adultPop
-2020,0.813898666,North Carolina,NC,rec_adultPop
-2030,0.816520758,North Carolina,NC,rec_adultPop
-2040,0.81629524,North Carolina,NC,rec_adultPop
-2050,0.816336162,North Carolina,NC,rec_adultPop
-2060,0.814297089,North Carolina,NC,rec_adultPop
-2070,0.813730978,North Carolina,NC,rec_adultPop
-2080,0.814375839,North Carolina,NC,rec_adultPop
-2090,0.816120517,North Carolina,NC,rec_adultPop
-2010,0.811903309,North Dakota,ND,rec_adultPop
-2020,0.79455602,North Dakota,ND,rec_adultPop
-2030,0.802318028,North Dakota,ND,rec_adultPop
-2040,0.801694258,North Dakota,ND,rec_adultPop
-2050,0.79645955,North Dakota,ND,rec_adultPop
-2060,0.798820721,North Dakota,ND,rec_adultPop
-2070,0.797690283,North Dakota,ND,rec_adultPop
-2080,0.796690631,North Dakota,ND,rec_adultPop
-2090,0.798023754,North Dakota,ND,rec_adultPop
-2010,0.809094447,Ohio,OH,rec_adultPop
-2020,0.806721466,Ohio,OH,rec_adultPop
-2030,0.807486614,Ohio,OH,rec_adultPop
-2040,0.807834906,Ohio,OH,rec_adultPop
-2050,0.804170225,Ohio,OH,rec_adultPop
-2060,0.803336347,Ohio,OH,rec_adultPop
-2070,0.803003921,Ohio,OH,rec_adultPop
-2080,0.802784238,Ohio,OH,rec_adultPop
-2090,0.804082461,Ohio,OH,rec_adultPop
-2010,0.79715419,Oklahoma,OK,rec_adultPop
-2020,0.801619375,Oklahoma,OK,rec_adultPop
-2030,0.807524491,Oklahoma,OK,rec_adultPop
-2040,0.808651287,Oklahoma,OK,rec_adultPop
-2050,0.808856238,Oklahoma,OK,rec_adultPop
-2060,0.810151368,Oklahoma,OK,rec_adultPop
-2070,0.810818363,Oklahoma,OK,rec_adultPop
-2080,0.811852511,Oklahoma,OK,rec_adultPop
-2090,0.814317763,Oklahoma,OK,rec_adultPop
-2010,0.810416494,Oregon,OR,rec_adultPop
-2020,0.806058761,Oregon,OR,rec_adultPop
-2030,0.809991244,Oregon,OR,rec_adultPop
-2040,0.808323781,Oregon,OR,rec_adultPop
-2050,0.805159867,Oregon,OR,rec_adultPop
-2060,0.805953818,Oregon,OR,rec_adultPop
-2070,0.805801102,Oregon,OR,rec_adultPop
-2080,0.806229757,Oregon,OR,rec_adultPop
-2090,0.809375027,Oregon,OR,rec_adultPop
-2010,0.821157309,Pennsylvania,PA,rec_adultPop
-2020,0.809719,Pennsylvania,PA,rec_adultPop
-2030,0.812830797,Pennsylvania,PA,rec_adultPop
-2040,0.812690732,Pennsylvania,PA,rec_adultPop
-2050,0.806750842,Pennsylvania,PA,rec_adultPop
-2060,0.806844473,Pennsylvania,PA,rec_adultPop
-2070,0.806519803,Pennsylvania,PA,rec_adultPop
-2080,0.805916778,Pennsylvania,PA,rec_adultPop
-2090,0.807550592,Pennsylvania,PA,rec_adultPop
-2010,0.818346069,Rhode Island,RI,rec_adultPop
-2020,0.803170149,Rhode Island,RI,rec_adultPop
-2030,0.816832845,Rhode Island,RI,rec_adultPop
-2040,0.8165848,Rhode Island,RI,rec_adultPop
-2050,0.810116179,Rhode Island,RI,rec_adultPop
-2060,0.813221059,Rhode Island,RI,rec_adultPop
-2070,0.812713977,Rhode Island,RI,rec_adultPop
-2080,0.812124325,Rhode Island,RI,rec_adultPop
-2090,0.815429445,Rhode Island,RI,rec_adultPop
-2010,0.806280463,South Carolina,SC,rec_adultPop
-2020,0.810655641,South Carolina,SC,rec_adultPop
-2030,0.816478716,South Carolina,SC,rec_adultPop
-2040,0.816246143,South Carolina,SC,rec_adultPop
-2050,0.815574498,South Carolina,SC,rec_adultPop
-2060,0.814752602,South Carolina,SC,rec_adultPop
-2070,0.814298245,South Carolina,SC,rec_adultPop
-2080,0.814975046,South Carolina,SC,rec_adultPop
-2090,0.816691574,South Carolina,SC,rec_adultPop
-2010,0.801901263,South Dakota,SD,rec_adultPop
-2020,0.799878452,South Dakota,SD,rec_adultPop
-2030,0.800742854,South Dakota,SD,rec_adultPop
-2040,0.804548856,South Dakota,SD,rec_adultPop
-2050,0.80349102,South Dakota,SD,rec_adultPop
-2060,0.80428781,South Dakota,SD,rec_adultPop
-2070,0.805447959,South Dakota,SD,rec_adultPop
-2080,0.805596958,South Dakota,SD,rec_adultPop
-2090,0.806964739,South Dakota,SD,rec_adultPop
-2010,0.808818875,Tennessee,TN,rec_adultPop
-2020,0.812617362,Tennessee,TN,rec_adultPop
-2030,0.815062081,Tennessee,TN,rec_adultPop
-2040,0.813274006,Tennessee,TN,rec_adultPop
-2050,0.812022591,Tennessee,TN,rec_adultPop
-2060,0.81028911,Tennessee,TN,rec_adultPop
-2070,0.809219756,Tennessee,TN,rec_adultPop
-2080,0.809575517,Tennessee,TN,rec_adultPop
-2090,0.811193941,Tennessee,TN,rec_adultPop
-2010,0.77517079,Texas,TX,rec_adultPop
-2020,0.788447101,Texas,TX,rec_adultPop
-2030,0.797198325,Texas,TX,rec_adultPop
-2040,0.799662526,Texas,TX,rec_adultPop
-2050,0.80154863,Texas,TX,rec_adultPop
-2060,0.80261993,Texas,TX,rec_adultPop
-2070,0.804058366,Texas,TX,rec_adultPop
-2080,0.806374032,Texas,TX,rec_adultPop
-2090,0.809555615,Texas,TX,rec_adultPop
-2010,0.749450724,Utah,UT,rec_adultPop
-2020,0.782312969,Utah,UT,rec_adultPop
-2030,0.791340813,Utah,UT,rec_adultPop
-2040,0.799368711,Utah,UT,rec_adultPop
-2050,0.807331077,Utah,UT,rec_adultPop
-2060,0.809729924,Utah,UT,rec_adultPop
-2070,0.811641283,Utah,UT,rec_adultPop
-2080,0.81313765,Utah,UT,rec_adultPop
-2090,0.81547707,Utah,UT,rec_adultPop
-2010,0.83205963,Vermont,VT,rec_adultPop
-2020,0.814007321,Vermont,VT,rec_adultPop
-2030,0.819572503,Vermont,VT,rec_adultPop
-2040,0.818379574,Vermont,VT,rec_adultPop
-2050,0.808574976,Vermont,VT,rec_adultPop
-2060,0.809090115,Vermont,VT,rec_adultPop
-2070,0.807359456,Vermont,VT,rec_adultPop
-2080,0.805796307,Vermont,VT,rec_adultPop
-2090,0.807440107,Vermont,VT,rec_adultPop
-2010,0.807344997,Virginia,VA,rec_adultPop
-2020,0.811886168,Virginia,VA,rec_adultPop
-2030,0.820003545,Virginia,VA,rec_adultPop
-2040,0.817684832,Virginia,VA,rec_adultPop
-2050,0.816111111,Virginia,VA,rec_adultPop
-2060,0.815295597,Virginia,VA,rec_adultPop
-2070,0.813245461,Virginia,VA,rec_adultPop
-2080,0.813498257,Virginia,VA,rec_adultPop
-2090,0.81574288,Virginia,VA,rec_adultPop
-2010,0.80647677,Washington,WA,rec_adultPop
-2020,0.805665553,Washington,WA,rec_adultPop
-2030,0.809763062,Washington,WA,rec_adultPop
-2040,0.808983672,Washington,WA,rec_adultPop
-2050,0.805373469,Washington,WA,rec_adultPop
-2060,0.805150771,Washington,WA,rec_adultPop
-2070,0.805100485,Washington,WA,rec_adultPop
-2080,0.805345689,Washington,WA,rec_adultPop
-2090,0.807624931,Washington,WA,rec_adultPop
-2010,0.823424802,West Virginia,WV,rec_adultPop
-2020,0.810078232,West Virginia,WV,rec_adultPop
-2030,0.810000395,West Virginia,WV,rec_adultPop
-2040,0.803022791,West Virginia,WV,rec_adultPop
-2050,0.795723152,West Virginia,WV,rec_adultPop
-2060,0.795075465,West Virginia,WV,rec_adultPop
-2070,0.79212141,West Virginia,WV,rec_adultPop
-2080,0.791194697,West Virginia,WV,rec_adultPop
-2090,0.793992525,West Virginia,WV,rec_adultPop
-2010,0.811477949,Wisconsin,WI,rec_adultPop
-2020,0.805362365,Wisconsin,WI,rec_adultPop
-2030,0.808059901,Wisconsin,WI,rec_adultPop
-2040,0.80904365,Wisconsin,WI,rec_adultPop
-2050,0.804873979,Wisconsin,WI,rec_adultPop
-2060,0.804443777,Wisconsin,WI,rec_adultPop
-2070,0.804556459,Wisconsin,WI,rec_adultPop
-2080,0.804344714,Wisconsin,WI,rec_adultPop
-2090,0.805841208,Wisconsin,WI,rec_adultPop
-2010,0.811079823,Wyoming,WY,rec_adultPop
-2020,0.806204716,Wyoming,WY,rec_adultPop
-2030,0.812272083,Wyoming,WY,rec_adultPop
-2040,0.812931909,Wyoming,WY,rec_adultPop
-2050,0.81121283,Wyoming,WY,rec_adultPop
-2060,0.813457433,Wyoming,WY,rec_adultPop
-2070,0.814406888,Wyoming,WY,rec_adultPop
-2080,0.816190623,Wyoming,WY,rec_adultPop
-2090,0.820398037,Wyoming,WY,rec_adultPop
+"state","postal","scalarName","year","value"
+"Alabama","AL","rec_adultPop",2000,NA
+"Alabama","AL","rec_adultPop",2010,0.806481583414589
+"Alabama","AL","rec_adultPop",2020,0.807188773283238
+"Alabama","AL","rec_adultPop",2030,0.810505666651778
+"Alabama","AL","rec_adultPop",2040,0.809635352638556
+"Alabama","AL","rec_adultPop",2050,0.807541014729904
+"Alabama","AL","rec_adultPop",2060,0.806504238354583
+"Alabama","AL","rec_adultPop",2070,0.806157808593914
+"Alabama","AL","rec_adultPop",2080,0.806448952310975
+"Alabama","AL","rec_adultPop",2090,0.808037176308501
+"Alabama","AL","rec_adultPop",2300,0.81212060765502
+"Arizona","AZ","rec_adultPop",2000,NA
+"Arizona","AZ","rec_adultPop",2010,0.785037392567403
+"Arizona","AZ","rec_adultPop",2020,0.793827499216363
+"Arizona","AZ","rec_adultPop",2030,0.798718600330351
+"Arizona","AZ","rec_adultPop",2040,0.800719903505032
+"Arizona","AZ","rec_adultPop",2050,0.802876294438565
+"Arizona","AZ","rec_adultPop",2060,0.804467693894678
+"Arizona","AZ","rec_adultPop",2070,0.805692852808116
+"Arizona","AZ","rec_adultPop",2080,0.807853066821134
+"Arizona","AZ","rec_adultPop",2090,0.811418519774027
+"Arizona","AZ","rec_adultPop",2300,0.880668978691415
+"Arkansas","AR","rec_adultPop",2000,NA
+"Arkansas","AR","rec_adultPop",2010,0.803110439951773
+"Arkansas","AR","rec_adultPop",2020,0.807404898073426
+"Arkansas","AR","rec_adultPop",2030,0.809638490107746
+"Arkansas","AR","rec_adultPop",2040,0.809873974364911
+"Arkansas","AR","rec_adultPop",2050,0.809394909313754
+"Arkansas","AR","rec_adultPop",2060,0.808792796777433
+"Arkansas","AR","rec_adultPop",2070,0.808624532913418
+"Arkansas","AR","rec_adultPop",2080,0.809142289908665
+"Arkansas","AR","rec_adultPop",2090,0.810966323846263
+"Arkansas","AR","rec_adultPop",2300,0.8315880190693
+"California","CA","rec_adultPop",2000,NA
+"California","CA","rec_adultPop",2010,0.784847108797586
+"California","CA","rec_adultPop",2020,0.784882238656683
+"California","CA","rec_adultPop",2030,0.797441040950621
+"California","CA","rec_adultPop",2040,0.798705302741017
+"California","CA","rec_adultPop",2050,0.797704882804308
+"California","CA","rec_adultPop",2060,0.800235923926127
+"California","CA","rec_adultPop",2070,0.800895440321215
+"California","CA","rec_adultPop",2080,0.802672498513761
+"California","CA","rec_adultPop",2090,0.806802287282682
+"California","CA","rec_adultPop",2300,0.864434630806061
+"Colorado","CO","rec_adultPop",2000,NA
+"Colorado","CO","rec_adultPop",2010,0.80160952874146
+"Colorado","CO","rec_adultPop",2020,0.81093906098833
+"Colorado","CO","rec_adultPop",2030,0.818813430907718
+"Colorado","CO","rec_adultPop",2040,0.817075561829952
+"Colorado","CO","rec_adultPop",2050,0.815948525483313
+"Colorado","CO","rec_adultPop",2060,0.815568290642331
+"Colorado","CO","rec_adultPop",2070,0.814295846049219
+"Colorado","CO","rec_adultPop",2080,0.815549233306964
+"Colorado","CO","rec_adultPop",2090,0.818421448669858
+"Colorado","CO","rec_adultPop",2300,0.862552738481905
+"Connecticut","CT","rec_adultPop",2000,NA
+"Connecticut","CT","rec_adultPop",2010,0.814921816325434
+"Connecticut","CT","rec_adultPop",2020,0.808947286411183
+"Connecticut","CT","rec_adultPop",2030,0.810140375029158
+"Connecticut","CT","rec_adultPop",2040,0.811866067867292
+"Connecticut","CT","rec_adultPop",2050,0.80756028996849
+"Connecticut","CT","rec_adultPop",2060,0.806170362953802
+"Connecticut","CT","rec_adultPop",2070,0.806693862581061
+"Connecticut","CT","rec_adultPop",2080,0.807498367570752
+"Connecticut","CT","rec_adultPop",2090,0.809514158370324
+"Connecticut","CT","rec_adultPop",2300,0.795319056238162
+"Delaware","DE","rec_adultPop",2000,NA
+"Delaware","DE","rec_adultPop",2010,0.805846630321704
+"Delaware","DE","rec_adultPop",2020,0.807563813288668
+"Delaware","DE","rec_adultPop",2030,0.813454639853642
+"Delaware","DE","rec_adultPop",2040,0.813407146304457
+"Delaware","DE","rec_adultPop",2050,0.812185745366555
+"Delaware","DE","rec_adultPop",2060,0.812805188730959
+"Delaware","DE","rec_adultPop",2070,0.812072068761125
+"Delaware","DE","rec_adultPop",2080,0.81280734588562
+"Delaware","DE","rec_adultPop",2090,0.815390705701468
+"Delaware","DE","rec_adultPop",2300,0.840443903573349
+"District of Columbia","DC","rec_adultPop",2000,NA
+"District of Columbia","DC","rec_adultPop",2010,0.801220299809663
+"District of Columbia","DC","rec_adultPop",2020,0.771706144213236
+"District of Columbia","DC","rec_adultPop",2030,0.833978923159203
+"District of Columbia","DC","rec_adultPop",2040,0.802862364819491
+"District of Columbia","DC","rec_adultPop",2050,0.796167944091517
+"District of Columbia","DC","rec_adultPop",2060,0.812516999073724
+"District of Columbia","DC","rec_adultPop",2070,0.798185556378177
+"District of Columbia","DC","rec_adultPop",2080,0.795426165735139
+"District of Columbia","DC","rec_adultPop",2090,0.806157309030618
+"District of Columbia","DC","rec_adultPop",2300,0.819116958235624
+"Florida","FL","rec_adultPop",2000,NA
+"Florida","FL","rec_adultPop",2010,0.814396590280963
+"Florida","FL","rec_adultPop",2020,0.811780086126429
+"Florida","FL","rec_adultPop",2030,0.815864701520965
+"Florida","FL","rec_adultPop",2040,0.813510716906463
+"Florida","FL","rec_adultPop",2050,0.811711864208762
+"Florida","FL","rec_adultPop",2060,0.810905470194995
+"Florida","FL","rec_adultPop",2070,0.81046842347387
+"Florida","FL","rec_adultPop",2080,0.811702045004811
+"Florida","FL","rec_adultPop",2090,0.813971047052744
+"Florida","FL","rec_adultPop",2300,0.812853996078671
+"Georgia","GA","rec_adultPop",2000,NA
+"Georgia","GA","rec_adultPop",2010,0.793759573682787
+"Georgia","GA","rec_adultPop",2020,0.808800574602007
+"Georgia","GA","rec_adultPop",2030,0.814194473807167
+"Georgia","GA","rec_adultPop",2040,0.815361506660925
+"Georgia","GA","rec_adultPop",2050,0.816207557154464
+"Georgia","GA","rec_adultPop",2060,0.814782311053557
+"Georgia","GA","rec_adultPop",2070,0.814232117279151
+"Georgia","GA","rec_adultPop",2080,0.815022555205558
+"Georgia","GA","rec_adultPop",2090,0.816806473953797
+"Georgia","GA","rec_adultPop",2300,0.877304587165198
+"Idaho","ID","rec_adultPop",2000,NA
+"Idaho","ID","rec_adultPop",2010,0.790564559116851
+"Idaho","ID","rec_adultPop",2020,0.800558675941697
+"Idaho","ID","rec_adultPop",2030,0.802250974131308
+"Idaho","ID","rec_adultPop",2040,0.806900520341434
+"Idaho","ID","rec_adultPop",2050,0.807644383906406
+"Idaho","ID","rec_adultPop",2060,0.808737875525062
+"Idaho","ID","rec_adultPop",2070,0.810417876721755
+"Idaho","ID","rec_adultPop",2080,0.811666664345762
+"Idaho","ID","rec_adultPop",2090,0.813798925913609
+"Idaho","ID","rec_adultPop",2300,0.874789138755099
+"Illinois","IL","rec_adultPop",2000,NA
+"Illinois","IL","rec_adultPop",2010,0.79768563410032
+"Illinois","IL","rec_adultPop",2020,0.798852632439452
+"Illinois","IL","rec_adultPop",2030,0.804886940988233
+"Illinois","IL","rec_adultPop",2040,0.804551679915345
+"Illinois","IL","rec_adultPop",2050,0.803318050123377
+"Illinois","IL","rec_adultPop",2060,0.803946463799163
+"Illinois","IL","rec_adultPop",2070,0.803662531366322
+"Illinois","IL","rec_adultPop",2080,0.804700635954308
+"Illinois","IL","rec_adultPop",2090,0.807633063902185
+"Illinois","IL","rec_adultPop",2300,0.83374506713208
+"Indiana","IN","rec_adultPop",2000,NA
+"Indiana","IN","rec_adultPop",2010,0.79989230130766
+"Indiana","IN","rec_adultPop",2020,0.802524564431508
+"Indiana","IN","rec_adultPop",2030,0.804078228638942
+"Indiana","IN","rec_adultPop",2040,0.80494105420827
+"Indiana","IN","rec_adultPop",2050,0.803117721016026
+"Indiana","IN","rec_adultPop",2060,0.802607489268524
+"Indiana","IN","rec_adultPop",2070,0.802467194826302
+"Indiana","IN","rec_adultPop",2080,0.802683931734358
+"Indiana","IN","rec_adultPop",2090,0.804367710396397
+"Indiana","IN","rec_adultPop",2300,0.816115659254333
+"Iowa","IA","rec_adultPop",2000,NA
+"Iowa","IA","rec_adultPop",2010,0.80827536338831
+"Iowa","IA","rec_adultPop",2020,0.800278664776814
+"Iowa","IA","rec_adultPop",2030,0.801911367840408
+"Iowa","IA","rec_adultPop",2040,0.803493711744865
+"Iowa","IA","rec_adultPop",2050,0.799228192103284
+"Iowa","IA","rec_adultPop",2060,0.800556548508387
+"Iowa","IA","rec_adultPop",2070,0.800750664965419
+"Iowa","IA","rec_adultPop",2080,0.800220736511409
+"Iowa","IA","rec_adultPop",2090,0.802246006963903
+"Iowa","IA","rec_adultPop",2300,0.786418946349834
+"Kansas","KS","rec_adultPop",2000,NA
+"Kansas","KS","rec_adultPop",2010,0.798131032262864
+"Kansas","KS","rec_adultPop",2020,0.800078504768034
+"Kansas","KS","rec_adultPop",2030,0.804515856739152
+"Kansas","KS","rec_adultPop",2040,0.807081900443539
+"Kansas","KS","rec_adultPop",2050,0.806003406225015
+"Kansas","KS","rec_adultPop",2060,0.80740614591924
+"Kansas","KS","rec_adultPop",2070,0.808122270038935
+"Kansas","KS","rec_adultPop",2080,0.808637977038313
+"Kansas","KS","rec_adultPop",2090,0.810832584505234
+"Kansas","KS","rec_adultPop",2300,0.844174159141457
+"Kentucky","KY","rec_adultPop",2000,NA
+"Kentucky","KY","rec_adultPop",2010,0.808555249461981
+"Kentucky","KY","rec_adultPop",2020,0.811531134785332
+"Kentucky","KY","rec_adultPop",2030,0.813548519074885
+"Kentucky","KY","rec_adultPop",2040,0.811450913289158
+"Kentucky","KY","rec_adultPop",2050,0.809927081428493
+"Kentucky","KY","rec_adultPop",2060,0.808487371631106
+"Kentucky","KY","rec_adultPop",2070,0.807020501494541
+"Kentucky","KY","rec_adultPop",2080,0.807002215327257
+"Kentucky","KY","rec_adultPop",2090,0.808329752880292
+"Kentucky","KY","rec_adultPop",2300,0.807737824353358
+"Louisiana","LA","rec_adultPop",2000,NA
+"Louisiana","LA","rec_adultPop",2010,0.793975530618735
+"Louisiana","LA","rec_adultPop",2020,0.797136847423669
+"Louisiana","LA","rec_adultPop",2030,0.806572540707499
+"Louisiana","LA","rec_adultPop",2040,0.807095625130983
+"Louisiana","LA","rec_adultPop",2050,0.806026495317611
+"Louisiana","LA","rec_adultPop",2060,0.807513532225332
+"Louisiana","LA","rec_adultPop",2070,0.806852910663276
+"Louisiana","LA","rec_adultPop",2080,0.807449141230223
+"Louisiana","LA","rec_adultPop",2090,0.809539239735374
+"Louisiana","LA","rec_adultPop",2300,0.850393976166551
+"Maine","ME","rec_adultPop",2000,NA
+"Maine","ME","rec_adultPop",2010,0.834186891010839
+"Maine","ME","rec_adultPop",2020,0.82221954494374
+"Maine","ME","rec_adultPop",2030,0.823522378606115
+"Maine","ME","rec_adultPop",2040,0.822881808105092
+"Maine","ME","rec_adultPop",2050,0.814940769761906
+"Maine","ME","rec_adultPop",2060,0.813382236056042
+"Maine","ME","rec_adultPop",2070,0.812529948874629
+"Maine","ME","rec_adultPop",2080,0.811549443062451
+"Maine","ME","rec_adultPop",2090,0.812666496149081
+"Maine","ME","rec_adultPop",2300,0.756175459636967
+"Maryland","MD","rec_adultPop",2000,NA
+"Maryland","MD","rec_adultPop",2010,0.806911362077499
+"Maryland","MD","rec_adultPop",2020,0.807518989645414
+"Maryland","MD","rec_adultPop",2030,0.814599445476553
+"Maryland","MD","rec_adultPop",2040,0.813361830753823
+"Maryland","MD","rec_adultPop",2050,0.810294738806805
+"Maryland","MD","rec_adultPop",2060,0.810063248761238
+"Maryland","MD","rec_adultPop",2070,0.809077998188364
+"Maryland","MD","rec_adultPop",2080,0.8092203925867
+"Maryland","MD","rec_adultPop",2090,0.811589407633757
+"Maryland","MD","rec_adultPop",2300,0.823869277218934
+"Massachusetts","MA","rec_adultPop",2000,NA
+"Massachusetts","MA","rec_adultPop",2010,0.812652696546259
+"Massachusetts","MA","rec_adultPop",2020,0.805056867415407
+"Massachusetts","MA","rec_adultPop",2030,0.814583964449058
+"Massachusetts","MA","rec_adultPop",2040,0.81070251822402
+"Massachusetts","MA","rec_adultPop",2050,0.806756033401413
+"Massachusetts","MA","rec_adultPop",2060,0.807966492785095
+"Massachusetts","MA","rec_adultPop",2070,0.805794841338101
+"Massachusetts","MA","rec_adultPop",2080,0.806041339507302
+"Massachusetts","MA","rec_adultPop",2090,0.809107231718777
+"Massachusetts","MA","rec_adultPop",2300,0.799800386546636
+"Michigan","MI","rec_adultPop",2000,NA
+"Michigan","MI","rec_adultPop",2010,0.808151780722004
+"Michigan","MI","rec_adultPop",2020,0.804633645572172
+"Michigan","MI","rec_adultPop",2030,0.805948099509826
+"Michigan","MI","rec_adultPop",2040,0.807618443048068
+"Michigan","MI","rec_adultPop",2050,0.803982389783134
+"Michigan","MI","rec_adultPop",2060,0.80329045074968
+"Michigan","MI","rec_adultPop",2070,0.803642876399443
+"Michigan","MI","rec_adultPop",2080,0.803701390721149
+"Michigan","MI","rec_adultPop",2090,0.805161177328374
+"Michigan","MI","rec_adultPop",2300,0.797310843420094
+"Minnesota","MN","rec_adultPop",2000,NA
+"Minnesota","MN","rec_adultPop",2010,0.806228458769859
+"Minnesota","MN","rec_adultPop",2020,0.804551531173342
+"Minnesota","MN","rec_adultPop",2030,0.807264939395134
+"Minnesota","MN","rec_adultPop",2040,0.808356109339909
+"Minnesota","MN","rec_adultPop",2050,0.804823682444175
+"Minnesota","MN","rec_adultPop",2060,0.804696614825857
+"Minnesota","MN","rec_adultPop",2070,0.804588764021615
+"Minnesota","MN","rec_adultPop",2080,0.80406733384536
+"Minnesota","MN","rec_adultPop",2090,0.805723728685038
+"Minnesota","MN","rec_adultPop",2300,0.804398812212383
+"Mississippi","MS","rec_adultPop",2000,NA
+"Mississippi","MS","rec_adultPop",2010,0.793665674300282
+"Mississippi","MS","rec_adultPop",2020,0.799857767501293
+"Mississippi","MS","rec_adultPop",2030,0.806864629444886
+"Mississippi","MS","rec_adultPop",2040,0.808630883001806
+"Mississippi","MS","rec_adultPop",2050,0.80856342217428
+"Mississippi","MS","rec_adultPop",2060,0.808878892817411
+"Mississippi","MS","rec_adultPop",2070,0.808671362798646
+"Mississippi","MS","rec_adultPop",2080,0.809303339913333
+"Mississippi","MS","rec_adultPop",2090,0.81099135871402
+"Mississippi","MS","rec_adultPop",2300,0.856471280300082
+"Missouri","MO","rec_adultPop",2000,NA
+"Missouri","MO","rec_adultPop",2010,0.807278119912434
+"Missouri","MO","rec_adultPop",2020,0.807330305680105
+"Missouri","MO","rec_adultPop",2030,0.811720788627019
+"Missouri","MO","rec_adultPop",2040,0.811849374745613
+"Missouri","MO","rec_adultPop",2050,0.810104910762679
+"Missouri","MO","rec_adultPop",2060,0.810389184639285
+"Missouri","MO","rec_adultPop",2070,0.809738276303069
+"Missouri","MO","rec_adultPop",2080,0.809850742534503
+"Missouri","MO","rec_adultPop",2090,0.811820078634781
+"Missouri","MO","rec_adultPop",2300,0.823742720280945
+"Montana","MT","rec_adultPop",2000,NA
+"Montana","MT","rec_adultPop",2010,0.81934398846658
+"Montana","MT","rec_adultPop",2020,0.809326232065414
+"Montana","MT","rec_adultPop",2030,0.810164054316634
+"Montana","MT","rec_adultPop",2040,0.810958175230228
+"Montana","MT","rec_adultPop",2050,0.806500349089766
+"Montana","MT","rec_adultPop",2060,0.807044252493302
+"Montana","MT","rec_adultPop",2070,0.80783329699191
+"Montana","MT","rec_adultPop",2080,0.807845484690707
+"Montana","MT","rec_adultPop",2090,0.809726177511659
+"Montana","MT","rec_adultPop",2300,0.784479423754989
+"Nebraska","NE","rec_adultPop",2000,NA
+"Nebraska","NE","rec_adultPop",2010,0.797918692830493
+"Nebraska","NE","rec_adultPop",2020,0.799656167176733
+"Nebraska","NE","rec_adultPop",2030,0.801000442394543
+"Nebraska","NE","rec_adultPop",2040,0.804727546537347
+"Nebraska","NE","rec_adultPop",2050,0.803351437274121
+"Nebraska","NE","rec_adultPop",2060,0.803942934041008
+"Nebraska","NE","rec_adultPop",2070,0.805596217887562
+"Nebraska","NE","rec_adultPop",2080,0.806068143721093
+"Nebraska","NE","rec_adultPop",2090,0.807748339028855
+"Nebraska","NE","rec_adultPop",2300,0.833551160299558
+"Nevada","NV","rec_adultPop",2000,NA
+"Nevada","NV","rec_adultPop",2010,0.796894895508769
+"Nevada","NV","rec_adultPop",2020,0.810145532009265
+"Nevada","NV","rec_adultPop",2030,0.81340810513371
+"Nevada","NV","rec_adultPop",2040,0.813531172785273
+"Nevada","NV","rec_adultPop",2050,0.813610660794483
+"Nevada","NV","rec_adultPop",2060,0.813193801797562
+"Nevada","NV","rec_adultPop",2070,0.813496024237767
+"Nevada","NV","rec_adultPop",2080,0.815295299403119
+"Nevada","NV","rec_adultPop",2090,0.818237663613492
+"Nevada","NV","rec_adultPop",2300,0.87426242988839
+"New Hampshire","NH","rec_adultPop",2000,NA
+"New Hampshire","NH","rec_adultPop",2010,0.822632851695104
+"New Hampshire","NH","rec_adultPop",2020,0.817148567574463
+"New Hampshire","NH","rec_adultPop",2030,0.819154855548369
+"New Hampshire","NH","rec_adultPop",2040,0.821082829998764
+"New Hampshire","NH","rec_adultPop",2050,0.814784718353322
+"New Hampshire","NH","rec_adultPop",2060,0.813147547391339
+"New Hampshire","NH","rec_adultPop",2070,0.812922744220458
+"New Hampshire","NH","rec_adultPop",2080,0.812487903659665
+"New Hampshire","NH","rec_adultPop",2090,0.813854387765328
+"New Hampshire","NH","rec_adultPop",2300,0.790810919949667
+"New Jersey","NJ","rec_adultPop",2000,NA
+"New Jersey","NJ","rec_adultPop",2010,0.805105521848042
+"New Jersey","NJ","rec_adultPop",2020,0.807000413211194
+"New Jersey","NJ","rec_adultPop",2030,0.807187258639352
+"New Jersey","NJ","rec_adultPop",2040,0.805753857852135
+"New Jersey","NJ","rec_adultPop",2050,0.803907778660894
+"New Jersey","NJ","rec_adultPop",2060,0.801015105268685
+"New Jersey","NJ","rec_adultPop",2070,0.800795994837115
+"New Jersey","NJ","rec_adultPop",2080,0.802474365422556
+"New Jersey","NJ","rec_adultPop",2090,0.804331402232708
+"New Jersey","NJ","rec_adultPop",2300,0.802299338242455
+"New Mexico","NM","rec_adultPop",2000,NA
+"New Mexico","NM","rec_adultPop",2010,0.78412816135947
+"New Mexico","NM","rec_adultPop",2020,0.788313537406214
+"New Mexico","NM","rec_adultPop",2030,0.805714560091564
+"New Mexico","NM","rec_adultPop",2040,0.807826547006246
+"New Mexico","NM","rec_adultPop",2050,0.808456185554004
+"New Mexico","NM","rec_adultPop",2060,0.811745938390786
+"New Mexico","NM","rec_adultPop",2070,0.812941513315725
+"New Mexico","NM","rec_adultPop",2080,0.815170216471999
+"New Mexico","NM","rec_adultPop",2090,0.818800369375814
+"New Mexico","NM","rec_adultPop",2300,0.909814915418716
+"New York","NY","rec_adultPop",2000,NA
+"New York","NY","rec_adultPop",2010,0.810128809358284
+"New York","NY","rec_adultPop",2020,0.803149705958131
+"New York","NY","rec_adultPop",2030,0.810128671596723
+"New York","NY","rec_adultPop",2040,0.806684855331723
+"New York","NY","rec_adultPop",2050,0.803799017145574
+"New York","NY","rec_adultPop",2060,0.804624999182397
+"New York","NY","rec_adultPop",2070,0.804302963427182
+"New York","NY","rec_adultPop",2080,0.805672398050152
+"New York","NY","rec_adultPop",2090,0.808532243621601
+"New York","NY","rec_adultPop",2300,0.804341258562808
+"North Carolina","NC","rec_adultPop",2000,NA
+"North Carolina","NC","rec_adultPop",2010,0.803728520246763
+"North Carolina","NC","rec_adultPop",2020,0.813898665954809
+"North Carolina","NC","rec_adultPop",2030,0.816520758030288
+"North Carolina","NC","rec_adultPop",2040,0.816295239536051
+"North Carolina","NC","rec_adultPop",2050,0.816336161725237
+"North Carolina","NC","rec_adultPop",2060,0.814297089435689
+"North Carolina","NC","rec_adultPop",2070,0.813730978306041
+"North Carolina","NC","rec_adultPop",2080,0.814375839403473
+"North Carolina","NC","rec_adultPop",2090,0.816120517453711
+"North Carolina","NC","rec_adultPop",2300,0.848649510121949
+"North Dakota","ND","rec_adultPop",2000,NA
+"North Dakota","ND","rec_adultPop",2010,0.811903308749754
+"North Dakota","ND","rec_adultPop",2020,0.794556019969612
+"North Dakota","ND","rec_adultPop",2030,0.80231802791539
+"North Dakota","ND","rec_adultPop",2040,0.801694257928919
+"North Dakota","ND","rec_adultPop",2050,0.796459550102717
+"North Dakota","ND","rec_adultPop",2060,0.798820721445905
+"North Dakota","ND","rec_adultPop",2070,0.797690282782656
+"North Dakota","ND","rec_adultPop",2080,0.796690630649437
+"North Dakota","ND","rec_adultPop",2090,0.798023753950353
+"North Dakota","ND","rec_adultPop",2300,0.761589922601925
+"Ohio","OH","rec_adultPop",2000,NA
+"Ohio","OH","rec_adultPop",2010,0.809094446954501
+"Ohio","OH","rec_adultPop",2020,0.8067214663931
+"Ohio","OH","rec_adultPop",2030,0.807486613605447
+"Ohio","OH","rec_adultPop",2040,0.807834906475707
+"Ohio","OH","rec_adultPop",2050,0.804170225466996
+"Ohio","OH","rec_adultPop",2060,0.803336346767947
+"Ohio","OH","rec_adultPop",2070,0.80300392116257
+"Ohio","OH","rec_adultPop",2080,0.80278423795601
+"Ohio","OH","rec_adultPop",2090,0.804082461331578
+"Ohio","OH","rec_adultPop",2300,0.790925999071406
+"Oklahoma","OK","rec_adultPop",2000,NA
+"Oklahoma","OK","rec_adultPop",2010,0.797154190026906
+"Oklahoma","OK","rec_adultPop",2020,0.801619375434194
+"Oklahoma","OK","rec_adultPop",2030,0.807524490760675
+"Oklahoma","OK","rec_adultPop",2040,0.808651286562109
+"Oklahoma","OK","rec_adultPop",2050,0.808856237519302
+"Oklahoma","OK","rec_adultPop",2060,0.810151367689208
+"Oklahoma","OK","rec_adultPop",2070,0.81081836269232
+"Oklahoma","OK","rec_adultPop",2080,0.81185251128478
+"Oklahoma","OK","rec_adultPop",2090,0.814317763394384
+"Oklahoma","OK","rec_adultPop",2300,0.859372143484015
+"Oregon","OR","rec_adultPop",2000,NA
+"Oregon","OR","rec_adultPop",2010,0.810416493558256
+"Oregon","OR","rec_adultPop",2020,0.80605876070352
+"Oregon","OR","rec_adultPop",2030,0.809991244075778
+"Oregon","OR","rec_adultPop",2040,0.808323781067931
+"Oregon","OR","rec_adultPop",2050,0.805159867221376
+"Oregon","OR","rec_adultPop",2060,0.805953818345914
+"Oregon","OR","rec_adultPop",2070,0.805801101761227
+"Oregon","OR","rec_adultPop",2080,0.806229756962684
+"Oregon","OR","rec_adultPop",2090,0.809375026622319
+"Oregon","OR","rec_adultPop",2300,0.806641175915485
+"Pennsylvania","PA","rec_adultPop",2000,NA
+"Pennsylvania","PA","rec_adultPop",2010,0.821157308616293
+"Pennsylvania","PA","rec_adultPop",2020,0.809718999852655
+"Pennsylvania","PA","rec_adultPop",2030,0.812830797458715
+"Pennsylvania","PA","rec_adultPop",2040,0.812690731530065
+"Pennsylvania","PA","rec_adultPop",2050,0.806750842324049
+"Pennsylvania","PA","rec_adultPop",2060,0.806844472606271
+"Pennsylvania","PA","rec_adultPop",2070,0.806519803351356
+"Pennsylvania","PA","rec_adultPop",2080,0.805916778497829
+"Pennsylvania","PA","rec_adultPop",2090,0.807550591720106
+"Pennsylvania","PA","rec_adultPop",2300,0.771832959867613
+"Rhode Island","RI","rec_adultPop",2000,NA
+"Rhode Island","RI","rec_adultPop",2010,0.818346068746292
+"Rhode Island","RI","rec_adultPop",2020,0.803170148852502
+"Rhode Island","RI","rec_adultPop",2030,0.816832845297315
+"Rhode Island","RI","rec_adultPop",2040,0.816584800312364
+"Rhode Island","RI","rec_adultPop",2050,0.810116178515488
+"Rhode Island","RI","rec_adultPop",2060,0.813221059322901
+"Rhode Island","RI","rec_adultPop",2070,0.81271397742422
+"Rhode Island","RI","rec_adultPop",2080,0.812124324697468
+"Rhode Island","RI","rec_adultPop",2090,0.815429445296945
+"Rhode Island","RI","rec_adultPop",2300,0.80777330874241
+"South Carolina","SC","rec_adultPop",2000,NA
+"South Carolina","SC","rec_adultPop",2010,0.806280463497533
+"South Carolina","SC","rec_adultPop",2020,0.810655641215118
+"South Carolina","SC","rec_adultPop",2030,0.816478716291741
+"South Carolina","SC","rec_adultPop",2040,0.816246142631468
+"South Carolina","SC","rec_adultPop",2050,0.815574497804494
+"South Carolina","SC","rec_adultPop",2060,0.814752601883004
+"South Carolina","SC","rec_adultPop",2070,0.814298244962394
+"South Carolina","SC","rec_adultPop",2080,0.814975046296224
+"South Carolina","SC","rec_adultPop",2090,0.816691574166725
+"South Carolina","SC","rec_adultPop",2300,0.844020739673352
+"South Dakota","SD","rec_adultPop",2000,NA
+"South Dakota","SD","rec_adultPop",2010,0.801901263279691
+"South Dakota","SD","rec_adultPop",2020,0.799878452023234
+"South Dakota","SD","rec_adultPop",2030,0.800742854353216
+"South Dakota","SD","rec_adultPop",2040,0.804548856061094
+"South Dakota","SD","rec_adultPop",2050,0.803491020290403
+"South Dakota","SD","rec_adultPop",2060,0.804287809914735
+"South Dakota","SD","rec_adultPop",2070,0.80544795898108
+"South Dakota","SD","rec_adultPop",2080,0.805596957999915
+"South Dakota","SD","rec_adultPop",2090,0.806964738774053
+"South Dakota","SD","rec_adultPop",2300,0.820256361946754
+"Tennessee","TN","rec_adultPop",2000,NA
+"Tennessee","TN","rec_adultPop",2010,0.808818875054081
+"Tennessee","TN","rec_adultPop",2020,0.812617361940811
+"Tennessee","TN","rec_adultPop",2030,0.815062080777431
+"Tennessee","TN","rec_adultPop",2040,0.813274006487968
+"Tennessee","TN","rec_adultPop",2050,0.812022590852508
+"Tennessee","TN","rec_adultPop",2060,0.810289109843042
+"Tennessee","TN","rec_adultPop",2070,0.809219755716404
+"Tennessee","TN","rec_adultPop",2080,0.809575516686558
+"Tennessee","TN","rec_adultPop",2090,0.811193940895077
+"Tennessee","TN","rec_adultPop",2300,0.817428488727691
+"Texas","TX","rec_adultPop",2000,NA
+"Texas","TX","rec_adultPop",2010,0.775170789855441
+"Texas","TX","rec_adultPop",2020,0.788447101073741
+"Texas","TX","rec_adultPop",2030,0.79719832494788
+"Texas","TX","rec_adultPop",2040,0.799662526361786
+"Texas","TX","rec_adultPop",2050,0.801548630159994
+"Texas","TX","rec_adultPop",2060,0.802619930234657
+"Texas","TX","rec_adultPop",2070,0.804058365857984
+"Texas","TX","rec_adultPop",2080,0.806374032392554
+"Texas","TX","rec_adultPop",2090,0.809555614769559
+"Texas","TX","rec_adultPop",2300,0.899815780169121
+"Utah","UT","rec_adultPop",2000,NA
+"Utah","UT","rec_adultPop",2010,0.749450723663684
+"Utah","UT","rec_adultPop",2020,0.782312969398569
+"Utah","UT","rec_adultPop",2030,0.791340813319961
+"Utah","UT","rec_adultPop",2040,0.799368710820906
+"Utah","UT","rec_adultPop",2050,0.807331076812129
+"Utah","UT","rec_adultPop",2060,0.809729924312441
+"Utah","UT","rec_adultPop",2070,0.811641282745407
+"Utah","UT","rec_adultPop",2080,0.813137650093515
+"Utah","UT","rec_adultPop",2090,0.8154770702423
+"Utah","UT","rec_adultPop",2300,0.988796230011168
+"Vermont","VT","rec_adultPop",2000,NA
+"Vermont","VT","rec_adultPop",2010,0.832059630085958
+"Vermont","VT","rec_adultPop",2020,0.814007321013848
+"Vermont","VT","rec_adultPop",2030,0.819572503035236
+"Vermont","VT","rec_adultPop",2040,0.818379574216842
+"Vermont","VT","rec_adultPop",2050,0.808574975913292
+"Vermont","VT","rec_adultPop",2060,0.809090115437935
+"Vermont","VT","rec_adultPop",2070,0.807359456495161
+"Vermont","VT","rec_adultPop",2080,0.805796306559211
+"Vermont","VT","rec_adultPop",2090,0.807440106778262
+"Vermont","VT","rec_adultPop",2300,0.742813858095558
+"Virginia","VA","rec_adultPop",2000,NA
+"Virginia","VA","rec_adultPop",2010,0.80734499715343
+"Virginia","VA","rec_adultPop",2020,0.81188616763567
+"Virginia","VA","rec_adultPop",2030,0.820003544537114
+"Virginia","VA","rec_adultPop",2040,0.81768483208761
+"Virginia","VA","rec_adultPop",2050,0.816111110559827
+"Virginia","VA","rec_adultPop",2060,0.815295596525567
+"Virginia","VA","rec_adultPop",2070,0.813245460950422
+"Virginia","VA","rec_adultPop",2080,0.813498257190946
+"Virginia","VA","rec_adultPop",2090,0.815742879615395
+"Virginia","VA","rec_adultPop",2300,0.837787321078051
+"Washington","WA","rec_adultPop",2000,NA
+"Washington","WA","rec_adultPop",2010,0.806476769529963
+"Washington","WA","rec_adultPop",2020,0.805665553411589
+"Washington","WA","rec_adultPop",2030,0.809763062252856
+"Washington","WA","rec_adultPop",2040,0.808983671792312
+"Washington","WA","rec_adultPop",2050,0.805373469451299
+"Washington","WA","rec_adultPop",2060,0.805150771417715
+"Washington","WA","rec_adultPop",2070,0.805100484700926
+"Washington","WA","rec_adultPop",2080,0.805345689181261
+"Washington","WA","rec_adultPop",2090,0.807624931075632
+"Washington","WA","rec_adultPop",2300,0.810638855133016
+"West Virginia","WV","rec_adultPop",2000,NA
+"West Virginia","WV","rec_adultPop",2010,0.8234248018081
+"West Virginia","WV","rec_adultPop",2020,0.810078232279545
+"West Virginia","WV","rec_adultPop",2030,0.810000394513834
+"West Virginia","WV","rec_adultPop",2040,0.80302279108311
+"West Virginia","WV","rec_adultPop",2050,0.795723152339027
+"West Virginia","WV","rec_adultPop",2060,0.795075464925377
+"West Virginia","WV","rec_adultPop",2070,0.792121409777705
+"West Virginia","WV","rec_adultPop",2080,0.79119469684901
+"West Virginia","WV","rec_adultPop",2090,0.793992525438675
+"West Virginia","WV","rec_adultPop",2300,0.716732799968934
+"Wisconsin","WI","rec_adultPop",2000,NA
+"Wisconsin","WI","rec_adultPop",2010,0.811477948709792
+"Wisconsin","WI","rec_adultPop",2020,0.805362365208876
+"Wisconsin","WI","rec_adultPop",2030,0.808059901199696
+"Wisconsin","WI","rec_adultPop",2040,0.809043650041863
+"Wisconsin","WI","rec_adultPop",2050,0.804873979331755
+"Wisconsin","WI","rec_adultPop",2060,0.80444377721875
+"Wisconsin","WI","rec_adultPop",2070,0.804556459296534
+"Wisconsin","WI","rec_adultPop",2080,0.804344714385462
+"Wisconsin","WI","rec_adultPop",2090,0.805841207638798
+"Wisconsin","WI","rec_adultPop",2300,0.791044762327439
+"Wyoming","WY","rec_adultPop",2000,NA
+"Wyoming","WY","rec_adultPop",2010,0.811079822615916
+"Wyoming","WY","rec_adultPop",2020,0.806204715885732
+"Wyoming","WY","rec_adultPop",2030,0.812272083390889
+"Wyoming","WY","rec_adultPop",2040,0.812931909195418
+"Wyoming","WY","rec_adultPop",2050,0.811212829654755
+"Wyoming","WY","rec_adultPop",2060,0.813457433310058
+"Wyoming","WY","rec_adultPop",2070,0.814406887890875
+"Wyoming","WY","rec_adultPop",2080,0.816190622667852
+"Wyoming","WY","rec_adultPop",2090,0.820398037255218
+"Wyoming","WY","rec_adultPop",2300,0.844858350683384


### PR DESCRIPTION
Scalars extended to 2300 for the Forestry and Outdoor Recreation sectors. Forestry repeats the last known year (2098), while Outdoor Recreation extrapolates from 2090 to 2300 given the rate of change from 2010 to 2090. @knoiva-indecon Take a look and merge into the new sector branch